### PR TITLE
Fix shared-account multi-mower sessions for v0.3.4-beta2

### DIFF
--- a/.github/release-notes/0.3.4-beta2.md
+++ b/.github/release-notes/0.3.4-beta2.md
@@ -1,0 +1,40 @@
+title: Navimower 0.3.4-beta2 — shared-account multi-mower fix
+
+## Multi-mower private-cloud session fix
+
+- Reuse one deterministic private-cloud app/device identity for every Navimower config entry that uses the same account.
+- Prevent adding or reauthenticating one shared-account mower from invalidating the other mower entry's private-cloud session.
+- Automatically align different device identities left by `0.3.4-beta1` on the next integration reload or Home Assistant restart.
+- Preserve each mower's serial-backed config entry, entity unique IDs, options, map cache and retained history while identities converge.
+
+## Setup and reload fixes
+
+- Always show the mower selector before Smart Home OAuth, even when only one unconfigured mower remains.
+- Replace the custom config-entry update listener with `OptionsFlowWithReload`.
+- Keep explicit reauth/reconfigure reloads while avoiding the deprecated listener-plus-reload combination that caused a second setup pass and duplicate `_2` entity IDs on Home Assistant 2026.7.
+- Continue allowing OAuth token refreshes to update entry data without reloading every entity.
+
+## MQTT diagnostics
+
+- Keep one official OAuth/MQTT bridge per mower entry in this beta.
+- Treat a docked or otherwise idle mower as not expected to publish continuous position data.
+- Stop reporting `Live position valid: Disconnected` solely because an idle mower's last pose aged out; the binary diagnostic is unknown until a live pose is expected again.
+- Broker connection, state packets and battery telemetry remain independent from pose freshness.
+
+## Supported shared-account arrangement
+
+One dedicated Home Assistant account may now contain several mowers shared from their owner accounts. Add each mower as a separate Navimower config entry and use the same private-cloud account and Smart Home OAuth account when both accounts can see the selected mower.
+
+After upgrading from beta1, restart Home Assistant or reload both mower entries once. An already-created beta1 reauthentication flow may still need to be completed or dismissed, but the different-device-ID conflict will not be recreated.
+
+## Testing requested
+
+Please verify that:
+
+- both mowers remain private-cloud connected for several polling cycles;
+- reconfiguring one mower does not interrupt the other;
+- each mower receives its own map, entities, commands and retained route history;
+- `MQTT position stream` becomes live and `Position source` becomes `mqtt` when that mower starts moving;
+- reloading one entry does not create new duplicate entity IDs.
+
+Attach sanitized native diagnostics for every affected mower when reporting a beta issue.

--- a/.github/workflows/publish-prerelease.yaml
+++ b/.github/workflows/publish-prerelease.yaml
@@ -21,6 +21,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pytest voluptuous cryptography
+
+      - name: Compile integration
+        run: python -m compileall -q custom_components/navimower
+
+      - name: Run regression tests
+        run: python -m pytest -q
+
       - name: Read integration version
         id: version
         shell: bash

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-          cache: pip
 
       - name: Install test dependencies
         run: python -m pip install --upgrade pytest voluptuous cryptography

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,34 @@
+name: Test Navimower
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "fix/**"
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pytest voluptuous cryptography
+
+      - name: Compile integration
+        run: python -m compileall -q custom_components/navimower
+
+      - name: Run regression tests
+        run: python -m pytest -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.3.4-beta2 — shared-account multi-mower session fix
+
+- Reuse one deterministic private-cloud app/device identity for every Navimower
+  entry using the same account, preventing one mower login from invalidating the
+  other mower entry's private session.
+- Automatically align different identities left by `0.3.4-beta1` when the
+  integration is reloaded or Home Assistant restarts, without changing mower
+  devices, entities, options, maps or retained history.
+- Always show the mower selector before Smart Home OAuth, including when only one
+  unconfigured mower remains.
+- Replace the custom config-entry update listener with `OptionsFlowWithReload`,
+  avoiding the deprecated listener-plus-config-flow reload combination and the
+  duplicate setup/entity race seen on Home Assistant 2026.7.
+- Keep OAuth token data updates reload-free while private/OAuth reconfigure flows
+  still perform one explicit integration reload.
+- Report idle/docked live-pose validity as unknown instead of falsely
+  disconnected when MQTT is connected but a continuous position stream is not
+  expected.
+- Add dedicated account-session regressions and a GitHub Actions test workflow.
+
 ## 0.3.3
 
 - Keep the existing ordered-zone command format for every mower family while the
@@ -103,7 +123,7 @@
 - Detects app-side partial resets such as 50% to 0-5%, while keeping partial
   cycles separate from `last_completed_at` and preserving the 95% practical
   completion rule.
-- Tracks MQTT vehicle-state and action freshness independently from pose age,
+- Tracks MQTT vehicle-state and action freshness independently of pose age,
   merges partial MQTT snapshots, and forces Docked off whenever the normalized
   mower activity is mowing, paused or returning.
 - Filters encoded/manual cutting-height values and removes unsupported raw

--- a/custom_components/navimower/__init__.py
+++ b/custom_components/navimower/__init__.py
@@ -11,11 +11,14 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
+from .account import shared_private_device_id
 from .channel import parse_channels
 from .const import (
     API_BASE_URL,
     CONF_API_BASE_URL,
     CONF_AUTH_IMPLEMENTATION,
+    CONF_DEVICE_ID,
+    CONF_EMAIL,
     CONF_MQTT_SOURCE_ENTRY_ID,
     CONF_OAUTH_TOKEN,
     DEFAULT_INCLUDE_RETURN_TRAIL,
@@ -52,24 +55,6 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 # The standalone map card, Mow Now dialog and schedule editor are distributed
 # from the separate navimower-map-card HACS dashboard repository.
-
-
-async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload only when user options change, never on OAuth token refresh.
-
-    Home Assistant writes refreshed OAuth tokens back to ``entry.data``. A
-    normal unconditional config-entry listener would therefore unload every
-    entity on each token refresh. Keep an explicit options snapshot and ignore
-    data-only updates.
-    """
-    domain_data = hass.data.setdefault(DOMAIN, {})
-    snapshots = domain_data.setdefault("_options_snapshot", {})
-    current = dict(entry.options)
-    previous = snapshots.get(entry.entry_id)
-    if previous == current:
-        return
-    snapshots[entry.entry_id] = current
-    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -134,12 +119,26 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Restore local data, then start private cloud and OAuth/MQTT in parallel."""
     async_register_oauth_implementation(hass)
-    domain_data = hass.data.setdefault(DOMAIN, {})
-    domain_data.setdefault("_options_snapshot", {})[entry.entry_id] = dict(
-        entry.options
-    )
-    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
+    # Entries created before v0.3.4-beta2 may contain different app/device IDs
+    # for the same private-cloud account. Converge them before constructing the
+    # client so an old pair heals automatically on the next reload or restart.
+    canonical_device_id = shared_private_device_id(
+        hass.config_entries.async_entries(DOMAIN),
+        entry.data.get(CONF_EMAIL),
+        entry.data.get(CONF_DEVICE_ID),
+    )
+    if canonical_device_id and entry.data.get(CONF_DEVICE_ID) != canonical_device_id:
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, CONF_DEVICE_ID: canonical_device_id},
+        )
+        _LOGGER.info(
+            "Aligned Navimower private-cloud identity for account-shared entry %s",
+            entry.entry_id,
+        )
+
+    domain_data = hass.data.setdefault(DOMAIN, {})
     coordinator = NavimowCoordinator(hass, entry)
     await coordinator.async_load_persistent_state()
     domain_data[entry.entry_id] = coordinator
@@ -228,9 +227,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.async_shutdown()
     domain_data = hass.data.get(DOMAIN) or {}
     domain_data.pop(entry.entry_id, None)
-    snapshots = domain_data.get("_options_snapshot")
-    if isinstance(snapshots, dict):
-        snapshots.pop(entry.entry_id, None)
     return True
 
 

--- a/custom_components/navimower/account.py
+++ b/custom_components/navimower/account.py
@@ -1,0 +1,54 @@
+"""Pure helpers for account-scoped private-cloud identity.
+
+Navimow's private app cloud associates an account session with a stable app
+``device_id``. Multiple Home Assistant config entries using the same account
+must therefore present the same identity; otherwise logging in one mower entry
+can invalidate another entry from that account.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from .const import CONF_DEVICE_ID, CONF_EMAIL
+
+
+def normalize_private_account(value: Any) -> str:
+    """Return the case-insensitive private-cloud account key."""
+    return str(value or "").strip().casefold()
+
+
+def private_account_entries(entries: Iterable[Any], email: Any) -> list[Any]:
+    """Return config entries that use the same private-cloud account."""
+    wanted = normalize_private_account(email)
+    if not wanted:
+        return []
+    return [
+        entry
+        for entry in entries
+        if normalize_private_account((getattr(entry, "data", {}) or {}).get(CONF_EMAIL))
+        == wanted
+    ]
+
+
+def shared_private_device_id(
+    entries: Iterable[Any],
+    email: Any,
+    fallback: Any = None,
+) -> str | None:
+    """Return one deterministic device identity for every entry of an account.
+
+    ``min`` lets entries created before multi-mower support converge on the same
+    value regardless of setup order. A fresh fallback is used only when the
+    account has no persisted identity yet.
+    """
+    identities = {
+        str(value).strip()
+        for entry in private_account_entries(entries, email)
+        if (value := (getattr(entry, "data", {}) or {}).get(CONF_DEVICE_ID))
+        and str(value).strip()
+    }
+    if identities:
+        return min(identities)
+    fallback_text = str(fallback or "").strip()
+    return fallback_text or None

--- a/custom_components/navimower/binary_sensor.py
+++ b/custom_components/navimower/binary_sensor.py
@@ -68,7 +68,19 @@ BINARY_SENSORS: tuple[NavimowBinaryDescription, ...] = (
         translation_key="pose_valid",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda d: d.get("mqtt_pose_valid") if d.get("mqtt_configured") else None,
+        # A docked/idle mower is not expected to publish a continuous pose. Keep
+        # this diagnostic unknown in that state instead of reporting a false
+        # disconnection while the MQTT broker and state stream remain healthy.
+        value_fn=lambda d: (
+            True
+            if d.get("mqtt_pose_valid")
+            else (
+                None
+                if not d.get("mqtt_configured")
+                or d.get("mqtt_stream_expected") is False
+                else False
+            )
+        ),
     ),
     NavimowBinaryDescription(
         key="docked",

--- a/custom_components/navimower/config_flow.py
+++ b/custom_components/navimower/config_flow.py
@@ -21,7 +21,7 @@ from homeassistant.config_entries import (
     SOURCE_RECONFIGURE,
     ConfigEntry,
     ConfigFlowResult,
-    OptionsFlow,
+    OptionsFlowWithReload,
 )
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import callback
@@ -29,6 +29,7 @@ from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import TextSelector, TextSelectorConfig, TextSelectorType
 
+from .account import shared_private_device_id
 from .api import NavimowCloudClient, NavimowError, PassportAuthError, PassportError
 from .channel import NavimowerChannel, parse_channels
 from .const import (
@@ -117,7 +118,17 @@ class NavimowConfigFlow(
 
     # ------------------------------------------------------------- private auth
     async def _authenticate(self, email: str, password: str) -> list[dict[str, Any]]:
-        device_id = self._device_id or uuid.uuid4().hex
+        # The private cloud binds one app/device identity to an account. Reuse
+        # the identity already stored by another mower entry of this account so
+        # logging in one mower cannot invalidate the other mower's session.
+        device_id = (
+            shared_private_device_id(
+                self._async_current_entries(),
+                email,
+                self._device_id,
+            )
+            or uuid.uuid4().hex
+        )
         self._device_id = device_id
         client = NavimowCloudClient(device_id=device_id, language=DEFAULT_LANGUAGE)
 
@@ -182,8 +193,9 @@ class NavimowConfigFlow(
                 if not remaining:
                     return await self.async_step_manual()
                 self._vehicles = remaining
-                if len(remaining) == 1:
-                    return await self._prepare_vehicle(remaining[0])
+                # Always show the mower selector, even when only one unconfigured
+                # mower remains. The confirmation makes the selected private
+                # mower explicit before the separate official OAuth step starts.
                 return await self.async_step_select_vehicle()
 
         return self.async_show_form(
@@ -496,7 +508,7 @@ class NavimowConfigFlow(
         return NavimowOptionsFlow()
 
 
-class NavimowOptionsFlow(OptionsFlow):
+class NavimowOptionsFlow(OptionsFlowWithReload):
     """Manage general history, user-friendly gates and local channels."""
 
     def __init__(self) -> None:

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.3.4-beta1"
+  "version": "0.3.4-beta2"
 }

--- a/docs/MULTI_MOWER_BETA.md
+++ b/docs/MULTI_MOWER_BETA.md
@@ -1,6 +1,6 @@
 # Multi-mower beta testing
 
-Navimower `0.3.4-beta1` promotes the existing multi-mower architecture to a public beta for broader field testing.
+Navimower `0.3.4-beta2` fixes account-session handling for multiple mowers and keeps the existing one-config-entry-per-mower model for field testing.
 
 ## Supported setup
 
@@ -9,17 +9,35 @@ Create one Navimower config entry per mower. Each entry is keyed by that mower's
 During setup:
 
 1. Sign in to the private Navimow app cloud.
-2. Select the mower to add when the account exposes more than one mower.
+2. Confirm the mower to add in the mower selector. The selector is shown even when only one unconfigured mower remains.
 3. Complete Smart Home OAuth and confirm that the same mower is visible there.
 4. Repeat the integration setup for the next mower.
 
 Home Assistant prevents the same serial number from being configured twice.
 
-## Account requirement
+## Account arrangement
 
-Use a separate dedicated/shared private-cloud account for each simultaneously configured mower.
+A single dedicated/shared private-cloud account may contain several mowers. Every Navimower entry using that account now reuses one deterministic private-cloud app/device identity, matching the vendor account-session model and preventing one mower entry from invalidating another entry's session.
 
-Reusing one private-cloud account across parallel config entries remains unsupported because the vendor login/session can invalidate or replace another active private session. Smart Home OAuth devices are matched to the selected serial number, but this does not remove the private-cloud session limitation.
+Existing beta1 entries that already have different private-cloud device identities are aligned automatically on the next integration reload or Home Assistant restart. The identity is selected deterministically from the values already stored for that account; mower serial numbers, entity unique IDs, options, maps and retained history are not changed.
+
+Recommended arrangement:
+
+```text
+Primary owner account(s) -> Navimow phone app
+                         -> share Tont and Niidu to one HA account
+
+Dedicated HA account     -> private-cloud login for both mower entries
+                         -> Smart Home OAuth for every visible mower
+```
+
+Do not keep the dedicated HA private-cloud account signed into the phone app after setup, because a phone login may still replace the vendor session used by Home Assistant.
+
+## Official OAuth and MQTT
+
+Each mower entry currently keeps its own OAuth session and MQTT bridge, while the selected official mower is matched by serial number and stored official device ID. This has been proven to work with several mowers visible to the same Smart Home OAuth account, but broader testing is still required.
+
+`MQTT connected` describes the broker connection. A docked mower may stop publishing continuous position packets while state and battery messages continue. In beta2, `Live position valid` no longer reports a false Disconnected state when a live pose is not expected; it becomes unknown until the mower is active again.
 
 ## Services and actions
 
@@ -57,6 +75,18 @@ data:
 
 The native lawn-mower entity actions already target the selected entity/device and do not need a separate service selector.
 
+## Upgrade verification
+
+After updating from beta1:
+
+1. Restart Home Assistant or reload both Navimower config entries.
+2. Confirm that neither mower repeatedly requests private-cloud reauthentication.
+3. Confirm that both entries show `Private cloud connected`, `Smart Home OAuth connected` and `MQTT connected`.
+4. Start each mower separately and verify that its `MQTT position stream` becomes live and its position source changes to MQTT.
+5. Reconfigure one mower and verify that the other mower remains connected.
+
+A reauthentication flow already created by beta1 may remain visible until it is completed or dismissed. Beta2 prevents the underlying different-device-ID conflict from being recreated.
+
 ## What to verify
 
 For each mower, verify independently that:
@@ -76,7 +106,7 @@ Open a GitHub issue and include:
 
 - mower models and firmware versions;
 - Home Assistant version;
-- whether each mower uses a separate private-cloud account;
+- whether the mowers use the same private-cloud and Smart Home OAuth accounts;
 - exact reproduction steps;
 - which mower was expected to react and which mower actually reacted;
 - sanitized native diagnostics for every affected mower.
@@ -86,6 +116,6 @@ Do not publish credentials, OAuth tokens, email addresses, full serial numbers o
 ## Known beta limitations
 
 - Multi-mower support still needs broader testing across mower families, regions and shared-owner arrangements.
-- One private-cloud account must not be reused by parallel entries.
-- The integration currently exposes one config entry per mower rather than one account-level entry containing multiple devices.
+- The integration exposes one config entry and one MQTT bridge per mower rather than one account-level entry containing several devices.
+- A pre-existing beta1 reauth notification may need to be completed or dismissed once after the upgrade.
 - Vendor-side account or OAuth behaviour may differ by region or firmware.

--- a/tests/test_v031_features.py
+++ b/tests/test_v031_features.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 
 ROOT = Path(__file__).parents[1]
-COMPONENT = ROOT / "custom_components" / "navimower"
+COMPONENT = ROOT / "custom_components/navimower"
 
 
 def test_native_diagnostics_entrypoint_exists() -> None:
@@ -42,7 +42,7 @@ def test_schedule_translation_exists() -> None:
 
 def test_manifest_version() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4-beta1"
+    assert manifest["version"] == "0.3.4-beta2"
 
 
 def test_diagnostics_redacts_oauth_device_id_and_summarizes_rtk() -> None:

--- a/tests/test_v034_beta2.py
+++ b/tests/test_v034_beta2.py
@@ -3,19 +3,29 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import sys
+import types
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
+PACKAGE = "navimower_v034_beta2_test"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _load_account_module():
-    spec = importlib.util.spec_from_file_location(
-        "navimower_test_account", COMPONENT / "account.py"
-    )
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    package = types.ModuleType(PACKAGE)
+    package.__path__ = [str(COMPONENT)]
+    sys.modules.setdefault(PACKAGE, package)
+    _load_module(f"{PACKAGE}.const", COMPONENT / "const.py")
+    return _load_module(f"{PACKAGE}.account", COMPONENT / "account.py")
 
 
 class _Entry:

--- a/tests/test_v034_beta2.py
+++ b/tests/test_v034_beta2.py
@@ -1,0 +1,60 @@
+"""Dependency-free regressions for Navimower v0.3.4-beta2."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _load_account_module():
+    spec = importlib.util.spec_from_file_location(
+        "navimower_test_account", COMPONENT / "account.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Entry:
+    def __init__(self, email: str, device_id: str | None) -> None:
+        self.data = {"email": email, "device_id": device_id}
+
+
+def test_same_account_uses_one_deterministic_private_identity() -> None:
+    account = _load_account_module()
+    entries = [
+        _Entry("Shared@Example.com", "device-b"),
+        _Entry(" shared@example.com ", "device-a"),
+        _Entry("other@example.com", "device-0"),
+    ]
+    assert account.shared_private_device_id(entries, "SHARED@example.com") == "device-a"
+    assert account.shared_private_device_id([], "new@example.com", "fresh") == "fresh"
+    assert account.shared_private_device_id([], "new@example.com") is None
+
+
+def test_config_flow_reuses_account_identity_and_always_confirms_mower() -> None:
+    source = (COMPONENT / "config_flow.py").read_text()
+    assert "shared_private_device_id(" in source
+    assert "self._async_current_entries()" in source
+    assert "return await self.async_step_select_vehicle()" in source
+    assert "if len(remaining) == 1" not in source
+
+
+def test_options_reload_without_deprecated_update_listener_pairing() -> None:
+    flow = (COMPONENT / "config_flow.py").read_text()
+    init = (COMPONENT / "__init__.py").read_text()
+    assert "OptionsFlowWithReload" in flow
+    assert "class NavimowOptionsFlow(OptionsFlowWithReload)" in flow
+    assert "add_update_listener" not in init
+    assert "_async_update_listener" not in init
+    assert "shared_private_device_id(" in init
+    assert "async_entries(DOMAIN)" in init
+
+
+def test_idle_mower_does_not_report_false_pose_disconnect() -> None:
+    source = (COMPONENT / "binary_sensor.py").read_text()
+    assert 'd.get("mqtt_stream_expected") is False' in source
+    assert "false\n            # disconnection" not in source.lower()


### PR DESCRIPTION
## Summary

- reuse one deterministic private-cloud device identity across every mower entry using the same account;
- automatically align different identities created by `0.3.4-beta1` on reload/restart;
- always show the mower selector before Smart Home OAuth;
- replace the deprecated custom update-listener reload pattern with `OptionsFlowWithReload`;
- avoid reporting an idle/docked mower's live pose as falsely disconnected;
- add regression tests, CI, beta documentation and release notes;
- bump the integration to `0.3.4-beta2`.

## Upgrade behavior

Existing config entries, mower devices, entity unique IDs, options, cached maps and retained history are preserved. Entries using the same private-cloud account converge on the same existing device identity at the next reload or Home Assistant restart.

A reauthentication flow already created by beta1 may still need to be completed or dismissed once.

## Validation and release gate

The prerelease workflow now installs test dependencies, compiles the full integration and runs the complete pytest suite before it is allowed to create a tag or GitHub release. A failed test leaves `v0.3.4-beta2` unpublished.

## Release

Merging to `main` triggers the guarded prerelease workflow. After tests pass it creates tag and GitHub prerelease `v0.3.4-beta2` from the merge commit using `.github/release-notes/0.3.4-beta2.md`.