### PR TITLE
Prepare Navimower 0.3.4-beta6

### DIFF
--- a/.github/release-notes/0.3.4-beta6.md
+++ b/.github/release-notes/0.3.4-beta6.md
@@ -1,0 +1,31 @@
+title: Navimower 0.3.4-beta6 — stable settings writeback
+
+## Settings write flow
+
+- Run each setting change as one transaction instead of calling the coordinator's refresh-after-command helper separately for the mower command and private-cloud persistence write.
+- Keep the required write order: send the immediate setting to the mower first, then save the same value to the private cloud.
+- Update the integration's last-good `set_list` cache only after every write in the transaction has returned successfully.
+- Continue normal battery, position, state and progress polling while the settings cache holds the acknowledged value.
+- Wait 15 seconds for private-cloud propagation, then bypass the normal 30/60-second `set_list` TTL and perform one forced fresh readback.
+- On a failed transaction, remove the temporary `set_list` TTL hold so normal polling can restore the actual reported state.
+
+This is designed to remove the visible switch sequence where a setting changed in Home Assistant briefly returned to its previous value before the private cloud caught up. The final state is still confirmed by a fresh cloud read rather than remaining permanently optimistic.
+
+## Covered setting entities
+
+The shared transaction is used by:
+
+- switches, including Weather Adaptive, Animal-friendly, Night light and Geo-fence alarm;
+- Work mode and other setting selects;
+- Weather Adaptive, battery and Geo-fence number entities;
+- the frost-protection time entity.
+
+Schedule-day writes already perform their mower and cloud operations inside one client transaction and are unchanged.
+
+## Interface cleanup
+
+- Change the **Geo-fence alarm** icon to `mdi:radar`.
+
+## Upgrade
+
+Install the prerelease through HACS and restart Home Assistant. Test settings in both directions: Home Assistant to the Navimow app and the Navimow app back to Home Assistant. After a Home Assistant write, allow about 15 seconds for the forced cloud confirmation.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.3.4-beta5"
+  "version": "0.3.4-beta6"
 }

--- a/custom_components/navimower/number.py
+++ b/custom_components/navimower/number.py
@@ -26,6 +26,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .coordinator import NavimowCoordinator
 from .entity import NavimowEntity
+from .setting_write import async_write_settings
 
 RAIN_WAIT_HOURS: tuple[float, ...] = (
     0.25,
@@ -239,20 +240,27 @@ class NavimowNumber(NavimowEntity, NumberEntity):
             robot_value = wire
         else:
             robot_value = str(wire)
-        await self.coordinator.async_send(
-            self.coordinator.client.send_setting_device,
-            self._sn,
-            {key: robot_value},
-        )
         if desc.cloud_hex:
             cloud_value: int | str = f"{wire:02X}"
         elif desc.cloud_string:
             cloud_value = str(wire)
         else:
             cloud_value = wire
-        await self.coordinator.async_send(
-            self.coordinator.client.save_setting_iot,
-            self._sn,
-            self.coordinator.vehicle_type,
-            {key: cloud_value},
+        await async_write_settings(
+            self.coordinator,
+            operations=(
+                (
+                    self.coordinator.client.send_setting_device,
+                    (self._sn, {key: robot_value}),
+                ),
+                (
+                    self.coordinator.client.save_setting_iot,
+                    (
+                        self._sn,
+                        self.coordinator.vehicle_type,
+                        {key: cloud_value},
+                    ),
+                ),
+            ),
+            cache_values={key: cloud_value},
         )

--- a/custom_components/navimower/select.py
+++ b/custom_components/navimower/select.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .coordinator import NavimowCoordinator
 from .entity import NavimowEntity
+from .setting_write import async_write_settings
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -178,14 +179,21 @@ class NavimowSettingSelect(NavimowEntity, SelectEntity):
             robot_value = f"{value:02d}"
         else:
             robot_value = str(value)
-        await self.coordinator.async_send(
-            self.coordinator.client.send_setting_device,
-            self._sn,
-            {key: robot_value},
-        )
-        await self.coordinator.async_send(
-            self.coordinator.client.save_setting_iot,
-            self._sn,
-            self.coordinator.vehicle_type,
-            {key: value},
+        await async_write_settings(
+            self.coordinator,
+            operations=(
+                (
+                    self.coordinator.client.send_setting_device,
+                    (self._sn, {key: robot_value}),
+                ),
+                (
+                    self.coordinator.client.save_setting_iot,
+                    (
+                        self._sn,
+                        self.coordinator.vehicle_type,
+                        {key: value},
+                    ),
+                ),
+            ),
+            cache_values={key: value},
         )

--- a/custom_components/navimower/setting_write.py
+++ b/custom_components/navimower/setting_write.py
@@ -1,0 +1,156 @@
+"""Transactional private-cloud setting writes with delayed readback.
+
+Navimow applies many settings through two blocking calls: an immediate command
+sent to the mower and a private-cloud persistence write. The private cloud is
+eventually consistent, so refreshing ``set_list`` between those calls can
+briefly republish the previous value.
+
+This helper runs every operation in one executor job, updates the integration's
+last-good settings cache only after all writes were acknowledged, and forces one
+fresh ``set_list`` read after a short propagation delay. Normal coordinator
+polls continue for battery, position and progress while reusing the write-through
+settings cache during that delay.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Sequence
+from datetime import UTC, datetime
+import logging
+import time
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+SETTING_READBACK_DELAY_SECONDS = 15.0
+
+SettingOperation = tuple[Callable[..., Any], tuple[Any, ...]]
+
+
+def _set_list_status(coordinator: Any) -> dict[str, Any]:
+    """Return a complete endpoint-status row for ``set_list``."""
+    return coordinator._endpoint_status.setdefault(  # noqa: SLF001
+        "set_list",
+        {
+            "attempts": 0,
+            "successes": 0,
+            "failures": 0,
+            "last_attempt_mono": None,
+            "last_success_mono": None,
+            "last_error": None,
+            "last_attempt_utc": None,
+            "last_success_utc": None,
+            "last_error_utc": None,
+        },
+    )
+
+
+async def _publish_write_through_cache(
+    coordinator: Any, cache_values: dict[str, Any]
+) -> None:
+    """Publish acknowledged values without waiting for stale cloud readback."""
+    raw_cache = coordinator._raw_cache  # noqa: SLF001
+    set_list = dict(raw_cache.get("set_list") or {})
+    set_list.update(cache_values)
+    raw_cache["set_list"] = set_list
+
+    # Reuse the coordinator's one authoritative parser so raw-backed and parsed
+    # entities (switch/select/number/time/schedule) all receive the same values.
+    raw_snapshot = dict(raw_cache)
+    raw_snapshot["set_list"] = dict(set_list)
+    parsed = await coordinator.hass.async_add_executor_job(
+        coordinator._parse, raw_snapshot  # noqa: SLF001
+    )
+
+    snapshot = dict(coordinator.data or parsed)
+    for key in (
+        "settings",
+        "schedule",
+        "next_mow",
+        "cut_height",
+        "cutting_height_mm",
+        "cutting_height_supported",
+    ):
+        if key in parsed:
+            snapshot[key] = parsed[key]
+    raw = dict(snapshot.get("raw") or {})
+    raw["set_list"] = dict((parsed.get("raw") or {}).get("set_list") or set_list)
+    snapshot["raw"] = raw
+    coordinator.async_set_updated_data(snapshot)
+
+
+def _schedule_readback(coordinator: Any, delay: float) -> None:
+    """Force one fresh ``set_list`` read after cloud propagation time."""
+    previous = getattr(coordinator, "_setting_readback_task", None)
+    if previous is not None and not previous.done():
+        previous.cancel()
+
+    async def _readback() -> None:
+        try:
+            await asyncio.sleep(delay)
+            if getattr(coordinator, "_shutdown_complete", False):
+                return
+            status = _set_list_status(coordinator)
+            # Bypass the normal 30/60-second endpoint TTL for this confirmation.
+            status["last_attempt_mono"] = None
+            status["last_attempt_utc"] = None
+            await coordinator.async_request_refresh()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 - normal polling remains the fallback.
+            _LOGGER.debug("Delayed Navimow settings readback failed", exc_info=True)
+        finally:
+            current = getattr(coordinator, "_setting_readback_task", None)
+            if current is asyncio.current_task():
+                coordinator._setting_readback_task = None  # noqa: SLF001
+
+    coordinator._setting_readback_task = coordinator.hass.async_create_task(  # noqa: SLF001
+        _readback(),
+        f"Navimower settings readback {coordinator.entry.entry_id}",
+    )
+
+
+async def async_write_settings(
+    coordinator: Any,
+    *,
+    operations: Sequence[SettingOperation],
+    cache_values: dict[str, Any],
+    readback_delay: float = SETTING_READBACK_DELAY_SECONDS,
+) -> Any:
+    """Run setting operations atomically, then confirm them after a delay.
+
+    No coordinator refresh occurs between operations. Once every blocking call
+    returns successfully, the acknowledged values are written through to the
+    local ``set_list`` cache. A forced cloud readback replaces that cache after
+    ``readback_delay`` seconds.
+    """
+    if not operations:
+        return None
+
+    status = _set_list_status(coordinator)
+    now = time.monotonic()
+    # A concurrent normal poll may continue, but it must not fetch an old
+    # ``set_list`` while this transaction is in flight.
+    status["last_attempt_mono"] = now
+    status["last_attempt_utc"] = datetime.now(UTC).isoformat()
+
+    def _run_operations() -> list[Any]:
+        return [func(*args) for func, args in operations]
+
+    try:
+        results = await coordinator.hass.async_add_executor_job(_run_operations)
+    except Exception:
+        # Let the next normal refresh establish the real state after a failed
+        # partial transaction instead of retaining the temporary TTL hold.
+        status["last_attempt_mono"] = None
+        status["last_attempt_utc"] = None
+        raise
+
+    coordinator._persist_session()  # noqa: SLF001
+    await _publish_write_through_cache(coordinator, cache_values)
+
+    # Reset the TTL from the completed transaction, not from its start.
+    status["last_attempt_mono"] = time.monotonic()
+    status["last_attempt_utc"] = datetime.now(UTC).isoformat()
+    _schedule_readback(coordinator, max(0.0, float(readback_delay)))
+    return results[-1] if results else None

--- a/custom_components/navimower/switch.py
+++ b/custom_components/navimower/switch.py
@@ -7,9 +7,8 @@ Two write families, both via ``/vehicle/set/save-set-data``:
 * "modern" MowerSettingBean toggles use ``operation_type:"iot_set"`` with a
   per-key value encoding and are sent to the robot first so the change applies.
 
-Feature detection is based on the values reported by the mower. A few settings
-that are not copied into the coordinator settings snapshot are read directly
-from the sanitized private-cloud ``set_list`` payload.
+Settings writes use one transaction and delayed cloud readback so an eventually
+consistent ``set_list`` cannot briefly restore the previous switch state.
 """
 from __future__ import annotations
 
@@ -26,6 +25,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .coordinator import NavimowCoordinator
 from .entity import NavimowEntity
+from .setting_write import async_write_settings
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -224,7 +224,7 @@ SWITCHES: tuple[NavimowSwitchDescription, ...] = (
     NavimowSwitchDescription(
         key="geo_fence_alarm",
         translation_key="geo_fence_alarm",
-        icon="mdi:shield-map-outline",
+        icon="mdi:radar",
         entity_category=EntityCategory.CONFIG,
         value_fn=lambda s: None,
         raw_read_key="guard",
@@ -358,30 +358,46 @@ class NavimowSwitch(NavimowEntity, SwitchEntity):
 
     async def _write(self, on: bool) -> None:
         desc = self.entity_description
+        operations = []
         if desc.iot:
-            robot_val: Any = (
+            robot_value: Any = (
                 (1 if on else 0) if desc.robot_numeric else ("1" if on else "0")
             )
-            await self.coordinator.async_send(
-                self.coordinator.client.send_setting_device,
-                self._sn,
-                {desc.robot_key or desc.write_key: robot_val},
+            cloud_value: Any = (
+                (1 if on else 0) if desc.numeric else ("1" if on else "0")
             )
-            await self.coordinator.async_send(
-                self.coordinator.client.set_iot_bool,
-                self._sn,
-                self.coordinator.vehicle_type,
-                desc.write_key,
-                on,
-                desc.numeric,
+            operations.extend(
+                (
+                    (
+                        self.coordinator.client.send_setting_device,
+                        (self._sn, {desc.robot_key or desc.write_key: robot_value}),
+                    ),
+                    (
+                        self.coordinator.client.set_iot_bool,
+                        (
+                            self._sn,
+                            self.coordinator.vehicle_type,
+                            desc.write_key,
+                            on,
+                            desc.numeric,
+                        ),
+                    ),
+                )
             )
         else:
-            await self.coordinator.async_send(
-                self.coordinator.client.set_bool_setting,
-                self._sn,
-                desc.write_key,
-                on,
+            cloud_value = "01" if on else "00"
+            operations.append(
+                (
+                    self.coordinator.client.set_bool_setting,
+                    (self._sn, desc.write_key, on),
+                )
             )
+
+        await async_write_settings(
+            self.coordinator,
+            operations=operations,
+            cache_values={desc.write_key: cloud_value},
+        )
         if desc.assumed:
             self._optimistic = on
             self.async_write_ha_state()

--- a/custom_components/navimower/time.py
+++ b/custom_components/navimower/time.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .coordinator import NavimowCoordinator
 from .entity import NavimowEntity
+from .setting_write import async_write_settings
 
 FROST_TIME_STEP_MINUTES = 15
 FROST_TIME_MAX_MINUTES = 12 * 60 + 45
@@ -74,14 +75,21 @@ class NavimowFrostTime(NavimowEntity, TimeEntity):
                 "The mower app currently supports frost times from 00:00 to 12:45"
             )
         wire = minutes // FROST_TIME_STEP_MINUTES
-        await self.coordinator.async_send(
-            self.coordinator.client.send_setting_device,
-            self._sn,
-            {"frostDelayTime": wire},
-        )
-        await self.coordinator.async_send(
-            self.coordinator.client.save_setting_iot,
-            self._sn,
-            self.coordinator.vehicle_type,
-            {"frostDelayTime": wire},
+        await async_write_settings(
+            self.coordinator,
+            operations=(
+                (
+                    self.coordinator.client.send_setting_device,
+                    (self._sn, {"frostDelayTime": wire}),
+                ),
+                (
+                    self.coordinator.client.save_setting_iot,
+                    (
+                        self._sn,
+                        self.coordinator.vehicle_type,
+                        {"frostDelayTime": wire},
+                    ),
+                ),
+            ),
+            cache_values={"frostDelayTime": wire},
         )

--- a/tests/test_v030_architecture.py
+++ b/tests/test_v030_architecture.py
@@ -9,7 +9,7 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_release_version_and_map_schema() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4-beta5"
+    assert manifest["version"] == "0.3.4-beta6"
     const_source = (COMPONENT / "const.py").read_text()
     assert "MAP_API_SCHEMA_VERSION: Final = 5" in const_source
 

--- a/tests/test_v031_features.py
+++ b/tests/test_v031_features.py
@@ -42,7 +42,7 @@ def test_schedule_translation_exists() -> None:
 
 def test_manifest_version() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4-beta5"
+    assert manifest["version"] == "0.3.4-beta6"
 
 
 def test_diagnostics_redacts_oauth_device_id_and_summarizes_rtk() -> None:

--- a/tests/test_v034_beta5.py
+++ b/tests/test_v034_beta5.py
@@ -1,4 +1,4 @@
-"""Regressions for Navimower v0.3.4-beta5."""
+"""Regressions introduced in Navimower v0.3.4-beta5."""
 from __future__ import annotations
 
 import ast
@@ -9,9 +9,9 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_manifest_version() -> None:
+def test_manifest_is_at_least_beta5_feature_line() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4-beta5"
+    assert manifest["version"].startswith("0.3.4-beta")
 
 
 def test_geo_fence_alarm_and_radius_are_cloud_backed() -> None:

--- a/tests/test_v034_beta6.py
+++ b/tests/test_v034_beta6.py
@@ -1,0 +1,61 @@
+"""Regressions for Navimower v0.3.4-beta6."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_manifest_version() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.3.4-beta6"
+
+
+def test_setting_transaction_has_one_executor_job_and_delayed_readback() -> None:
+    source = (COMPONENT / "setting_write.py").read_text()
+    assert "SETTING_READBACK_DELAY_SECONDS = 15.0" in source
+    assert "async_add_executor_job(_run_operations)" in source
+    assert "set_list.update(cache_values)" in source
+    assert "await asyncio.sleep(delay)" in source
+    assert 'status["last_attempt_mono"] = None' in source
+    assert "await coordinator.async_request_refresh()" in source
+    assert "coordinator.async_set_updated_data(snapshot)" in source
+    ast.parse(source)
+
+
+def test_all_setting_platforms_use_shared_transaction() -> None:
+    for filename in ("switch.py", "select.py", "number.py", "time.py"):
+        source = (COMPONENT / filename).read_text()
+        assert "from .setting_write import async_write_settings" in source
+        assert "await async_write_settings(" in source
+        ast.parse(source)
+
+
+def test_switches_no_longer_refresh_between_robot_and_cloud_writes() -> None:
+    source = (COMPONENT / "switch.py").read_text()
+    write_block = source.split("    async def _write(self, on: bool) -> None:", 1)[1]
+    write_block = write_block.split("    async def async_turn_on", 1)[0]
+    assert "send_setting_device" in write_block
+    assert "set_iot_bool" in write_block
+    assert "self.coordinator.async_send" not in write_block
+    assert "cache_values={desc.write_key: cloud_value}" in write_block
+
+
+def test_value_entities_use_acknowledged_write_through_values() -> None:
+    select_source = (COMPONENT / "select.py").read_text()
+    number_source = (COMPONENT / "number.py").read_text()
+    time_source = (COMPONENT / "time.py").read_text()
+    assert "cache_values={key: value}" in select_source
+    assert "cache_values={key: cloud_value}" in number_source
+    assert 'cache_values={"frostDelayTime": wire}' in time_source
+
+
+def test_geo_fence_alarm_uses_radar_icon() -> None:
+    source = (COMPONENT / "switch.py").read_text()
+    block = source.split('key="geo_fence_alarm"', 1)[1].split(
+        "NavimowSwitchDescription(", 1
+    )[0]
+    assert 'icon="mdi:radar"' in block


### PR DESCRIPTION
## Summary

- replace per-operation refreshes with one shared settings transaction
- keep robot-first, cloud-second ordering without refreshing between the calls
- write acknowledged values through to the local `set_list` cache
- continue normal telemetry polling while delaying only settings readback
- force a fresh `set_list` confirmation after 15 seconds
- apply the same flow to switch, select, number and time setting entities
- change the Geo-fence alarm icon to `mdi:radar`
- bump the manifest and add beta6 regressions/release notes

## Expected behavior

After a Home Assistant settings write, the entity should keep the acknowledged value instead of briefly returning to the previous cloud value. A forced cloud readback still confirms or corrects the final state after the propagation delay.

The guarded prerelease workflow must compile the integration and pass the full pytest suite before `v0.3.4-beta6` is published.