### PR TITLE
Prepare Navimower 0.3.4-beta7

### DIFF
--- a/.github/release-notes/0.3.4-beta7.md
+++ b/.github/release-notes/0.3.4-beta7.md
@@ -1,0 +1,32 @@
+title: Navimower 0.3.4-beta7 — verified setting encodings
+
+## Robot/cloud encoding fixes
+
+Live testing showed that several numeric settings use different representations on the two write paths:
+
+- the immediate mower `s:mower` command expects a hexadecimal string;
+- private-cloud `iot_set` and `set_list` use the normal decimal value.
+
+Beta7 applies the verified split encoding to:
+
+- **Geo-fence radius** — for example 20 m is sent to the mower as `14` and stored in cloud as `"20"`;
+- **Snow delay duration** — 36 h is sent to the mower as `24` and stored in cloud as `36`;
+- **Won't mow until after frost** — 07:00 is 28 quarter-hours, sent to the mower as `1C` and stored in cloud as `28`;
+- **Maximum mowing temperature** — 31 °C is sent to the mower as `1F` and stored in cloud as `31`.
+
+This fixes the observed conversions 20 → 32 m, 25 → 37 m, 36 → 54 h, 07:00 → 10:00 and 31 → 49 °C.
+
+## Safer Home Assistant controls
+
+- **Wait time after rain** is now a select containing only the values offered by the Navimow app: 15 min, 30 min, 1–12 h, then 14, 16, 18, 20, 22 and 24 h.
+- **Won't mow until after frost** is now a select containing only 15-minute choices from 00:00 through 12:45.
+- **Snow delay duration**, **Maximum mowing temperature** and **Geo-fence radius** remain numeric entities but now use sliders because every whole step in their ranges is valid.
+- The legacy frost time platform creates no duplicate entity after the select migration.
+
+## Settings writeback
+
+The beta6 transaction and delayed cloud-confirmation behavior is retained: mower and cloud writes happen without an intermediate refresh, the acknowledged value remains visible, and a forced fresh `set_list` readback follows after 15 seconds.
+
+## Upgrade and testing
+
+Install the prerelease through HACS and restart Home Assistant. Test the four corrected numeric settings from Home Assistant to the Navimow app, and verify app-to-Home Assistant updates after the normal cloud polling interval.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.3.4-beta6"
+  "version": "0.3.4-beta7"
 }

--- a/custom_components/navimower/number.py
+++ b/custom_components/navimower/number.py
@@ -20,36 +20,12 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import NavimowCoordinator
 from .entity import NavimowEntity
 from .setting_write import async_write_settings
-
-RAIN_WAIT_HOURS: tuple[float, ...] = (
-    0.25,
-    0.5,
-    1,
-    2,
-    3,
-    4,
-    5,
-    6,
-    7,
-    8,
-    9,
-    10,
-    11,
-    12,
-    14,
-    16,
-    18,
-    20,
-    22,
-    24,
-)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -65,7 +41,6 @@ class NavimowNumberDescription(NumberEntityDescription):
     robot_numeric: bool = False
     raw_read_key: str | None = None
     raw_base: int = 10
-    allowed_native_values: tuple[float, ...] | None = None
     enabled_default: bool = True
 
 
@@ -97,25 +72,7 @@ NUMBERS: tuple[NavimowNumberDescription, ...] = (
         value_fn=lambda s: s.get("charging_limit"),
         write_key="chargingLimit",
     ),
-    # Weather-adaptive settings
-    NavimowNumberDescription(
-        key="rain_delay_time",
-        translation_key="rain_delay_time",
-        icon="mdi:timer-pause",
-        entity_category=EntityCategory.CONFIG,
-        native_unit_of_measurement=UnitOfTime.HOURS,
-        native_min_value=0.25,
-        native_max_value=24,
-        native_step=0.25,
-        mode=NumberMode.BOX,
-        value_fn=lambda s: None,
-        raw_read_key="delayedPileSet",
-        raw_base=16,
-        write_key="delayedPileSet",
-        scale=4,
-        cloud_hex=True,
-        allowed_native_values=RAIN_WAIT_HOURS,
-    ),
+    # Weather-adaptive settings with regular, continuous app ranges.
     NavimowNumberDescription(
         key="snow_delay_time",
         translation_key="snow_delay_time",
@@ -125,12 +82,13 @@ NUMBERS: tuple[NavimowNumberDescription, ...] = (
         native_min_value=24,
         native_max_value=168,
         native_step=1,
-        mode=NumberMode.BOX,
+        mode=NumberMode.SLIDER,
         value_fn=lambda s: None,
         raw_read_key="snowDelayTime",
         write_key="snowDelayTime",
-        robot_hex=False,
-        robot_numeric=True,
+        # The mower command interprets its string as hexadecimal while set-list
+        # and the iot_set cloud copy expose/store decimal hours.
+        robot_hex=True,
     ),
     NavimowNumberDescription(
         key="maximum_mowing_temperature",
@@ -142,12 +100,12 @@ NUMBERS: tuple[NavimowNumberDescription, ...] = (
         native_min_value=30,
         native_max_value=45,
         native_step=1,
-        mode=NumberMode.BOX,
+        mode=NumberMode.SLIDER,
         value_fn=lambda s: None,
         raw_read_key="allowMaxTemp",
         write_key="allowMaxTemp",
-        robot_hex=False,
-        robot_numeric=True,
+        # Verified live: decimal text "31" is read by the mower as 0x31 (=49).
+        robot_hex=True,
     ),
     # Safety settings
     NavimowNumberDescription(
@@ -163,7 +121,9 @@ NUMBERS: tuple[NavimowNumberDescription, ...] = (
         value_fn=lambda s: None,
         raw_read_key="antiTheftRadius",
         write_key="antiTheftRadius",
-        robot_hex=False,
+        # The robot expects hex (20 m -> "14"), while cloud set-list stores the
+        # human decimal value as a string (20 m -> "20").
+        robot_hex=True,
         cloud_string=True,
         enabled_default=False,
     ),
@@ -188,11 +148,6 @@ def _wire_value(desc: NavimowNumberDescription, data: dict) -> int | None:
         return int(float(value))
     except (TypeError, ValueError):
         return None
-
-
-def _allowed(desc: NavimowNumberDescription, value: float) -> bool:
-    allowed = desc.allowed_native_values
-    return allowed is None or any(abs(value - item) < 1e-6 for item in allowed)
 
 
 async def async_setup_entry(
@@ -226,13 +181,7 @@ class NavimowNumber(NavimowEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         desc = self.entity_description
-        native = float(value)
-        if not _allowed(desc, native):
-            choices = ", ".join(f"{item:g}" for item in desc.allowed_native_values or ())
-            raise HomeAssistantError(
-                f"Unsupported {desc.key} value {native:g}; allowed values: {choices}"
-            )
-        wire = int(round(native * desc.scale))
+        wire = int(round(float(value) * desc.scale))
         key = desc.write_key
         if desc.robot_hex:
             robot_value: int | str = f"{wire:02X}"

--- a/custom_components/navimower/select.py
+++ b/custom_components/navimower/select.py
@@ -21,6 +21,35 @@ _LOGGER = logging.getLogger(__name__)
 
 ALL_ZONES = "All zones"
 
+RAIN_DELAY_VALUES: dict[str, str] = {
+    "15 min": "01",
+    "30 min": "02",
+    "1 h": "04",
+    "2 h": "08",
+    "3 h": "0C",
+    "4 h": "10",
+    "5 h": "14",
+    "6 h": "18",
+    "7 h": "1C",
+    "8 h": "20",
+    "9 h": "24",
+    "10 h": "28",
+    "11 h": "2C",
+    "12 h": "30",
+    "14 h": "38",
+    "16 h": "40",
+    "18 h": "48",
+    "20 h": "50",
+    "22 h": "58",
+    "24 h": "60",
+}
+
+# The app exposes only quarter-hour choices from midnight through 12:45.
+FROST_TIME_VALUES: dict[str, int] = {
+    f"{minutes // 60:02d}:{minutes % 60:02d}": minutes // 15
+    for minutes in range(0, 12 * 60 + 46, 15)
+}
+
 
 @dataclass(frozen=True, kw_only=True)
 class NavimowSelectDescription(SelectEntityDescription):
@@ -30,10 +59,37 @@ class NavimowSelectDescription(SelectEntityDescription):
     write_key: str
     value_map: dict[str, int | str]
     robot_numeric: bool = False
+    robot_hex: bool = False
+    cloud_hex: bool = False
+    cloud_string: bool = False
     raw_read_key: str | None = None
 
 
 SETTING_SELECTS: tuple[NavimowSelectDescription, ...] = (
+    NavimowSelectDescription(
+        key="rain_delay_time",
+        name="Wait time after rain",
+        icon="mdi:timer-pause",
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda s: None,
+        raw_read_key="delayedPileSet",
+        write_key="delayedPileSet",
+        # Both mower and cloud use the quarter-hour count encoded as hex.
+        value_map=RAIN_DELAY_VALUES,
+    ),
+    NavimowSelectDescription(
+        key="frost_delay_until",
+        name="Won't mow until after frost",
+        icon="mdi:clock-alert-outline",
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda s: None,
+        raw_read_key="frostDelayTime",
+        write_key="frostDelayTime",
+        value_map=FROST_TIME_VALUES,
+        # The mower command expects the quarter-hour count as a hex string;
+        # set-list and iot_set use the decimal integer.
+        robot_hex=True,
+    ),
     NavimowSelectDescription(
         key="work_mode",
         translation_key="work_mode",
@@ -47,7 +103,6 @@ SETTING_SELECTS: tuple[NavimowSelectDescription, ...] = (
             "efficient": "03",
             "precision": "04",
         },
-        robot_numeric=False,
     ),
     NavimowSelectDescription(
         key="night_light_level",
@@ -57,7 +112,6 @@ SETTING_SELECTS: tuple[NavimowSelectDescription, ...] = (
         value_fn=lambda s: s.get("night_light_level"),
         write_key="nightLightLevel",
         value_map={"dim": 0, "very_dim": 1},
-        robot_numeric=False,
     ),
     NavimowSelectDescription(
         key="weather_sensitivity",
@@ -78,10 +132,24 @@ def _raw_setting(data: dict, key: str) -> Any:
     return set_list.get(key) if isinstance(set_list, dict) else None
 
 
+def _normalize_raw_value(
+    desc: NavimowSelectDescription, value: Any
+) -> int | str | None:
+    """Normalize set-list values to the type used by the select value map."""
+    if value is None:
+        return None
+    mapped = tuple(desc.value_map.values())
+    if any(isinstance(candidate, int) for candidate in mapped):
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return None
+    return str(value).strip().upper()
+
+
 def _read_value(desc: NavimowSelectDescription, data: dict) -> int | str | None:
     if desc.raw_read_key is not None:
-        value = _raw_setting(data, desc.raw_read_key)
-        return None if value is None else str(value)
+        return _normalize_raw_value(desc, _raw_setting(data, desc.raw_read_key))
     return desc.value_fn(data.get("settings") or {})
 
 
@@ -171,14 +239,25 @@ class NavimowSettingSelect(NavimowEntity, SelectEntity):
         return self._reverse.get(value)
 
     async def async_select_option(self, option: str) -> None:
-        value = self.entity_description.value_map[option]
-        key = self.entity_description.write_key
-        if self.entity_description.robot_numeric:
-            robot_value: int | str = int(value)
+        desc = self.entity_description
+        value = desc.value_map[option]
+        key = desc.write_key
+        if desc.robot_hex:
+            robot_value: int | str = f"{int(value):02X}"
+        elif desc.robot_numeric:
+            robot_value = int(value)
         elif isinstance(value, int):
             robot_value = f"{value:02d}"
         else:
             robot_value = str(value)
+
+        if desc.cloud_hex:
+            cloud_value: int | str = f"{int(value):02X}"
+        elif desc.cloud_string:
+            cloud_value = str(value)
+        else:
+            cloud_value = value
+
         await async_write_settings(
             self.coordinator,
             operations=(
@@ -191,9 +270,9 @@ class NavimowSettingSelect(NavimowEntity, SelectEntity):
                     (
                         self._sn,
                         self.coordinator.vehicle_type,
-                        {key: value},
+                        {key: cloud_value},
                     ),
                 ),
             ),
-            cache_values={key: value},
+            cache_values={key: cloud_value},
         )

--- a/custom_components/navimower/time.py
+++ b/custom_components/navimower/time.py
@@ -1,95 +1,18 @@
-"""Time platform for Navimower settings."""
+"""Legacy time platform retained for entity-registry compatibility.
+
+The frost protection cutoff moved to a select entity in v0.3.4-beta7 so Home
+Assistant can expose only the quarter-hour values accepted by the mower app.
+"""
 from __future__ import annotations
 
-from datetime import time as dt_time
-from typing import Any
-
-from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-
-from .const import DOMAIN
-from .coordinator import NavimowCoordinator
-from .entity import NavimowEntity
-from .setting_write import async_write_settings
-
-FROST_TIME_STEP_MINUTES = 15
-FROST_TIME_MAX_MINUTES = 12 * 60 + 45
-
-FROST_TIME = TimeEntityDescription(
-    key="frost_delay_until",
-    translation_key="frost_delay_until",
-    icon="mdi:clock-alert-outline",
-    entity_category=EntityCategory.CONFIG,
-)
-
-
-def _raw_setting(data: dict, key: str) -> Any:
-    raw = data.get("raw") or {}
-    set_list = raw.get("set_list") or {}
-    return set_list.get(key) if isinstance(set_list, dict) else None
-
-
-def _frost_minutes(data: dict) -> int | None:
-    value = _raw_setting(data, "frostDelayTime")
-    try:
-        quarters = int(float(value))
-    except (TypeError, ValueError):
-        return None
-    minutes = quarters * FROST_TIME_STEP_MINUTES
-    return minutes if 0 <= minutes <= FROST_TIME_MAX_MINUTES else None
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
-    coordinator: NavimowCoordinator = hass.data[DOMAIN][entry.entry_id]
-    if _frost_minutes(coordinator.data or {}) is not None:
-        async_add_entities([NavimowFrostTime(coordinator)])
-
-
-class NavimowFrostTime(NavimowEntity, TimeEntity):
-    """Time of day until which frost protection keeps the mower docked."""
-
-    entity_description = FROST_TIME
-
-    def __init__(self, coordinator: NavimowCoordinator) -> None:
-        super().__init__(coordinator, FROST_TIME.key)
-
-    @property
-    def native_value(self) -> dt_time | None:
-        minutes = _frost_minutes(self.data)
-        if minutes is None:
-            return None
-        return dt_time(hour=minutes // 60, minute=minutes % 60)
-
-    async def async_set_value(self, value: dt_time) -> None:
-        if value.second or value.microsecond or value.minute % FROST_TIME_STEP_MINUTES:
-            raise HomeAssistantError("Frost time must use 15-minute intervals")
-        minutes = value.hour * 60 + value.minute
-        if not 0 <= minutes <= FROST_TIME_MAX_MINUTES:
-            raise HomeAssistantError(
-                "The mower app currently supports frost times from 00:00 to 12:45"
-            )
-        wire = minutes // FROST_TIME_STEP_MINUTES
-        await async_write_settings(
-            self.coordinator,
-            operations=(
-                (
-                    self.coordinator.client.send_setting_device,
-                    (self._sn, {"frostDelayTime": wire}),
-                ),
-                (
-                    self.coordinator.client.save_setting_iot,
-                    (
-                        self._sn,
-                        self.coordinator.vehicle_type,
-                        {"frostDelayTime": wire},
-                    ),
-                ),
-            ),
-            cache_values={"frostDelayTime": wire},
-        )
+    """Do not create legacy time entities."""

--- a/tests/test_v030_architecture.py
+++ b/tests/test_v030_architecture.py
@@ -9,7 +9,7 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_release_version_and_map_schema() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4-beta6"
+    assert manifest["version"] == "0.3.4-beta7"
     const_source = (COMPONENT / "const.py").read_text()
     assert "MAP_API_SCHEMA_VERSION: Final = 5" in const_source
 

--- a/tests/test_v031_features.py
+++ b/tests/test_v031_features.py
@@ -42,7 +42,7 @@ def test_schedule_translation_exists() -> None:
 
 def test_manifest_version() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4-beta6"
+    assert manifest["version"] == "0.3.4-beta7"
 
 
 def test_diagnostics_redacts_oauth_device_id_and_summarizes_rtk() -> None:

--- a/tests/test_v034_beta5.py
+++ b/tests/test_v034_beta5.py
@@ -48,20 +48,21 @@ def test_weather_switches_match_app_meaning() -> None:
 
 
 def test_rain_wait_options_and_hex_wire_encoding() -> None:
-    source = (COMPONENT / "number.py").read_text()
-    assert "RAIN_WAIT_HOURS" in source
-    for value in ("0.25", "0.5", "12", "14", "16", "18", "20", "22", "24"):
-        assert value in source
-    block = source.split('key="rain_delay_time"', 1)[1].split(
-        "NavimowNumberDescription(", 1
-    )[0]
-    assert 'raw_read_key="delayedPileSet"' in block
-    assert "raw_base=16" in block
-    assert "scale=4" in block
-    assert "cloud_hex=True" in block
-    assert "allowed_native_values=RAIN_WAIT_HOURS" in block
-    assert 'f"{wire:02X}"' in source
-    assert "wire = int(round(native * desc.scale))" in source
+    select_source = (COMPONENT / "select.py").read_text()
+    number_source = (COMPONENT / "number.py").read_text()
+    assert 'key="rain_delay_time"' in select_source
+    assert 'raw_read_key="delayedPileSet"' in select_source
+    for label, wire in (
+        ("15 min", "01"),
+        ("30 min", "02"),
+        ("1 h", "04"),
+        ("3 h", "0C"),
+        ("12 h", "30"),
+        ("14 h", "38"),
+        ("24 h", "60"),
+    ):
+        assert f'"{label}": "{wire}"' in select_source
+    assert 'key="rain_delay_time"' not in number_source
 
 
 def test_snow_and_temperature_ranges() -> None:
@@ -82,15 +83,16 @@ def test_snow_and_temperature_ranges() -> None:
     assert "native_step=1" in hot
 
 
-def test_frost_time_platform_uses_quarter_hours() -> None:
-    init_source = (COMPONENT / "__init__.py").read_text()
-    source = (COMPONENT / "time.py").read_text()
-    assert "Platform.TIME" in init_source
-    assert "FROST_TIME_STEP_MINUTES = 15" in source
-    assert "FROST_TIME_MAX_MINUTES = 12 * 60 + 45" in source
-    assert '"frostDelayTime": wire' in source
-    assert "send_setting_device" in source
-    assert "save_setting_iot" in source
+def test_frost_cutoff_uses_quarter_hour_select() -> None:
+    source = (COMPONENT / "select.py").read_text()
+    assert "FROST_TIME_VALUES" in source
+    assert "range(0, 12 * 60 + 46, 15)" in source
+    block = source.split('key="frost_delay_until"', 1)[1].split(
+        "NavimowSelectDescription(", 1
+    )[0]
+    assert 'raw_read_key="frostDelayTime"' in block
+    assert 'write_key="frostDelayTime"' in block
+    assert "robot_hex=True" in block
     ast.parse(source)
 
 
@@ -104,4 +106,3 @@ def test_translation_files_match_and_include_beta5_entities() -> None:
     assert entity["switch"]["geo_fence_alarm"]["name"] == "Geo-fence alarm"
     assert entity["number"]["snow_delay_time"]["name"] == "Snow delay duration"
     assert entity["number"]["maximum_mowing_temperature"]["name"] == "Maximum mowing temperature"
-    assert entity["time"]["frost_delay_until"]["name"] == "Won't mow until after frost"

--- a/tests/test_v034_beta6.py
+++ b/tests/test_v034_beta6.py
@@ -11,7 +11,7 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_manifest_version() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4-beta6"
+    assert manifest["version"] == "0.3.4-beta7"
 
 
 def test_setting_transaction_has_one_executor_job_and_delayed_readback() -> None:
@@ -26,8 +26,8 @@ def test_setting_transaction_has_one_executor_job_and_delayed_readback() -> None
     ast.parse(source)
 
 
-def test_all_setting_platforms_use_shared_transaction() -> None:
-    for filename in ("switch.py", "select.py", "number.py", "time.py"):
+def test_all_active_setting_platforms_use_shared_transaction() -> None:
+    for filename in ("switch.py", "select.py", "number.py"):
         source = (COMPONENT / filename).read_text()
         assert "from .setting_write import async_write_settings" in source
         assert "await async_write_settings(" in source
@@ -47,10 +47,15 @@ def test_switches_no_longer_refresh_between_robot_and_cloud_writes() -> None:
 def test_value_entities_use_acknowledged_write_through_values() -> None:
     select_source = (COMPONENT / "select.py").read_text()
     number_source = (COMPONENT / "number.py").read_text()
-    time_source = (COMPONENT / "time.py").read_text()
-    assert "cache_values={key: value}" in select_source
+    assert "cache_values={key: cloud_value}" in select_source
     assert "cache_values={key: cloud_value}" in number_source
-    assert 'cache_values={"frostDelayTime": wire}' in time_source
+
+
+def test_legacy_time_platform_creates_no_duplicate_frost_entity() -> None:
+    source = (COMPONENT / "time.py").read_text()
+    assert "Do not create legacy time entities" in source
+    assert "NavimowFrostTime" not in source
+    ast.parse(source)
 
 
 def test_geo_fence_alarm_uses_radar_icon() -> None:

--- a/tests/test_v034_beta7.py
+++ b/tests/test_v034_beta7.py
@@ -1,0 +1,90 @@
+"""Regressions for Navimower v0.3.4-beta7."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _description_block(source: str, key: str, marker: str) -> str:
+    return source.split(f'key="{key}"', 1)[1].split(marker, 1)[0]
+
+
+def test_manifest_version() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.3.4-beta7"
+
+
+def test_discrete_weather_values_use_selects() -> None:
+    select_source = (COMPONENT / "select.py").read_text()
+    number_source = (COMPONENT / "number.py").read_text()
+
+    rain = _description_block(
+        select_source, "rain_delay_time", "NavimowSelectDescription("
+    )
+    assert 'name="Wait time after rain"' in rain
+    assert 'raw_read_key="delayedPileSet"' in rain
+    assert "value_map=RAIN_DELAY_VALUES" in rain
+    assert 'key="rain_delay_time"' not in number_source
+
+    for label, wire in (
+        ("15 min", "01"),
+        ("30 min", "02"),
+        ("1 h", "04"),
+        ("2 h", "08"),
+        ("3 h", "0C"),
+        ("12 h", "30"),
+        ("14 h", "38"),
+        ("24 h", "60"),
+    ):
+        assert f'"{label}": "{wire}"' in select_source
+    assert "1.25" not in select_source
+
+
+def test_frost_select_is_quarter_hour_only_and_hex_to_robot() -> None:
+    source = (COMPONENT / "select.py").read_text()
+    block = _description_block(
+        source, "frost_delay_until", "NavimowSelectDescription("
+    )
+    assert "range(0, 12 * 60 + 46, 15)" in source
+    assert 'raw_read_key="frostDelayTime"' in block
+    assert "value_map=FROST_TIME_VALUES" in block
+    assert "robot_hex=True" in block
+    assert 'robot_value: int | str = f"{int(value):02X}"' in source
+    assert "cloud_value = value" in source
+
+    legacy = (COMPONENT / "time.py").read_text()
+    assert "NavimowFrostTime" not in legacy
+    assert "Do not create legacy time entities" in legacy
+
+
+def test_continuous_numeric_settings_are_sliders_with_hex_robot_values() -> None:
+    source = (COMPONENT / "number.py").read_text()
+    for key, raw_key, minimum, maximum in (
+        ("snow_delay_time", "snowDelayTime", 24, 168),
+        ("maximum_mowing_temperature", "allowMaxTemp", 30, 45),
+        ("geo_fence_radius", "antiTheftRadius", 10, 50),
+    ):
+        block = _description_block(source, key, "NavimowNumberDescription(")
+        assert f'raw_read_key="{raw_key}"' in block
+        assert f"native_min_value={minimum}" in block
+        assert f"native_max_value={maximum}" in block
+        assert "native_step=1" in block
+        assert "mode=NumberMode.SLIDER" in block
+        assert "robot_hex=True" in block
+
+    geo = _description_block(source, "geo_fence_radius", "NavimowNumberDescription(")
+    assert "cloud_string=True" in geo
+    assert 'robot_value: int | str = f"{wire:02X}"' in source
+    ast.parse(source)
+
+
+def test_live_capture_examples_match_hex_encoding() -> None:
+    assert f"{20:02X}" == "14"  # Geo-fence: 20 m, not decimal text "20" (=0x20/32).
+    assert f"{25:02X}" == "19"  # Geo-fence: 25 m, not decimal text "25" (=0x25/37).
+    assert f"{36:02X}" == "24"  # Snow delay: 36 h, not decimal text "36" (=0x36/54).
+    assert f"{28:02X}" == "1C"  # Frost 07:00: 28 quarter-hours, not 0x28/10:00.
+    assert f"{31:02X}" == "1F"  # Temperature 31 C, not decimal text "31" (=0x31/49).


### PR DESCRIPTION
## Summary

- fix verified mower-side HEX encoding for Geo-fence radius, Snow delay, Frost cutoff and Maximum mowing temperature
- keep cloud values in their observed decimal representations
- move Wait time after rain to a select containing only app-supported values
- move the frost cutoff to a quarter-hour select from 00:00 through 12:45
- use sliders for Snow delay, Maximum mowing temperature and Geo-fence radius
- retain the beta6 settings transaction and delayed cloud confirmation
- add beta7 regressions and release notes

## Live captures covered

- 20 m was previously interpreted as 0x20 = 32 m
- 25 m was previously interpreted as 0x25 = 37 m
- 36 h was previously interpreted as 0x36 = 54 h
- 07:00 (28 quarter-hours) was previously interpreted as 0x28 = 40 quarters = 10:00
- 31 °C was previously interpreted as 0x31 = 49 °C

The prerelease workflow must compile the integration and pass the full pytest suite before publishing `v0.3.4-beta7`.