### PR TITLE
Prepare Navimower 0.3.4-beta8

### DIFF
--- a/.github/release-notes/0.3.4-beta8.md
+++ b/.github/release-notes/0.3.4-beta8.md
@@ -1,0 +1,42 @@
+title: Navimower 0.3.4-beta8 — mapped preferences and H215 Lab controls
+
+## Newly mapped preferences
+
+Beta8 exposes the settings confirmed through paired Navimow app diagnostics:
+
+- **Do not disturb** switch using `dndModeSwitch`.
+- **Quiet period starts** and **Quiet period ends** selects covering the full day in 15-minute steps. The app value `4C20` is decoded as 19:00–08:00 and both fields are preserved when either time is changed.
+- **Energy saver** now uses the app name while retaining the confirmed `lowPowerSet` setting.
+- **Brightness** adds the three app choices: Default, Dim and Extra dim (`lightIntensity` values 0, 1 and 2).
+
+## H215 Lab controls
+
+Where the corresponding raw setting exists, Home Assistant now exposes:
+
+- **Terrain adapt** (`terrainAdaptSwitch`) as a switch.
+- **Edge sense** (`edgeSense`) as a switch.
+- **Edge sense mode** (`edgeSenselevel`) with Standard, Cautious and Extreme choices.
+
+These entities are presence-gated by the mower's returned `set_list`, so unsupported settings are not created.
+
+## Night mowing repair
+
+- Night mowing is returned to the device Controls section instead of Configuration.
+- State reads prefer the mower app's nested `camerabox.nightMowSwitch` value, with top-level fallbacks.
+- Writes use the confirmed legacy plain `save-set-data` format with `"01"`/`"00"` rather than the modern `iot_set` path.
+- The acknowledged value is also patched into the nested write-through cache so the Home Assistant state and Activity update immediately while delayed cloud confirmation remains active.
+
+## Snow delay display
+
+Snow delay remains stored and sent in hours, but Home Assistant now shows a **1–7 day** slider:
+
+- 1 day = 24 hours
+- 2 days = 48 hours
+- …
+- 7 days = 168 hours
+
+The mower still receives the underlying hour count as hexadecimal and the cloud stores decimal hours.
+
+## Testing scope
+
+The Satellite Signal Analyzer / Distribution map experiment on the X390 is intentionally not included in this beta. Install the prerelease through HACS, restart Home Assistant, and verify the newly exposed controls in both directions against the Navimow app.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.3.4-beta7"
+  "version": "0.3.4-beta8"
 }

--- a/custom_components/navimower/number.py
+++ b/custom_components/navimower/number.py
@@ -72,22 +72,23 @@ NUMBERS: tuple[NavimowNumberDescription, ...] = (
         value_fn=lambda s: s.get("charging_limit"),
         write_key="chargingLimit",
     ),
-    # Weather-adaptive settings with regular, continuous app ranges.
+    # Weather-adaptive settings with regular app ranges.
     NavimowNumberDescription(
         key="snow_delay_time",
-        translation_key="snow_delay_time",
+        name="Snow delay duration",
         icon="mdi:calendar-clock",
         entity_category=EntityCategory.CONFIG,
-        native_unit_of_measurement=UnitOfTime.HOURS,
-        native_min_value=24,
-        native_max_value=168,
+        native_unit_of_measurement=UnitOfTime.DAYS,
+        native_min_value=1,
+        native_max_value=7,
         native_step=1,
         mode=NumberMode.SLIDER,
         value_fn=lambda s: None,
         raw_read_key="snowDelayTime",
         write_key="snowDelayTime",
-        # The mower command interprets its string as hexadecimal while set-list
-        # and the iot_set cloud copy expose/store decimal hours.
+        scale=24,
+        # Home Assistant shows whole days. The mower command still expects the
+        # underlying hour count as hexadecimal; cloud set-list stores hours.
         robot_hex=True,
     ),
     NavimowNumberDescription(

--- a/custom_components/navimower/select.py
+++ b/custom_components/navimower/select.py
@@ -10,6 +10,7 @@ from homeassistant.components.select import SelectEntity, SelectEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -50,6 +51,12 @@ FROST_TIME_VALUES: dict[str, int] = {
     for minutes in range(0, 12 * 60 + 46, 15)
 }
 
+# Do Not Disturb start/end choices cover the full day in 15-minute steps.
+DAY_TIME_VALUES: dict[str, int] = {
+    f"{minutes // 60:02d}:{minutes % 60:02d}": minutes // 15
+    for minutes in range(0, 24 * 60, 15)
+}
+
 
 @dataclass(frozen=True, kw_only=True)
 class NavimowSelectDescription(SelectEntityDescription):
@@ -63,6 +70,7 @@ class NavimowSelectDescription(SelectEntityDescription):
     cloud_hex: bool = False
     cloud_string: bool = False
     raw_read_key: str | None = None
+    compound_index: int | None = None
 
 
 SETTING_SELECTS: tuple[NavimowSelectDescription, ...] = (
@@ -91,6 +99,28 @@ SETTING_SELECTS: tuple[NavimowSelectDescription, ...] = (
         robot_hex=True,
     ),
     NavimowSelectDescription(
+        key="quiet_period_start",
+        name="Quiet period starts",
+        icon="mdi:clock-start",
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda s: None,
+        raw_read_key="dndPeriod",
+        write_key="dndPeriod",
+        value_map=DAY_TIME_VALUES,
+        compound_index=0,
+    ),
+    NavimowSelectDescription(
+        key="quiet_period_end",
+        name="Quiet period ends",
+        icon="mdi:clock-end",
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda s: None,
+        raw_read_key="dndPeriod",
+        write_key="dndPeriod",
+        value_map=DAY_TIME_VALUES,
+        compound_index=1,
+    ),
+    NavimowSelectDescription(
         key="work_mode",
         translation_key="work_mode",
         icon="mdi:grass",
@@ -105,13 +135,42 @@ SETTING_SELECTS: tuple[NavimowSelectDescription, ...] = (
         },
     ),
     NavimowSelectDescription(
+        key="light_brightness",
+        name="Brightness",
+        icon="mdi:brightness-6",
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda s: None,
+        raw_read_key="lightIntensity",
+        write_key="lightIntensity",
+        value_map={
+            "Default": "0",
+            "Dim": "1",
+            "Extra dim": "2",
+        },
+    ),
+    NavimowSelectDescription(
         key="night_light_level",
         translation_key="night_light_level",
-        icon="mdi:brightness-6",
+        icon="mdi:brightness-4",
         entity_category=EntityCategory.CONFIG,
         value_fn=lambda s: s.get("night_light_level"),
         write_key="nightLightLevel",
         value_map={"dim": 0, "very_dim": 1},
+    ),
+    NavimowSelectDescription(
+        key="edge_sense_mode",
+        name="Edge sense mode",
+        icon="mdi:vector-line",
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda s: None,
+        raw_read_key="edgeSenselevel",
+        write_key="edgeSenselevel",
+        value_map={
+            "Standard": 0,
+            "Cautious": 1,
+            "Extreme": 2,
+        },
+        robot_numeric=True,
     ),
     NavimowSelectDescription(
         key="weather_sensitivity",
@@ -132,10 +191,28 @@ def _raw_setting(data: dict, key: str) -> Any:
     return set_list.get(key) if isinstance(set_list, dict) else None
 
 
+def _decode_dnd_period(value: Any) -> tuple[int, int] | None:
+    """Decode the app's two hexadecimal quarter-hour bytes."""
+    text = str(value).strip().upper() if value is not None else ""
+    if len(text) != 4:
+        return None
+    try:
+        start = int(text[:2], 16)
+        end = int(text[2:], 16)
+    except ValueError:
+        return None
+    if not 0 <= start < 96 or not 0 <= end < 96:
+        return None
+    return start, end
+
+
 def _normalize_raw_value(
     desc: NavimowSelectDescription, value: Any
 ) -> int | str | None:
     """Normalize set-list values to the type used by the select value map."""
+    if desc.compound_index is not None:
+        period = _decode_dnd_period(value)
+        return None if period is None else period[desc.compound_index]
     if value is None:
         return None
     mapped = tuple(desc.value_map.values())
@@ -242,21 +319,34 @@ class NavimowSettingSelect(NavimowEntity, SelectEntity):
         desc = self.entity_description
         value = desc.value_map[option]
         key = desc.write_key
-        if desc.robot_hex:
-            robot_value: int | str = f"{int(value):02X}"
-        elif desc.robot_numeric:
-            robot_value = int(value)
-        elif isinstance(value, int):
-            robot_value = f"{value:02d}"
-        else:
-            robot_value = str(value)
 
-        if desc.cloud_hex:
-            cloud_value: int | str = f"{int(value):02X}"
-        elif desc.cloud_string:
-            cloud_value = str(value)
+        if desc.compound_index is not None:
+            period = _decode_dnd_period(_raw_setting(self.data, key))
+            if period is None:
+                raise HomeAssistantError(
+                    "The Navimow app has not provided a valid quiet period."
+                )
+            updated = list(period)
+            updated[desc.compound_index] = int(value)
+            compound = f"{updated[0]:02X}{updated[1]:02X}"
+            robot_value: int | str = compound
+            cloud_value: int | str = compound
         else:
-            cloud_value = value
+            if desc.robot_hex:
+                robot_value = f"{int(value):02X}"
+            elif desc.robot_numeric:
+                robot_value = int(value)
+            elif isinstance(value, int):
+                robot_value = f"{value:02d}"
+            else:
+                robot_value = str(value)
+
+            if desc.cloud_hex:
+                cloud_value = f"{int(value):02X}"
+            elif desc.cloud_string:
+                cloud_value = str(value)
+            else:
+                cloud_value = value
 
         await async_write_settings(
             self.coordinator,

--- a/custom_components/navimower/switch.py
+++ b/custom_components/navimower/switch.py
@@ -1,11 +1,9 @@
-"""Switch platform for Navimower: cloud settings toggles.
+"""Switch platform for Navimower cloud settings.
 
-Two write families, both via ``/vehicle/set/save-set-data``:
-
-* legacy switches (nightMow/rain/sound/power-saving) use the *plain* form with a
-  zero-padded boolean string ('01'/'00');
-* "modern" MowerSettingBean toggles use ``operation_type:"iot_set"`` with a
-  per-key value encoding and are sent to the robot first so the change applies.
+``nightMowSwitch`` is a legacy setting written through the plain
+``save-set-data`` form with a zero-padded boolean string (``"01"``/``"00"``).
+Modern MowerSettingBean toggles use ``operation_type:"iot_set"`` and are sent
+to the mower first so the change applies immediately.
 
 Settings writes use one transaction and delayed cloud readback so an eventually
 consistent ``set_list`` cannot briefly restore the previous switch state.
@@ -43,6 +41,8 @@ class NavimowSwitchDescription(SwitchEntityDescription):
     assumed: bool = False
     gate_key: str | None = None
     raw_read_key: str | None = None
+    raw_read_path: tuple[str, ...] | None = None
+    raw_fallback_keys: tuple[str, ...] = ()
 
 
 SWITCHES: tuple[NavimowSwitchDescription, ...] = (
@@ -61,14 +61,13 @@ SWITCHES: tuple[NavimowSwitchDescription, ...] = (
     ),
     NavimowSwitchDescription(
         key="night_mow",
-        translation_key="night_mow",
+        name="Night mowing",
         icon="mdi:weather-night",
-        entity_category=EntityCategory.CONFIG,
         value_fn=lambda s: s.get("night_mow"),
         write_key="nightMowSwitch",
         proven=True,
-        iot=True,
-        numeric=True,
+        raw_read_path=("camerabox", "nightMowSwitch"),
+        raw_fallback_keys=("nightMowSwitch", "night_mow_switch"),
     ),
     NavimowSwitchDescription(
         key="mowing_cycle",
@@ -179,7 +178,7 @@ SWITCHES: tuple[NavimowSwitchDescription, ...] = (
     ),
     NavimowSwitchDescription(
         key="power_saving",
-        translation_key="power_saving",
+        name="Energy saver",
         icon="mdi:leaf",
         entity_category=EntityCategory.CONFIG,
         value_fn=lambda s: s.get("power_saving"),
@@ -187,6 +186,19 @@ SWITCHES: tuple[NavimowSwitchDescription, ...] = (
         proven=True,
         iot=True,
         numeric=True,
+    ),
+    NavimowSwitchDescription(
+        key="do_not_disturb",
+        name="Do not disturb",
+        icon="mdi:volume-off",
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda s: None,
+        raw_read_key="dndModeSwitch",
+        write_key="dndModeSwitch",
+        iot=True,
+        numeric=False,
+        robot_numeric=False,
+        enabled_default=True,
     ),
     NavimowSwitchDescription(
         key="night_light",
@@ -200,7 +212,7 @@ SWITCHES: tuple[NavimowSwitchDescription, ...] = (
         numeric=True,
         enabled_default=True,
     ),
-    # Safety and navigation settings
+    # Safety, navigation and model-specific Lab settings
     NavimowSwitchDescription(
         key="child_lock",
         translation_key="child_lock",
@@ -280,6 +292,30 @@ SWITCHES: tuple[NavimowSwitchDescription, ...] = (
         numeric=True,
         enabled_default=True,
     ),
+    NavimowSwitchDescription(
+        key="terrain_adapt",
+        name="Terrain adapt",
+        icon="mdi:terrain",
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda s: None,
+        raw_read_key="terrainAdaptSwitch",
+        write_key="terrainAdaptSwitch",
+        iot=True,
+        numeric=True,
+        enabled_default=True,
+    ),
+    NavimowSwitchDescription(
+        key="edge_sense",
+        name="Edge sense",
+        icon="mdi:vector-line",
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda s: None,
+        raw_read_key="edgeSense",
+        write_key="edgeSense",
+        iot=True,
+        numeric=True,
+        enabled_default=True,
+    ),
 )
 
 
@@ -298,15 +334,52 @@ def _as_bool(value: Any) -> bool | None:
     return None
 
 
-def _raw_setting(data: dict, key: str) -> Any:
+def _set_list(data: dict) -> dict:
     raw = data.get("raw") or {}
-    set_list = raw.get("set_list") or {}
-    return set_list.get(key) if isinstance(set_list, dict) else None
+    value = raw.get("set_list") or {}
+    return value if isinstance(value, dict) else {}
+
+
+def _raw_setting(data: dict, key: str) -> Any:
+    return _set_list(data).get(key)
+
+
+def _raw_setting_path(data: dict, path: tuple[str, ...]) -> Any:
+    value: Any = _set_list(data)
+    for key in path:
+        if not isinstance(value, dict):
+            return None
+        value = value.get(key)
+    return value
+
+
+def _read_raw_value(desc: NavimowSwitchDescription, data: dict) -> Any:
+    if desc.raw_read_path is not None:
+        value = _raw_setting_path(data, desc.raw_read_path)
+        if value is not None:
+            return value
+    if desc.raw_read_key is not None:
+        value = _raw_setting(data, desc.raw_read_key)
+        if value is not None:
+            return value
+    for key in desc.raw_fallback_keys:
+        value = _raw_setting(data, key)
+        if value is not None:
+            return value
+    return None
+
+
+def _uses_raw_read(desc: NavimowSwitchDescription) -> bool:
+    return bool(
+        desc.raw_read_key is not None
+        or desc.raw_read_path is not None
+        or desc.raw_fallback_keys
+    )
 
 
 def _read_value(desc: NavimowSwitchDescription, data: dict) -> bool | None:
-    if desc.raw_read_key is not None:
-        return _as_bool(_raw_setting(data, desc.raw_read_key))
+    if _uses_raw_read(desc):
+        return _as_bool(_read_raw_value(desc, data))
     return desc.value_fn(data.get("settings") or {})
 
 
@@ -314,11 +387,29 @@ def _present(desc: NavimowSwitchDescription, data: dict) -> bool:
     if desc.proven:
         return True
     settings = data.get("settings") or {}
-    if desc.raw_read_key is not None:
-        return _raw_setting(data, desc.raw_read_key) is not None
+    if _uses_raw_read(desc):
+        return _read_raw_value(desc, data) is not None
     if desc.gate_key is not None:
         return settings.get(desc.gate_key) is not None
     return desc.value_fn(settings) is not None
+
+
+def _nested_cache_root(
+    data: dict, path: tuple[str, ...], value: Any
+) -> tuple[str, dict[str, Any]]:
+    """Return a copied top-level subtree with one nested value updated."""
+    if len(path) < 2:
+        raise ValueError("nested cache path must contain at least two keys")
+    source = _set_list(data)
+    root_key = path[0]
+    root = dict(source.get(root_key) or {})
+    cursor = root
+    for key in path[1:-1]:
+        child = dict(cursor.get(key) or {})
+        cursor[key] = child
+        cursor = child
+    cursor[path[-1]] = value
+    return root_key, root
 
 
 async def async_setup_entry(
@@ -393,10 +484,19 @@ class NavimowSwitch(NavimowEntity, SwitchEntity):
                 )
             )
 
+        cache_values: dict[str, Any] = {desc.write_key: cloud_value}
+        if desc.raw_read_path is not None:
+            root_key, root = _nested_cache_root(
+                self.data, desc.raw_read_path, cloud_value
+            )
+            cache_values[root_key] = root
+        for key in desc.raw_fallback_keys:
+            cache_values[key] = cloud_value
+
         await async_write_settings(
             self.coordinator,
             operations=operations,
-            cache_values={desc.write_key: cloud_value},
+            cache_values=cache_values,
         )
         if desc.assumed:
             self._optimistic = on

--- a/tests/test_v030_architecture.py
+++ b/tests/test_v030_architecture.py
@@ -9,7 +9,7 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_release_version_and_map_schema() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4-beta7"
+    assert manifest["version"] == "0.3.4-beta8"
     const_source = (COMPONENT / "const.py").read_text()
     assert "MAP_API_SCHEMA_VERSION: Final = 5" in const_source
 

--- a/tests/test_v031_features.py
+++ b/tests/test_v031_features.py
@@ -42,7 +42,7 @@ def test_schedule_translation_exists() -> None:
 
 def test_manifest_version() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4-beta7"
+    assert manifest["version"] == "0.3.4-beta8"
 
 
 def test_diagnostics_redacts_oauth_device_id_and_summarizes_rtk() -> None:

--- a/tests/test_v034_beta5.py
+++ b/tests/test_v034_beta5.py
@@ -71,9 +71,11 @@ def test_snow_and_temperature_ranges() -> None:
         "NavimowNumberDescription(", 1
     )[0]
     assert 'raw_read_key="snowDelayTime"' in snow
-    assert "native_min_value=24" in snow
-    assert "native_max_value=168" in snow
+    assert "native_unit_of_measurement=UnitOfTime.DAYS" in snow
+    assert "native_min_value=1" in snow
+    assert "native_max_value=7" in snow
     assert "native_step=1" in snow
+    assert "scale=24" in snow
     hot = source.split('key="maximum_mowing_temperature"', 1)[1].split(
         "NavimowNumberDescription(", 1
     )[0]

--- a/tests/test_v034_beta6.py
+++ b/tests/test_v034_beta6.py
@@ -11,7 +11,7 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_manifest_version() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4-beta7"
+    assert manifest["version"] == "0.3.4-beta8"
 
 
 def test_setting_transaction_has_one_executor_job_and_delayed_readback() -> None:
@@ -41,7 +41,8 @@ def test_switches_no_longer_refresh_between_robot_and_cloud_writes() -> None:
     assert "send_setting_device" in write_block
     assert "set_iot_bool" in write_block
     assert "self.coordinator.async_send" not in write_block
-    assert "cache_values={desc.write_key: cloud_value}" in write_block
+    assert "cache_values=cache_values" in write_block
+    assert "cache_values: dict[str, Any] = {desc.write_key: cloud_value}" in write_block
 
 
 def test_value_entities_use_acknowledged_write_through_values() -> None:

--- a/tests/test_v034_beta7.py
+++ b/tests/test_v034_beta7.py
@@ -15,7 +15,7 @@ def _description_block(source: str, key: str, marker: str) -> str:
 
 def test_manifest_version() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4-beta7"
+    assert manifest["version"] == "0.3.4-beta8"
 
 
 def test_discrete_weather_values_use_selects() -> None:
@@ -53,7 +53,7 @@ def test_frost_select_is_quarter_hour_only_and_hex_to_robot() -> None:
     assert 'raw_read_key="frostDelayTime"' in block
     assert "value_map=FROST_TIME_VALUES" in block
     assert "robot_hex=True" in block
-    assert 'robot_value: int | str = f"{int(value):02X}"' in source
+    assert 'robot_value = f"{int(value):02X}"' in source
     assert "cloud_value = value" in source
 
     legacy = (COMPONENT / "time.py").read_text()
@@ -63,8 +63,17 @@ def test_frost_select_is_quarter_hour_only_and_hex_to_robot() -> None:
 
 def test_continuous_numeric_settings_are_sliders_with_hex_robot_values() -> None:
     source = (COMPONENT / "number.py").read_text()
+
+    snow = _description_block(source, "snow_delay_time", "NavimowNumberDescription(")
+    assert 'raw_read_key="snowDelayTime"' in snow
+    assert "native_min_value=1" in snow
+    assert "native_max_value=7" in snow
+    assert "native_step=1" in snow
+    assert "scale=24" in snow
+    assert "mode=NumberMode.SLIDER" in snow
+    assert "robot_hex=True" in snow
+
     for key, raw_key, minimum, maximum in (
-        ("snow_delay_time", "snowDelayTime", 24, 168),
         ("maximum_mowing_temperature", "allowMaxTemp", 30, 45),
         ("geo_fence_radius", "antiTheftRadius", 10, 50),
     ):

--- a/tests/test_v034_beta8.py
+++ b/tests/test_v034_beta8.py
@@ -1,0 +1,127 @@
+"""Regressions for Navimower v0.3.4-beta8."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _description_block(source: str, key: str, marker: str) -> str:
+    return source.split(f'key="{key}"', 1)[1].split(marker, 1)[0]
+
+
+def test_manifest_version() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.3.4-beta8"
+
+
+def test_snow_delay_is_exposed_as_one_to_seven_days() -> None:
+    source = (COMPONENT / "number.py").read_text()
+    block = _description_block(source, "snow_delay_time", "NavimowNumberDescription(")
+    assert "native_unit_of_measurement=UnitOfTime.DAYS" in block
+    assert "native_min_value=1" in block
+    assert "native_max_value=7" in block
+    assert "native_step=1" in block
+    assert "scale=24" in block
+    assert 'raw_read_key="snowDelayTime"' in block
+    assert "robot_hex=True" in block
+    assert 1 * 24 == 24
+    assert 7 * 24 == 168
+    assert f"{3 * 24:02X}" == "48"
+
+
+def test_night_mowing_uses_nested_read_and_legacy_write() -> None:
+    source = (COMPONENT / "switch.py").read_text()
+    block = _description_block(source, "night_mow", "NavimowSwitchDescription(")
+    assert 'name="Night mowing"' in block
+    assert "entity_category=EntityCategory.CONFIG" not in block
+    assert 'write_key="nightMowSwitch"' in block
+    assert 'raw_read_path=("camerabox", "nightMowSwitch")' in block
+    assert 'raw_fallback_keys=("nightMowSwitch", "night_mow_switch")' in block
+    assert "iot=True" not in block
+    assert "set_bool_setting" in source
+    assert "_nested_cache_root(" in source
+    assert "cache_values[root_key] = root" in source
+
+
+def test_do_not_disturb_and_quiet_period_mapping() -> None:
+    switch_source = (COMPONENT / "switch.py").read_text()
+    select_source = (COMPONENT / "select.py").read_text()
+
+    dnd = _description_block(
+        switch_source, "do_not_disturb", "NavimowSwitchDescription("
+    )
+    assert 'raw_read_key="dndModeSwitch"' in dnd
+    assert 'write_key="dndModeSwitch"' in dnd
+    assert "robot_numeric=False" in dnd
+    assert "numeric=False" in dnd
+
+    for key, index in (("quiet_period_start", 0), ("quiet_period_end", 1)):
+        block = _description_block(select_source, key, "NavimowSelectDescription(")
+        assert 'raw_read_key="dndPeriod"' in block
+        assert 'write_key="dndPeriod"' in block
+        assert "value_map=DAY_TIME_VALUES" in block
+        assert f"compound_index={index}" in block
+
+    assert "range(0, 24 * 60, 15)" in select_source
+    assert 'compound = f"{updated[0]:02X}{updated[1]:02X}"' in select_source
+    assert int("4C", 16) * 15 // 60 == 19
+    assert int("20", 16) * 15 // 60 == 8
+
+
+def test_energy_saver_and_three_level_brightness() -> None:
+    switch_source = (COMPONENT / "switch.py").read_text()
+    select_source = (COMPONENT / "select.py").read_text()
+
+    energy = _description_block(
+        switch_source, "power_saving", "NavimowSwitchDescription("
+    )
+    assert 'name="Energy saver"' in energy
+    assert 'write_key="lowPowerSet"' in energy
+    assert "numeric=True" in energy
+
+    brightness = _description_block(
+        select_source, "light_brightness", "NavimowSelectDescription("
+    )
+    assert 'raw_read_key="lightIntensity"' in brightness
+    assert 'write_key="lightIntensity"' in brightness
+    assert '"Default": "0"' in brightness
+    assert '"Dim": "1"' in brightness
+    assert '"Extra dim": "2"' in brightness
+
+
+def test_h215_lab_controls_are_raw_key_gated() -> None:
+    switch_source = (COMPONENT / "switch.py").read_text()
+    select_source = (COMPONENT / "select.py").read_text()
+
+    terrain = _description_block(
+        switch_source, "terrain_adapt", "NavimowSwitchDescription("
+    )
+    assert 'raw_read_key="terrainAdaptSwitch"' in terrain
+    assert 'write_key="terrainAdaptSwitch"' in terrain
+    assert "numeric=True" in terrain
+
+    edge = _description_block(
+        switch_source, "edge_sense", "NavimowSwitchDescription("
+    )
+    assert 'raw_read_key="edgeSense"' in edge
+    assert 'write_key="edgeSense"' in edge
+    assert "numeric=True" in edge
+
+    level = _description_block(
+        select_source, "edge_sense_mode", "NavimowSelectDescription("
+    )
+    assert 'raw_read_key="edgeSenselevel"' in level
+    assert 'write_key="edgeSenselevel"' in level
+    assert '"Standard": 0' in level
+    assert '"Cautious": 1' in level
+    assert '"Extreme": 2' in level
+    assert "robot_numeric=True" in level
+
+
+def test_beta8_setting_sources_compile() -> None:
+    for filename in ("switch.py", "select.py", "number.py"):
+        ast.parse((COMPONENT / filename).read_text())


### PR DESCRIPTION
## Summary

- expose Do not disturb and split the app's `dndPeriod` into 15-minute Quiet period start/end selects
- rename the confirmed `lowPowerSet` control to Energy saver
- add Brightness with Default, Dim and Extra dim options from `lightIntensity`
- add presence-gated Terrain adapt, Edge sense and Edge sense mode controls
- repair Night mowing by reading `camerabox.nightMowSwitch`, using the legacy `"01"`/`"00"` write path, and returning it to device Controls
- show Snow delay as a 1–7 day slider while retaining hour-based robot/cloud encoding
- exclude the X390 Satellite Signal Analyzer experiment from this beta
- add beta8 regressions and prerelease notes

## Diagnostic mappings covered

- `dndModeSwitch`: off/on
- `dndPeriod`: `4C20` = 19:00–08:00
- `lowPowerSet`: Energy saver
- `lightIntensity`: 0 Default, 1 Dim, 2 Extra dim
- `terrainAdaptSwitch`: Terrain adapt
- `edgeSense`: Edge sense
- `edgeSenselevel`: 0 Standard, 1 Cautious, 2 Extreme

The prerelease workflow must compile the integration and pass the full pytest suite before publishing `v0.3.4-beta8`.