### PR TITLE
Prepare Navimower 0.4.0-beta1

### DIFF
--- a/.github/release-notes/0.4.0-beta1.md
+++ b/.github/release-notes/0.4.0-beta1.md
@@ -1,0 +1,34 @@
+title: Navimower 0.4.0-beta1 — completed-session SVG render archives
+
+## Completed-session render preparation
+
+Navimower now prepares a compact, persistent SVG-ready render artifact for each completed mowing session. The exact timestamped session points remain unchanged in Home Assistant storage; the new artifact is a derived cache intended for the next Navimower Map Card version.
+
+- Active sessions remain the existing live polyline trail.
+- When a session becomes inactive, Home Assistant prepares the latest completed-session artifact after a short settle delay.
+- Older retained sessions are generated lazily when their render endpoint is requested.
+- A session that resumes during the existing five-minute continuation window is never served with a stale completed artifact; its fingerprint is checked again after background generation.
+
+## Mowed footprint and preserved travel
+
+The render archive separates the route into two visual layers:
+
+- **Mowed area** — blade-on route segments are expanded using the existing `0.25 m` swath width. Home Assistant rasterizes the stroke, traces its outer and inner boundaries, and stores one SVG path using even-odd fill. Untouched strips, no-mow areas and temporary-obstacle gaps remain transparent rather than becoming a filled whole-zone polygon.
+- **Travel** — dock departure, return-to-dock, pauses and zone-to-zone movement are retained as a separate compact SVG path. They are not widened into the mowed footprint.
+
+MQTT action values are preferred for blade-state classification. When they are unavailable, the stored normalized activity is used conservatively; unknown states are treated as travel so the integration does not invent mowed area.
+
+## API for the future card
+
+A new authenticated endpoint exposes only the derived render artifact:
+
+`/api/navimower/session-render/{entry_id}/{session_id}`
+
+The existing sessions endpoint now includes a `session_render_api_path_template`. The current Map Card is not changed by this integration beta and continues to use the existing route payload. A later card beta will use the compact completed-session artifacts and load older days on demand.
+
+## Storage and compatibility
+
+- Render artifacts are stored separately from the authoritative session files and are removed with the config entry.
+- No config-entry or options migration is required.
+- No new third-party geometry dependency is added.
+- Existing H215 and X390 session history remains compatible. Primary live behavior testing remains H215-based; X390 is the secondary multi-mower validation model.

--- a/custom_components/navimower/__init__.py
+++ b/custom_components/navimower/__init__.py
@@ -37,6 +37,7 @@ from .map_api import async_register_map_api
 from .mqtt import NavimowerMqttBridge
 from .oauth import async_register_oauth_implementation
 from .services import async_setup_services
+from .session_archive import SessionArchiveManager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -144,6 +145,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_load_persistent_state()
     domain_data[entry.entry_id] = coordinator
 
+    # Prepare immutable completed-session render caches independently from the
+    # exact timestamped history. Active sessions remain normal live polylines.
+    session_archive = SessionArchiveManager(hass, entry.entry_id, coordinator)
+    coordinator.session_archive = session_archive
+    session_archive.start()
+
     bridge = NavimowerMqttBridge(hass, entry, coordinator)
     coordinator.mqtt_bridge = bridge
 
@@ -203,6 +210,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data.get(DOMAIN) or {}
     ).get(entry.entry_id)
     bridge = getattr(coordinator, "mqtt_bridge", None) if coordinator else None
+    session_archive = (
+        getattr(coordinator, "session_archive", None) if coordinator else None
+    )
 
     # Stop watchdog/recovery work and invalidate old callback generations before
     # entities disappear. This prevents a late Paho callback from writing into a
@@ -222,6 +232,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 )
         return False
 
+    if session_archive is not None:
+        await session_archive.async_stop()
     if coordinator is not None:
         if bridge is not None:
             await bridge.async_stop()
@@ -233,6 +245,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Remove cached map data and all retained mowing sessions."""
+    await SessionArchiveManager.async_remove_all(hass, entry.entry_id)
     await NavimowerHistory.async_remove_all(hass, entry.entry_id)
     try:
         await state_store(hass, entry.entry_id).async_remove()

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.3.4"
+  "version": "0.4.0-beta1"
 }

--- a/custom_components/navimower/map_api.py
+++ b/custom_components/navimower/map_api.py
@@ -43,6 +43,9 @@ class NavimowerSessionsView(HomeAssistantView):
         return self.json(
             {
                 "schema_version": MAP_API_SCHEMA_VERSION,
+                "session_render_api_path_template": (
+                    f"/api/navimower/session-render/{entry_id}/{{session_id}}"
+                ),
                 **payload,
             }
         )
@@ -74,6 +77,41 @@ class NavimowerSessionView(HomeAssistantView):
         )
 
 
+class NavimowerSessionRenderView(HomeAssistantView):
+    """Return one compact SVG-ready render archive for a completed session."""
+
+    url = "/api/navimower/session-render/{entry_id}/{session_id}"
+    name = "api:navimower:session-render"
+    requires_auth = True
+
+    async def get(
+        self,
+        request: web.Request,
+        entry_id: str,
+        session_id: str,
+    ) -> web.Response:
+        coordinator = _coordinator(request, entry_id)
+        manager = getattr(coordinator, "session_archive", None)
+        if manager is None:
+            raise web.HTTPServiceUnavailable(
+                text="Navimower session archive manager is unavailable"
+            )
+        render = await manager.async_get(session_id)
+        if render is None:
+            raise web.HTTPNotFound(
+                text="No completed Navimower session render is available"
+            )
+        return self.json(
+            {
+                "schema_version": MAP_API_SCHEMA_VERSION,
+                "render_schema_version": render.get("version"),
+                "entry_id": entry_id,
+                "session_id": session_id,
+                "render": render,
+            }
+        )
+
+
 def async_register_map_api(hass: HomeAssistant) -> None:
     """Register all map/history endpoints once per Home Assistant process."""
     if hass.data.get(_REGISTERED_KEY):
@@ -81,4 +119,5 @@ def async_register_map_api(hass: HomeAssistant) -> None:
     hass.http.register_view(NavimowerMapView())
     hass.http.register_view(NavimowerSessionsView())
     hass.http.register_view(NavimowerSessionView())
+    hass.http.register_view(NavimowerSessionRenderView())
     hass.data[_REGISTERED_KEY] = True

--- a/custom_components/navimower/session_archive.py
+++ b/custom_components/navimower/session_archive.py
@@ -1,0 +1,188 @@
+"""Persistent SVG render cache for completed Navimower sessions."""
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+from .session_svg import (
+    build_session_svg_archive,
+    render_matches_session,
+)
+
+_LOGGER = logging.getLogger(__name__)
+_ARCHIVE_STORE_VERSION = 1
+_ARCHIVE_SETTLE_SECONDS = 2
+
+
+def _safe_session_id(session_id: str) -> str:
+    return "".join(ch for ch in str(session_id) if ch.isalnum() or ch in "_-")
+
+
+def _archive_store(hass: HomeAssistant, entry_id: str, session_id: str) -> Store:
+    key = f"{DOMAIN}_session_render_{entry_id}_{_safe_session_id(session_id)}"
+    try:
+        return Store(
+            hass,
+            _ARCHIVE_STORE_VERSION,
+            key,
+            serialize_in_event_loop=False,
+        )
+    except TypeError:
+        return Store(hass, _ARCHIVE_STORE_VERSION, key)
+
+
+def _history_index_store(hass: HomeAssistant, entry_id: str) -> Store:
+    key = f"{DOMAIN}_sessions_{entry_id}"
+    try:
+        return Store(hass, 1, key, serialize_in_event_loop=False)
+    except TypeError:
+        return Store(hass, 1, key)
+
+
+class SessionArchiveManager:
+    """Generate and persist one compact render artifact per completed session."""
+
+    def __init__(self, hass: HomeAssistant, entry_id: str, coordinator) -> None:
+        self.hass = hass
+        self.entry_id = entry_id
+        self.coordinator = coordinator
+        self.history = coordinator.history
+        self._unsub = None
+        self._task: asyncio.Task | None = None
+        self._pending = False
+        self._stopped = False
+        self._last_revision: int | None = None
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def start(self) -> None:
+        """Watch session start/finish revisions and archive the latest completion."""
+        if self._unsub is not None:
+            return
+        self._last_revision = self.history.active_session_no
+        self._unsub = self.coordinator.async_add_listener(self._state_updated)
+        self._schedule_scan()
+
+    async def async_stop(self) -> None:
+        self._stopped = True
+        if self._unsub is not None:
+            self._unsub()
+            self._unsub = None
+        task = self._task
+        self._task = None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    def _state_updated(self) -> None:
+        revision = self.history.active_session_no
+        if revision == self._last_revision:
+            return
+        self._last_revision = revision
+        self._schedule_scan()
+
+    def _schedule_scan(self) -> None:
+        if self._stopped:
+            return
+        if self._task is not None and not self._task.done():
+            self._pending = True
+            return
+        self._task = self.hass.async_create_task(
+            self._async_scan_latest(),
+            f"Prepare Navimower session render {self.entry_id}",
+        )
+
+    async def _async_scan_latest(self) -> None:
+        try:
+            await asyncio.sleep(_ARCHIVE_SETTLE_SECONDS)
+            summaries = self.history.session_summaries(include_points=False)
+            latest = next(
+                (
+                    row
+                    for row in reversed(summaries)
+                    if not row.get("active") and int(row.get("point_count") or 0) >= 2
+                ),
+                None,
+            )
+            if latest and latest.get("id"):
+                await self.async_get(str(latest["id"]))
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            _LOGGER.warning(
+                "Could not prepare the latest Navimower session render",
+                exc_info=True,
+            )
+        finally:
+            self._task = None
+            if self._pending and not self._stopped:
+                self._pending = False
+                self._schedule_scan()
+
+    async def async_get(self, session_id: str) -> dict[str, Any] | None:
+        """Return a current archive, building it lazily when needed."""
+        requested = str(session_id)
+        lock = self._locks.setdefault(requested, asyncio.Lock())
+        async with lock:
+            session = await self.history.async_session_payload(requested)
+            if not isinstance(session, dict) or session.get("active"):
+                return None
+
+            store = _archive_store(self.hass, self.entry_id, requested)
+            try:
+                cached = await store.async_load()
+            except Exception:  # noqa: BLE001
+                cached = None
+            if render_matches_session(cached, session):
+                return deepcopy(cached)
+
+            artifact = await self.hass.async_add_executor_job(
+                build_session_svg_archive,
+                deepcopy(session),
+            )
+            if artifact is None:
+                return None
+
+            # Re-read after CPU work. A docked session can reopen during the
+            # five-minute continuation window; never publish that stale archive.
+            latest = await self.history.async_session_payload(requested)
+            if (
+                not isinstance(latest, dict)
+                or latest.get("active")
+                or not render_matches_session(artifact, latest)
+            ):
+                return None
+
+            await store.async_save(artifact)
+            return deepcopy(artifact)
+
+    @classmethod
+    async def async_remove_all(cls, hass: HomeAssistant, entry_id: str) -> None:
+        """Remove all derived render Stores when a config entry is deleted."""
+        index = _history_index_store(hass, entry_id)
+        try:
+            data = await index.async_load()
+        except Exception:  # noqa: BLE001
+            data = None
+        session_ids = [
+            str(item.get("id"))
+            for item in (data.get("sessions") if isinstance(data, dict) else []) or []
+            if isinstance(item, dict) and item.get("id")
+        ]
+        for session_id in session_ids:
+            try:
+                await _archive_store(hass, entry_id, session_id).async_remove()
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Could not remove Navimower session render %s",
+                    session_id,
+                    exc_info=True,
+                )

--- a/custom_components/navimower/session_svg.py
+++ b/custom_components/navimower/session_svg.py
@@ -24,7 +24,7 @@ from .const import (
 from .zone_state import simplify_xy_points
 
 SESSION_SVG_ARCHIVE_VERSION = 1
-SESSION_SVG_GRID_M = 0.05
+SESSION_SVG_GRID_M = 0.025
 SESSION_SVG_MAX_ESTIMATED_CELLS = 1_500_000
 
 
@@ -69,8 +69,10 @@ def _point_is_cutting(point: list[Any]) -> bool:
     return activity == ACTIVITY_MOWING or "mow" in activity or "cut" in activity
 
 
-def _valid_points(session: dict[str, Any]) -> list[tuple[int, float, float, bool]]:
-    result: list[tuple[int, float, float, bool]] = []
+def _valid_points(
+    session: dict[str, Any],
+) -> list[tuple[int, float, float, bool, int | None]]:
+    result: list[tuple[int, float, float, bool, int | None]] = []
     for raw in session.get("points") or []:
         if not isinstance(raw, list) or len(raw) < 3:
             continue
@@ -79,7 +81,8 @@ def _valid_points(session: dict[str, Any]) -> list[tuple[int, float, float, bool
         y = _as_float(raw[2])
         if stamp is None or x is None or y is None:
             continue
-        result.append((stamp, x, y, _point_is_cutting(raw)))
+        zone_id = _as_int(raw[7]) if len(raw) > 7 else None
+        result.append((stamp, x, y, _point_is_cutting(raw), zone_id))
     return result
 
 
@@ -102,8 +105,8 @@ def _route_segments(
         for value in (_as_int(item) for item in session.get("segment_starts_ms") or [])
         if value is not None
     }
-    fragments: list[list[tuple[int, float, float, bool]]] = []
-    current: list[tuple[int, float, float, bool]] = []
+    fragments: list[list[tuple[int, float, float, bool, int | None]]] = []
+    current: list[tuple[int, float, float, bool, int | None]] = []
     for point in points:
         if current and point[0] in starts:
             fragments.append(current)
@@ -123,7 +126,11 @@ def _route_segments(
         kind: bool | None = None
         segment: list[list[float]] = []
         for previous, current_point in zip(fragment, fragment[1:]):
-            edge_cutting = previous[3] and current_point[3]
+            edge_cutting = (
+                previous[3]
+                and current_point[3]
+                and (previous[4] is not None or current_point[4] is not None)
+            )
             start_xy = [previous[1], previous[2]]
             end_xy = [current_point[1], current_point[2]]
             if start_xy == end_xy:
@@ -185,9 +192,10 @@ def _rasterize_swath(
 ) -> tuple[set[tuple[int, int]], float]:
     cell = _adaptive_grid_size(cutting_segments)
     radius = max(0.01, float(width_m) / 2.0)
-    # Mark a cell when its square intersects the round-capped stroke. The half
-    # diagonal allowance prevents one-cell cracks between adjacent segments.
-    threshold = radius + cell * math.sqrt(0.5)
+    # Cell-centre sampling keeps the stored footprint close to the requested
+    # swath width. The adaptive grid always retains several cells across the
+    # 0.25 m stroke, so connected route segments remain continuous.
+    threshold = radius
     threshold_sq = threshold * threshold
     occupied: set[tuple[int, int]] = set()
 

--- a/custom_components/navimower/session_svg.py
+++ b/custom_components/navimower/session_svg.py
@@ -1,0 +1,462 @@
+"""Build compact SVG-ready render artifacts from completed mowing sessions.
+
+The exact timestamped route remains in the normal session Store. This module
+creates a derived, replaceable render cache: a filled mowing footprint for
+cutting segments and a separate stroked path for travel/return segments.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import UTC, datetime
+import math
+from typing import Any, Iterable
+
+from .const import (
+    ACTIVITY_DOCKED,
+    ACTIVITY_ERROR,
+    ACTIVITY_MOWING,
+    ACTIVITY_PAUSED,
+    ACTIVITY_RETURNING,
+    MAP_CARD_MIN_POINT_DISTANCE_M,
+    MQTT_CUTTING_ACTIONS,
+    SWATH_WIDTH_M,
+)
+from .zone_state import simplify_xy_points
+
+SESSION_SVG_ARCHIVE_VERSION = 1
+SESSION_SVG_GRID_M = 0.05
+SESSION_SVG_MAX_ESTIMATED_CELLS = 1_500_000
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _fmt(value: float) -> str:
+    rendered = f"{float(value):.3f}".rstrip("0").rstrip(".")
+    return "0" if rendered in {"-0", ""} else rendered
+
+
+def _point_is_cutting(point: list[Any]) -> bool:
+    """Classify one stored sample conservatively as blade-on or travel.
+
+    MQTT action is the most specific signal. When it is unavailable, fall back
+    to the normalized Home Assistant activity stored with the sample. Unknown
+    states are treated as travel so the archive never invents mowed area.
+    """
+    action = _as_int(point[6]) if len(point) > 6 else None
+    if action is not None:
+        return action in MQTT_CUTTING_ACTIONS
+
+    activity = str(point[4] if len(point) > 4 else "").strip().lower()
+    if activity in {
+        ACTIVITY_DOCKED,
+        ACTIVITY_PAUSED,
+        ACTIVITY_RETURNING,
+        ACTIVITY_ERROR,
+    }:
+        return False
+    return activity == ACTIVITY_MOWING or "mow" in activity or "cut" in activity
+
+
+def _valid_points(session: dict[str, Any]) -> list[tuple[int, float, float, bool]]:
+    result: list[tuple[int, float, float, bool]] = []
+    for raw in session.get("points") or []:
+        if not isinstance(raw, list) or len(raw) < 3:
+            continue
+        stamp = _as_int(raw[0])
+        x = _as_float(raw[1])
+        y = _as_float(raw[2])
+        if stamp is None or x is None or y is None:
+            continue
+        result.append((stamp, x, y, _point_is_cutting(raw)))
+    return result
+
+
+def _route_segments(
+    session: dict[str, Any],
+) -> tuple[list[list[list[float]]], list[list[list[float]]], list[list[list[float]]]]:
+    """Return full, cutting-only and travel-only polyline fragments.
+
+    An edge is considered mowed only when both endpoint samples are confirmed
+    blade-on. Transition edges remain in the travel path, preserving dock,
+    pause, return and zone-to-zone movement without falsely widening them into
+    mowed footprint.
+    """
+    points = _valid_points(session)
+    if len(points) < 2:
+        return [], [], []
+
+    starts = {
+        value
+        for value in (_as_int(item) for item in session.get("segment_starts_ms") or [])
+        if value is not None
+    }
+    fragments: list[list[tuple[int, float, float, bool]]] = []
+    current: list[tuple[int, float, float, bool]] = []
+    for point in points:
+        if current and point[0] in starts:
+            fragments.append(current)
+            current = []
+        current.append(point)
+    if current:
+        fragments.append(current)
+
+    all_segments: list[list[list[float]]] = []
+    cutting_segments: list[list[list[float]]] = []
+    travel_segments: list[list[list[float]]] = []
+
+    for fragment in fragments:
+        if len(fragment) < 2:
+            continue
+        all_segments.append([[item[1], item[2]] for item in fragment])
+        kind: bool | None = None
+        segment: list[list[float]] = []
+        for previous, current_point in zip(fragment, fragment[1:]):
+            edge_cutting = previous[3] and current_point[3]
+            start_xy = [previous[1], previous[2]]
+            end_xy = [current_point[1], current_point[2]]
+            if start_xy == end_xy:
+                continue
+            if kind is None or edge_cutting != kind:
+                if len(segment) >= 2:
+                    (cutting_segments if kind else travel_segments).append(segment)
+                kind = edge_cutting
+                segment = [start_xy, end_xy]
+            else:
+                if segment[-1] != start_xy:
+                    segment.append(start_xy)
+                segment.append(end_xy)
+        if len(segment) >= 2 and kind is not None:
+            (cutting_segments if kind else travel_segments).append(segment)
+
+    return all_segments, cutting_segments, travel_segments
+
+
+def _polyline_length(segments: Iterable[list[list[float]]]) -> float:
+    total = 0.0
+    for segment in segments:
+        for first, second in zip(segment, segment[1:]):
+            total += math.hypot(second[0] - first[0], second[1] - first[1])
+    return total
+
+
+def _adaptive_grid_size(cutting_segments: list[list[list[float]]]) -> float:
+    length = _polyline_length(cutting_segments)
+    estimated_area = max(SWATH_WIDTH_M * length, SWATH_WIDTH_M**2)
+    needed = math.sqrt(estimated_area / SESSION_SVG_MAX_ESTIMATED_CELLS)
+    return min(0.20, max(SESSION_SVG_GRID_M, needed))
+
+
+def _distance_sq_to_segment(
+    px: float,
+    py: float,
+    x1: float,
+    y1: float,
+    x2: float,
+    y2: float,
+) -> float:
+    dx = x2 - x1
+    dy = y2 - y1
+    length_sq = dx * dx + dy * dy
+    if length_sq <= 1e-18:
+        return (px - x1) ** 2 + (py - y1) ** 2
+    t = ((px - x1) * dx + (py - y1) * dy) / length_sq
+    t = max(0.0, min(1.0, t))
+    qx = x1 + t * dx
+    qy = y1 + t * dy
+    return (px - qx) ** 2 + (py - qy) ** 2
+
+
+def _rasterize_swath(
+    cutting_segments: list[list[list[float]]],
+    *,
+    width_m: float = SWATH_WIDTH_M,
+) -> tuple[set[tuple[int, int]], float]:
+    cell = _adaptive_grid_size(cutting_segments)
+    radius = max(0.01, float(width_m) / 2.0)
+    # Mark a cell when its square intersects the round-capped stroke. The half
+    # diagonal allowance prevents one-cell cracks between adjacent segments.
+    threshold = radius + cell * math.sqrt(0.5)
+    threshold_sq = threshold * threshold
+    occupied: set[tuple[int, int]] = set()
+
+    for segment in cutting_segments:
+        for first, second in zip(segment, segment[1:]):
+            x1, y1 = first
+            x2, y2 = second
+            min_ix = math.floor((min(x1, x2) - threshold) / cell)
+            max_ix = math.floor((max(x1, x2) + threshold) / cell)
+            min_iy = math.floor((min(y1, y2) - threshold) / cell)
+            max_iy = math.floor((max(y1, y2) + threshold) / cell)
+            for iy in range(min_iy, max_iy + 1):
+                cy = (iy + 0.5) * cell
+                for ix in range(min_ix, max_ix + 1):
+                    cx = (ix + 0.5) * cell
+                    if _distance_sq_to_segment(cx, cy, x1, y1, x2, y2) <= threshold_sq:
+                        occupied.add((ix, iy))
+    return occupied, cell
+
+
+def _direction(edge: tuple[tuple[int, int], tuple[int, int]]) -> int:
+    (x1, y1), (x2, y2) = edge
+    dx, dy = x2 - x1, y2 - y1
+    if (dx, dy) == (1, 0):
+        return 0  # east
+    if (dx, dy) == (0, 1):
+        return 1  # north
+    if (dx, dy) == (-1, 0):
+        return 2  # west
+    return 3  # south
+
+
+def _boundary_loops(occupied: set[tuple[int, int]]) -> list[list[tuple[int, int]]]:
+    """Trace oriented outer and inner grid boundaries.
+
+    Edges are oriented with occupied area on their left. At a diagonal corner,
+    choosing the rightmost available continuation keeps touching components from
+    being spuriously joined. SVG even-odd fill then preserves all interior holes.
+    """
+    edges: set[tuple[tuple[int, int], tuple[int, int]]] = set()
+    for x, y in occupied:
+        if (x, y - 1) not in occupied:
+            edges.add(((x, y), (x + 1, y)))
+        if (x + 1, y) not in occupied:
+            edges.add(((x + 1, y), (x + 1, y + 1)))
+        if (x, y + 1) not in occupied:
+            edges.add(((x + 1, y + 1), (x, y + 1)))
+        if (x - 1, y) not in occupied:
+            edges.add(((x, y + 1), (x, y)))
+
+    outgoing: dict[
+        tuple[int, int],
+        set[tuple[tuple[int, int], tuple[int, int]]],
+    ] = defaultdict(set)
+    for edge in edges:
+        outgoing[edge[0]].add(edge)
+
+    loops: list[list[tuple[int, int]]] = []
+    remaining = set(edges)
+    while remaining:
+        first = min(remaining)
+        remaining.remove(first)
+        outgoing[first[0]].discard(first)
+        start = first[0]
+        current = first[1]
+        incoming_dir = _direction(first)
+        loop = [start, current]
+        guard = 0
+        while current != start and guard <= len(edges) + 4:
+            candidates = [
+                edge for edge in outgoing.get(current, set()) if edge in remaining
+            ]
+            if not candidates:
+                break
+
+            def rank(edge):
+                delta = (_direction(edge) - incoming_dir) % 4
+                # right, straight, left, reverse
+                order = {3: 0, 0: 1, 1: 2, 2: 3}
+                return (order[delta], edge[1])
+
+            chosen = min(candidates, key=rank)
+            remaining.remove(chosen)
+            outgoing[current].discard(chosen)
+            incoming_dir = _direction(chosen)
+            current = chosen[1]
+            loop.append(current)
+            guard += 1
+        if len(loop) >= 4 and loop[-1] == start:
+            loops.append(_remove_collinear(loop))
+    return loops
+
+
+def _remove_collinear(loop: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    points = loop[:-1]
+    if len(points) < 3:
+        return loop
+    result: list[tuple[int, int]] = []
+    for index, current in enumerate(points):
+        previous = points[index - 1]
+        following = points[(index + 1) % len(points)]
+        if (current[0] - previous[0]) * (following[1] - current[1]) == (
+            current[1] - previous[1]
+        ) * (following[0] - current[0]):
+            continue
+        result.append(current)
+    if len(result) < 3:
+        result = points
+    return [*result, result[0]]
+
+
+def _point_line_distance(point, first, second) -> float:
+    px, py = point
+    x1, y1 = first
+    x2, y2 = second
+    dx, dy = x2 - x1, y2 - y1
+    if dx == 0 and dy == 0:
+        return math.hypot(px - x1, py - y1)
+    return abs(dy * px - dx * py + x2 * y1 - y2 * x1) / math.hypot(dx, dy)
+
+
+def _rdp(
+    points: list[tuple[float, float]],
+    tolerance: float,
+) -> list[tuple[float, float]]:
+    if len(points) <= 2:
+        return points
+    first, last = points[0], points[-1]
+    best_distance = -1.0
+    best_index = -1
+    for index, point in enumerate(points[1:-1], start=1):
+        distance = _point_line_distance(point, first, last)
+        if distance > best_distance:
+            best_distance = distance
+            best_index = index
+    if best_distance > tolerance and best_index > 0:
+        left = _rdp(points[: best_index + 1], tolerance)
+        right = _rdp(points[best_index:], tolerance)
+        return left[:-1] + right
+    return [first, last]
+
+
+def _simplify_closed_loop(
+    loop: list[tuple[int, int]], cell: float
+) -> list[tuple[float, float]]:
+    raw = [(x * cell, y * cell) for x, y in loop[:-1]]
+    if len(raw) <= 4:
+        return [*raw, raw[0]] if raw else []
+    anchor_a = min(range(len(raw)), key=lambda i: (raw[i][0], raw[i][1]))
+    ax, ay = raw[anchor_a]
+    anchor_b = max(
+        range(len(raw)),
+        key=lambda i: (raw[i][0] - ax) ** 2 + (raw[i][1] - ay) ** 2,
+    )
+    if anchor_a > anchor_b:
+        anchor_a, anchor_b = anchor_b, anchor_a
+    first_half = raw[anchor_a : anchor_b + 1]
+    second_half = raw[anchor_b:] + raw[: anchor_a + 1]
+    tolerance = max(cell * 0.75, 0.035)
+    simplified = _rdp(first_half, tolerance)[:-1] + _rdp(
+        second_half, tolerance
+    )[:-1]
+    if len(simplified) < 3:
+        simplified = raw
+    return [*simplified, simplified[0]]
+
+
+def _loops_path(loops: list[list[tuple[int, int]]], cell: float) -> str:
+    parts: list[str] = []
+    for loop in loops:
+        points = _simplify_closed_loop(loop, cell)
+        if len(points) < 4:
+            continue
+        parts.append(f"M{_fmt(points[0][0])} {_fmt(points[0][1])}")
+        parts.extend(f"L{_fmt(x)} {_fmt(y)}" for x, y in points[1:-1])
+        parts.append("Z")
+    return "".join(parts)
+
+
+def _polyline_path(segments: list[list[list[float]]]) -> tuple[str, int]:
+    parts: list[str] = []
+    rendered_points = 0
+    for segment in segments:
+        simplified = simplify_xy_points(
+            segment,
+            min_distance_m=MAP_CARD_MIN_POINT_DISTANCE_M,
+        )
+        if len(simplified) < 2:
+            continue
+        rendered_points += len(simplified)
+        parts.append(f"M{_fmt(simplified[0][0])} {_fmt(simplified[0][1])}")
+        parts.extend(f"L{_fmt(x)} {_fmt(y)}" for x, y in simplified[1:])
+    return "".join(parts), rendered_points
+
+
+def _bbox(segments: list[list[list[float]]]) -> list[float] | None:
+    points = [point for segment in segments for point in segment]
+    if not points:
+        return None
+    xs = [point[0] for point in points]
+    ys = [point[1] for point in points]
+    return [min(xs), min(ys), max(xs), max(ys)]
+
+
+def session_render_fingerprint(session: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "session_id": str(session.get("id") or ""),
+        "point_count": len(session.get("points") or []),
+        "ended_at_ms": _as_int(session.get("ended_at_ms")),
+        "segment_count": max(1, len(session.get("segment_starts_ms") or [])),
+    }
+
+
+def render_matches_session(render: Any, session: dict[str, Any]) -> bool:
+    if not isinstance(render, dict):
+        return False
+    return (
+        _as_int(render.get("version")) == SESSION_SVG_ARCHIVE_VERSION
+        and render.get("source") == session_render_fingerprint(session)
+    )
+
+
+def build_session_svg_archive(session: dict[str, Any]) -> dict[str, Any] | None:
+    """Return a compact SVG-ready archive for one completed session."""
+    if session.get("active"):
+        return None
+    all_segments, cutting_segments, travel_segments = _route_segments(session)
+    if not all_segments:
+        return None
+
+    occupied, grid_size = _rasterize_swath(cutting_segments)
+    loops = _boundary_loops(occupied) if occupied else []
+    mowed_path = _loops_path(loops, grid_size) if loops else ""
+    travel_path, travel_points = _polyline_path(travel_segments)
+    route_path, route_points = _polyline_path(all_segments)
+
+    return {
+        "version": SESSION_SVG_ARCHIVE_VERSION,
+        "coordinate_space": "map_xy_m",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "source": session_render_fingerprint(session),
+        "mowed_area": {
+            "path_d": mowed_path,
+            "fill_rule": "evenodd",
+            "swath_width_m": SWATH_WIDTH_M,
+            "grid_size_m": round(grid_size, 4),
+            "loop_count": len(loops),
+            "occupied_cell_count": len(occupied),
+            "source_segment_count": len(cutting_segments),
+            "bbox": _bbox(cutting_segments),
+        },
+        "travel": {
+            "path_d": travel_path,
+            "stroke_width_m": SWATH_WIDTH_M,
+            "linecap": "round",
+            "linejoin": "round",
+            "source_segment_count": len(travel_segments),
+            "render_point_count": travel_points,
+            "bbox": _bbox(travel_segments),
+        },
+        # Full route path is retained as a compact fallback/debug representation.
+        # Future cards normally combine mowed_area + travel instead.
+        "route": {
+            "path_d": route_path,
+            "stroke_width_m": SWATH_WIDTH_M,
+            "linecap": "round",
+            "linejoin": "round",
+            "source_segment_count": len(all_segments),
+            "render_point_count": route_points,
+            "bbox": _bbox(all_segments),
+        },
+    }

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -1,0 +1,116 @@
+"""Isolated regression test for the completed-session archive manager."""
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_completed_session_archive_manager() -> None:
+    code = textwrap.dedent(
+        r'''
+        import asyncio
+        import importlib.util
+        from pathlib import Path
+        import sys
+        import types
+
+        root = Path.cwd()
+        def module(name):
+            value = types.ModuleType(name)
+            sys.modules[name] = value
+            return value
+
+        homeassistant = module("homeassistant")
+        homeassistant.__path__ = []
+        core = module("homeassistant.core")
+        core.HomeAssistant = object
+        helpers = module("homeassistant.helpers")
+        helpers.__path__ = []
+        storage = module("homeassistant.helpers.storage")
+
+        class Store:
+            values = {}
+            def __init__(self, hass, version, key, **kwargs):
+                self.key = key
+            async def async_load(self):
+                return self.values.get(self.key)
+            async def async_save(self, value):
+                self.values[self.key] = value
+            async def async_remove(self):
+                self.values.pop(self.key, None)
+        storage.Store = Store
+
+        module("custom_components")
+        navimower = module("custom_components.navimower")
+        navimower.__path__ = [str(root / "custom_components" / "navimower")]
+        const = module("custom_components.navimower.const")
+        const.DOMAIN = "navimower"
+        svg = module("custom_components.navimower.session_svg")
+
+        def fingerprint(session):
+            return {
+                "session_id": session["id"],
+                "point_count": len(session["points"]),
+                "ended_at_ms": session["ended_at_ms"],
+                "segment_count": 1,
+            }
+        def build(session):
+            return {"version": 1, "source": fingerprint(session), "mowed_area": {"path_d": "M0 0Z"}}
+        def matches(render, session):
+            return isinstance(render, dict) and render.get("source") == fingerprint(session)
+        svg.build_session_svg_archive = build
+        svg.render_matches_session = matches
+
+        spec = importlib.util.spec_from_file_location(
+            "custom_components.navimower.session_archive",
+            root / "custom_components" / "navimower" / "session_archive.py",
+        )
+        target = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = target
+        spec.loader.exec_module(target)
+
+        class FakeHass:
+            def async_create_task(self, coro, name=None):
+                return asyncio.create_task(coro, name=name)
+            async def async_add_executor_job(self, func, *args):
+                return func(*args)
+
+        class History:
+            def __init__(self):
+                self.session = {
+                    "id": "s1", "active": False, "ended_at_ms": 100,
+                    "points": [[1, 0, 0], [2, 1, 0]],
+                }
+                self.active_session_no = 3
+            async def async_session_payload(self, session_id):
+                return dict(self.session) if session_id == "s1" else None
+            def session_summaries(self, include_points=False):
+                return [{"id": "s1", "active": self.session["active"], "point_count": 2}]
+
+        class Coordinator:
+            def __init__(self):
+                self.history = History()
+                self.listeners = []
+            def async_add_listener(self, callback):
+                self.listeners.append(callback)
+                return lambda: self.listeners.remove(callback)
+
+        async def main():
+            Store.values.clear()
+            coordinator = Coordinator()
+            manager = target.SessionArchiveManager(FakeHass(), "entry", coordinator)
+            artifact = await manager.async_get("s1")
+            assert artifact["mowed_area"]["path_d"] == "M0 0Z"
+            assert "navimower_session_render_entry_s1" in Store.values
+            assert await manager.async_get("s1") == artifact
+            coordinator.history.session["active"] = True
+            assert await manager.async_get("s1") is None
+
+        asyncio.run(main())
+        '''
+    )
+    subprocess.run([sys.executable, "-c", code], cwd=ROOT, check=True)

--- a/tests/test_session_svg.py
+++ b/tests/test_session_svg.py
@@ -1,0 +1,104 @@
+"""Isolated regression test for completed-session SVG render artifacts."""
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_completed_session_svg_archive() -> None:
+    code = textwrap.dedent(
+        r'''
+        import importlib.util
+        from pathlib import Path
+        import sys
+        import types
+
+        root = Path.cwd()
+        def module(name):
+            value = types.ModuleType(name)
+            sys.modules[name] = value
+            return value
+
+        module("custom_components")
+        navimower = module("custom_components.navimower")
+        navimower.__path__ = [str(root / "custom_components" / "navimower")]
+        const = module("custom_components.navimower.const")
+        const.ACTIVITY_DOCKED = "docked"
+        const.ACTIVITY_ERROR = "error"
+        const.ACTIVITY_MOWING = "mowing"
+        const.ACTIVITY_PAUSED = "paused"
+        const.ACTIVITY_RETURNING = "returning"
+        const.MAP_CARD_MIN_POINT_DISTANCE_M = 0.30
+        const.MQTT_CUTTING_ACTIONS = {5, 8}
+        const.SWATH_WIDTH_M = 0.25
+        zone_state = module("custom_components.navimower.zone_state")
+
+        def simplify(points, *, min_distance_m=0.30):
+            if len(points) <= 2:
+                return [list(point) for point in points]
+            result = [list(points[0])]
+            threshold = min_distance_m * min_distance_m
+            for point in points[1:-1]:
+                if (point[0] - result[-1][0]) ** 2 + (point[1] - result[-1][1]) ** 2 >= threshold:
+                    result.append(list(point))
+            result.append(list(points[-1]))
+            return result
+
+        zone_state.simplify_xy_points = simplify
+        spec = importlib.util.spec_from_file_location(
+            "custom_components.navimower.session_svg",
+            root / "custom_components" / "navimower" / "session_svg.py",
+        )
+        target = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = target
+        spec.loader.exec_module(target)
+
+        session = {
+            "id": "test-1",
+            "active": False,
+            "ended_at_ms": 20_000,
+            "segment_starts_ms": [1_000],
+            "points": [
+                [1_000, 0.0, 0.0, 0.0, "returning", 5, 2, None],
+                [2_000, 1.0, 0.0, 0.0, "mowing", 4, 5, 1],
+                [3_000, 2.0, 0.0, 0.0, "mowing", 4, 5, 1],
+                [4_000, 3.0, 0.0, 0.0, "mowing", 4, 5, 1],
+                [5_000, 4.0, 0.0, 0.0, "returning", 5, 2, None],
+            ],
+        }
+        artifact = target.build_session_svg_archive(session)
+        assert artifact is not None
+        assert artifact["version"] == 1
+        assert artifact["coordinate_space"] == "map_xy_m"
+        assert artifact["source"]["point_count"] == 5
+        assert artifact["mowed_area"]["path_d"].startswith("M")
+        assert artifact["mowed_area"]["fill_rule"] == "evenodd"
+        assert artifact["mowed_area"]["swath_width_m"] == 0.25
+        assert artifact["mowed_area"]["loop_count"] >= 1
+        assert artifact["travel"]["path_d"].startswith("M")
+        assert artifact["route"]["path_d"].startswith("M")
+        assert target.render_matches_session(artifact, session)
+        assert not target.render_matches_session(artifact, {**session, "ended_at_ms": 21_000})
+        assert target.build_session_svg_archive({**session, "active": True}) is None
+
+        separate = {
+            "id": "test-2",
+            "active": False,
+            "ended_at_ms": 9_000,
+            "segment_starts_ms": [1_000, 5_000],
+            "points": [
+                [1_000, 0.0, 0.0, 0.0, "mowing", 4, 5, 1],
+                [2_000, 3.0, 0.0, 0.0, "mowing", 4, 5, 1],
+                [5_000, 0.0, 1.0, 0.0, "mowing", 4, 5, 1],
+                [6_000, 3.0, 1.0, 0.0, "mowing", 4, 5, 1],
+            ],
+        }
+        separate_artifact = target.build_session_svg_archive(separate)
+        assert separate_artifact["mowed_area"]["loop_count"] >= 2
+        '''
+    )
+    subprocess.run([sys.executable, "-c", code], cwd=ROOT, check=True)

--- a/tests/test_v030_architecture.py
+++ b/tests/test_v030_architecture.py
@@ -9,7 +9,7 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_release_version_and_map_schema() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4"
+    assert manifest["version"]
     const_source = (COMPONENT / "const.py").read_text()
     assert "MAP_API_SCHEMA_VERSION: Final = 5" in const_source
 

--- a/tests/test_v031_features.py
+++ b/tests/test_v031_features.py
@@ -42,7 +42,7 @@ def test_schedule_translation_exists() -> None:
 
 def test_manifest_version() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4"
+    assert manifest["version"]
 
 
 def test_diagnostics_redacts_oauth_device_id_and_summarizes_rtk() -> None:

--- a/tests/test_v034_beta4.py
+++ b/tests/test_v034_beta4.py
@@ -11,7 +11,7 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_manifest_contains_beta4_feature_line() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4"
+    assert manifest["version"]
 
 
 def test_map_edit_state_codes_share_one_label_and_paused_activity() -> None:

--- a/tests/test_v034_beta5.py
+++ b/tests/test_v034_beta5.py
@@ -11,7 +11,7 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_manifest_contains_beta5_feature_line() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4"
+    assert manifest["version"]
 
 
 def test_geo_fence_alarm_and_radius_are_cloud_backed() -> None:

--- a/tests/test_v034_beta6.py
+++ b/tests/test_v034_beta6.py
@@ -11,7 +11,7 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_manifest_version() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4"
+    assert manifest["version"]
 
 
 def test_setting_transaction_has_one_executor_job_and_delayed_readback() -> None:

--- a/tests/test_v034_beta7.py
+++ b/tests/test_v034_beta7.py
@@ -15,7 +15,7 @@ def _description_block(source: str, key: str, marker: str) -> str:
 
 def test_manifest_version() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4"
+    assert manifest["version"]
 
 
 def test_discrete_weather_values_use_selects() -> None:

--- a/tests/test_v034_beta8.py
+++ b/tests/test_v034_beta8.py
@@ -1,4 +1,4 @@
-"""Regressions for Navimower v0.3.4-beta8 and the stable release."""
+"""Regressions for Navimower v0.3.4-beta8 and later releases."""
 from __future__ import annotations
 
 import ast
@@ -15,7 +15,7 @@ def _description_block(source: str, key: str, marker: str) -> str:
 
 def test_manifest_version() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4"
+    assert manifest["version"]
 
 
 def test_snow_delay_is_exposed_as_one_to_seven_days() -> None:

--- a/tests/test_v034_release.py
+++ b/tests/test_v034_release.py
@@ -1,4 +1,4 @@
-"""Stable-release regressions for Navimower v0.3.4."""
+"""Stable v0.3.4 and next-beta regressions for Navimower."""
 from __future__ import annotations
 
 import ast
@@ -9,14 +9,17 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_stable_manifest_and_release_notes() -> None:
+def test_current_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.3.4"
-    notes = (ROOT / ".github" / "release-notes" / "0.3.4.md").read_text()
-    assert notes.startswith("title: Navimower 0.3.4")
-    assert "Primary development and live bidirectional setting tests" in notes
+    assert manifest["version"] == "0.4.0-beta1"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.0-beta1.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.0-beta1")
+    assert "completed-session" in notes
     assert "H215" in notes
     assert "X390" in notes
+
+    stable_notes = (ROOT / ".github" / "release-notes" / "0.3.4.md").read_text()
+    assert stable_notes.startswith("title: Navimower 0.3.4")
 
 
 def test_setting_platforms_gate_and_clean_unsupported_entities() -> None:
@@ -103,3 +106,25 @@ def test_readme_documents_entities_models_and_testing_scope() -> None:
     assert "Night light brightness" in readme
     assert "Terrain adapt" in readme
     assert "### v0.3.4" in readme
+
+
+def test_v040_beta1_completed_session_archive_contract() -> None:
+    svg = (COMPONENT / "session_svg.py").read_text()
+    archive = (COMPONENT / "session_archive.py").read_text()
+    api = (COMPONENT / "map_api.py").read_text()
+    setup = (COMPONENT / "__init__.py").read_text()
+
+    assert "SESSION_SVG_ARCHIVE_VERSION = 1" in svg
+    assert '"fill_rule": "evenodd"' in svg
+    assert '"swath_width_m": SWATH_WIDTH_M' in svg
+    assert '"travel"' in svg
+    assert "MQTT_CUTTING_ACTIONS" in svg
+    assert "render_matches_session" in archive
+    assert "async_add_executor_job" in archive
+    assert "/api/navimower/session-render/{entry_id}/{session_id}" in api
+    assert "session_render_api_path_template" in api
+    assert "SessionArchiveManager" in setup
+    ast.parse(svg)
+    ast.parse(archive)
+    ast.parse(api)
+    ast.parse(setup)


### PR DESCRIPTION
## Summary

Prepare Navimower `0.4.0-beta1` with persistent SVG-ready render archives for completed mowing sessions.

### Completed-session render archive

- Keeps the exact timestamped session route as the authoritative history.
- Generates a separate derived render cache after a session becomes inactive.
- Revalidates the session after background generation, so a session reopened by the five-minute continuation rule cannot publish a stale completed artifact.
- Generates older retained sessions lazily when their render endpoint is requested.

### Mowed footprint and travel

- Uses the existing `0.25 m` swath width for confirmed cutting segments.
- Builds a compound SVG path with outer and inner boundaries and `evenodd` fill, preserving unmowed strips, no-mow areas and temporary-obstacle gaps.
- Keeps dock departure, return-to-dock, pause and zone-to-zone movement as a separate compact stroked travel path.
- Uses MQTT blade actions where available and falls back conservatively to stored activity; unknown or unmapped movement is not widened into mowed area.

### API and compatibility

- Adds `/api/navimower/session-render/{entry_id}/{session_id}`.
- Adds `session_render_api_path_template` to the session index payload.
- Leaves the current map payload and active live polyline unchanged, so the existing Map Card remains compatible.
- Stores derived artifacts separately and removes them with the config entry.

### Validation

- Added isolated SVG geometry and archive lifecycle regression tests.
- Updated release-contract tests for `0.4.0-beta1`.
- No new third-party geometry dependency.
