### PR TITLE
Release Navimower 0.4.0-beta2

### DIFF
--- a/.github/release-notes/0.4.0-beta2.md
+++ b/.github/release-notes/0.4.0-beta2.md
@@ -1,0 +1,22 @@
+title: Navimower 0.4.0-beta2 — lightweight Map Card payloads
+
+## Faster dashboard loading
+
+The authenticated Map Card endpoint now honours the optional query flags used by Navimower Map Card `0.3.0-beta1` and later:
+
+- `include_sessions=0`
+- `include_daily_trails=0`
+
+When both flags are disabled, Home Assistant returns the static map, live mower state, current active-session trail, zone details and control metadata without loading or serializing retained completed-session points or legacy daily trail geometry.
+
+This removes the largest remaining avoidable payload from the initial dashboard request, especially for installations with multiple mowers or longer session-retention periods. Completed-session metadata and SVG render archives continue to load independently through the lightweight sessions and session-render endpoints.
+
+## Backward compatibility
+
+Older Map Card versions that omit the query flags continue to receive the complete legacy Map API response. The two options can also be controlled independently: requesting either retained sessions or daily trails still includes only that requested history layer.
+
+No config-entry migration, entity change or map schema bump is required.
+
+## Testing scope
+
+Primary live testing remains H215-based, with X390 used as the secondary multi-mower and map-performance validation model. This beta is intended to be used with Navimower Map Card `0.3.0-beta1` or later; the current recommended card beta is `0.3.0-beta4`.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.0-beta1"
+  "version": "0.4.0-beta2"
 }

--- a/custom_components/navimower/map_api.py
+++ b/custom_components/navimower/map_api.py
@@ -1,13 +1,17 @@
 """Authenticated HTTP API for the standalone Navimower Map Card."""
 from __future__ import annotations
 
+from typing import Any
+
 from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, MAP_API_SCHEMA_VERSION
 
 _REGISTERED_KEY = f"{DOMAIN}_map_api_registered"
+_FALSE_QUERY_VALUES = frozenset({"0", "false", "no", "off"})
 
 
 def _coordinator(request: web.Request, entry_id: str):
@@ -18,8 +22,78 @@ def _coordinator(request: web.Request, entry_id: str):
     return coordinator
 
 
+def _query_enabled(request: web.Request, key: str) -> bool:
+    """Return an optional include flag, preserving the full legacy response."""
+    value = request.query.get(key)
+    if value is None:
+        return True
+    return str(value).strip().lower() not in _FALSE_QUERY_VALUES
+
+
+async def _async_map_payload(
+    coordinator: Any,
+    *,
+    include_sessions: bool,
+    include_daily_trails: bool,
+) -> dict[str, Any]:
+    """Build only the map payload sections requested by the frontend.
+
+    Older cards omit both query parameters and keep the original complete
+    response. Newer cards can skip retained session points and daily trail
+    geometry, avoiding their storage reads, simplification work, JSON encoding,
+    transfer, and browser parsing on every dashboard load.
+    """
+    if include_sessions and include_daily_trails:
+        return await coordinator.async_map_payload()
+
+    sessions = (
+        await coordinator.history.async_card_sessions() if include_sessions else []
+    )
+    daily_trails = None
+    if include_daily_trails:
+        data = coordinator.data or {}
+        map_data = data.get("map") or coordinator._map_snapshot(
+            coordinator._map_geometry or {},
+            cutting_height_supported=data.get("cutting_height_supported"),
+        )
+        today = dt_util.now().date().isoformat()
+        daily_cache_key = (
+            today,
+            coordinator.history.trail_revision,
+            coordinator._map_cache_key,
+        )
+        if (
+            coordinator._daily_trails_cache_key == daily_cache_key
+            and coordinator._daily_trails_cache is not None
+        ):
+            daily_trails = coordinator._daily_trails_cache
+        else:
+            daily_trails = await coordinator.history.async_daily_zone_trails(
+                [
+                    dict(item)
+                    for item in (map_data or {}).get("zones") or []
+                    if isinstance(item, dict)
+                ]
+            )
+            coordinator._daily_trails_cache_key = daily_cache_key
+            coordinator._daily_trails_cache = daily_trails
+
+    payload = coordinator._map_payload_with_sessions(sessions, daily_trails)
+    if not include_sessions:
+        for key in (
+            "sessions",
+            "session_xy_point_format",
+            "session_segment_point_format",
+        ):
+            payload.pop(key, None)
+    if not include_daily_trails:
+        payload.pop("daily_trails", None)
+        payload.pop("daily_trails_revision", None)
+    return payload
+
+
 class NavimowerMapView(HomeAssistantView):
-    """Return map geometry, live trail and retained card sessions."""
+    """Return map geometry, live trail and optional retained card history."""
 
     url = "/api/navimower/map/{entry_id}"
     name = "api:navimower:map"
@@ -27,7 +101,15 @@ class NavimowerMapView(HomeAssistantView):
 
     async def get(self, request: web.Request, entry_id: str) -> web.Response:
         coordinator = _coordinator(request, entry_id)
-        return self.json(await coordinator.async_map_payload())
+        return self.json(
+            await _async_map_payload(
+                coordinator,
+                include_sessions=_query_enabled(request, "include_sessions"),
+                include_daily_trails=_query_enabled(
+                    request, "include_daily_trails"
+                ),
+            )
+        )
 
 
 class NavimowerSessionsView(HomeAssistantView):

--- a/tests/test_v034_release.py
+++ b/tests/test_v034_release.py
@@ -11,12 +11,17 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_current_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.0-beta1"
-    notes = (ROOT / ".github" / "release-notes" / "0.4.0-beta1.md").read_text()
-    assert notes.startswith("title: Navimower 0.4.0-beta1")
-    assert "completed-session" in notes
+    assert manifest["version"] == "0.4.0-beta2"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.0-beta2.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.0-beta2")
+    assert "include_sessions=0" in notes
+    assert "include_daily_trails=0" in notes
     assert "H215" in notes
     assert "X390" in notes
+
+    beta1_notes = (ROOT / ".github" / "release-notes" / "0.4.0-beta1.md").read_text()
+    assert beta1_notes.startswith("title: Navimower 0.4.0-beta1")
+    assert "completed-session" in beta1_notes
 
     stable_notes = (ROOT / ".github" / "release-notes" / "0.3.4.md").read_text()
     assert stable_notes.startswith("title: Navimower 0.3.4")
@@ -128,3 +133,20 @@ def test_v040_beta1_completed_session_archive_contract() -> None:
     ast.parse(archive)
     ast.parse(api)
     ast.parse(setup)
+
+
+def test_v040_beta2_lightweight_map_payload_contract() -> None:
+    api = (COMPONENT / "map_api.py").read_text()
+
+    assert '_FALSE_QUERY_VALUES = frozenset({"0", "false", "no", "off"})' in api
+    assert 'include_sessions=_query_enabled(request, "include_sessions")' in api
+    assert 'request, "include_daily_trails"' in api
+    assert "if include_sessions and include_daily_trails:" in api
+    assert "return await coordinator.async_map_payload()" in api
+    assert "await coordinator.history.async_card_sessions() if include_sessions else []" in api
+    assert "if include_daily_trails:" in api
+    assert 'payload.pop("sessions", None)' not in api
+    assert '"sessions",' in api
+    assert 'payload.pop("daily_trails", None)' in api
+    assert 'payload.pop("daily_trails_revision", None)' in api
+    ast.parse(api)


### PR DESCRIPTION
## Summary

Prepare Navimower `0.4.0-beta2` with lightweight initial Map Card payloads.

- Honour `include_sessions=0` and `include_daily_trails=0` on `/api/navimower/map/{entry_id}`.
- Preserve the complete legacy response when those parameters are omitted.
- Skip retained-session storage reads and daily-trail generation when the corresponding layer is excluded.
- Keep the static map, live mower state, active trail, zone details, controls, lightweight sessions endpoint, and completed-session render endpoint unchanged.
- Support the two include flags independently.
- Add release notes and regression contracts for the new query behavior.

This is primarily intended for Navimower Map Card `0.3.0-beta1` and later, including the current `0.3.0-beta4` card, which already sends both lightweight query flags.