### PR TITLE
Release Navimower 0.4.0

### DIFF
--- a/.github/release-notes/0.4.0.md
+++ b/.github/release-notes/0.4.0.md
@@ -1,0 +1,39 @@
+title: Navimower 0.4.0 — completed-session archives, lighter maps and H1 zone selection
+
+## Completed-session render archives
+
+Navimower now prepares a compact, persistent SVG-ready render artifact for every completed mowing session while keeping the exact timestamped route as the authoritative history.
+
+- Confirmed blade-on route segments are expanded with the existing `0.25 m` swath width into an even-odd SVG footprint that preserves untouched strips, no-mow areas and temporary-obstacle gaps.
+- Dock departure, return-to-dock, pauses and zone-to-zone travel remain a separate compact path and are never widened into mowed area.
+- The latest completed session is prepared after a short settle delay; older retained sessions are generated lazily when requested.
+- A session reopened by the existing five-minute continuation rule is revalidated so a stale completed artifact is never published.
+- The authenticated endpoint `/api/navimower/session-render/{entry_id}/{session_id}` serves the derived render artifact independently from the exact session route.
+
+These changes were introduced and tested through `0.4.0-beta1`.
+
+## Lightweight Map Card payloads
+
+The authenticated Map Card endpoint supports the optional query flags introduced in `0.4.0-beta2`:
+
+- `include_sessions=0`
+- `include_daily_trails=0`
+
+When both are disabled, Home Assistant returns the static map, live mower state, active-session trail, zone details and controls without loading or serializing retained completed-session routes or legacy daily-trail geometry. Older card versions that omit the flags continue to receive the complete legacy response, and each history layer can still be requested independently.
+
+This reduces initial dashboard payloads, especially with multiple mowers or longer history retention, while completed-session metadata and SVG archives continue loading through their dedicated endpoints.
+
+## First-generation H-series mowing
+
+First-generation H-series mowers can still select one zone, several zones or all zones through `navimower.mow` and the native lawn-mower start flow.
+
+At present these H1 models do not receive the custom zone-order command. The selected zones are sent to the mower, but the mower chooses their mowing order automatically. Newer models that support custom sequencing continue to follow the selected zone order.
+
+The H1 compatibility check is intentionally explicit for the H500/H800/H1500/H3000 family and the observed H1 vehicle type, so newer H-prefixed models such as H215 are not misclassified.
+
+## Compatibility and validation
+
+- No config-entry, entity or map-schema migration is required.
+- Existing entities are retained; this release does not broadly remove settings based on a single startup snapshot.
+- Existing H215 and X390 operation remains compatible.
+- The guarded release workflow compiles the integration and runs the full pytest suite before creating the stable `v0.4.0` tag and GitHub release.

--- a/.github/release-notes/0.4.0.md
+++ b/.github/release-notes/0.4.0.md
@@ -27,7 +27,7 @@ This reduces initial dashboard payloads, especially with multiple mowers or long
 
 First-generation H-series mowers can still select one zone, several zones or all zones through `navimower.mow` and the native lawn-mower start flow.
 
-At present these H1 models do not receive the custom zone-order command. The selected zones are sent to the mower, but the mower chooses their mowing order automatically. Newer models that support custom sequencing continue to follow the selected zone order.
+At present these H1 models do not receive the custom zone order command. The selected zones are sent to the mower, but the mower chooses their mowing order automatically. Newer models that support custom sequencing continue to follow the selected zone order.
 
 The H1 compatibility check is intentionally explicit for the H500/H800/H1500/H3000 family and the observed H1 vehicle type, so newer H-prefixed models such as H215 are not misclassified.
 

--- a/custom_components/navimower/lawn_mower.py
+++ b/custom_components/navimower/lawn_mower.py
@@ -27,6 +27,7 @@ from .const import (
 )
 from .coordinator import NavimowCoordinator
 from .entity import NavimowEntity
+from .model_support import supports_ordered_zone_mowing
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -104,7 +105,11 @@ class NavimowLawnMower(NavimowEntity, LawnMowerEntity):
         ]
         region_ids = sel or available_ids
         partition_ids = encode_partition_ids(region_ids)
-        ordered = bool(sel)
+        requested_ordered = bool(sel)
+        ordered = requested_ordered and supports_ordered_zone_mowing(
+            self.data.get("model") or self.coordinator.entry.data.get("model"),
+            self.coordinator.vehicle_type,
+        )
         partition_setup = mow_setup(reset=True, ordered=ordered)
         self.coordinator.begin_mow_command_trace(
             source="lawn_mower.start_mowing",
@@ -117,7 +122,7 @@ class NavimowLawnMower(NavimowEntity, LawnMowerEntity):
         )
         self.coordinator.set_pending_activity(ACTIVITY_MOWING)
         self.coordinator.set_command_target(
-            sel if ordered else [], source="lawn_mower.start_mowing"
+            sel if requested_ordered else [], source="lawn_mower.start_mowing"
         )
         try:
             result = await self.coordinator.async_send(
@@ -133,7 +138,7 @@ class NavimowLawnMower(NavimowEntity, LawnMowerEntity):
         except Exception as err:
             self.coordinator.record_mow_command_error(err)
             self.coordinator.clear_pending_activity()
-            if ordered:
+            if requested_ordered:
                 self.coordinator.clear_command_target()
             raise
 

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.0-beta2"
+  "version": "0.4.0"
 }

--- a/custom_components/navimower/model_support.py
+++ b/custom_components/navimower/model_support.py
@@ -1,0 +1,45 @@
+"""Small model-family compatibility helpers."""
+from __future__ import annotations
+
+from typing import Final
+
+# First-generation Navimow H-series models do support selecting one or more
+# mowing zones, but do not expose the later app feature that lets the user set a
+# custom zone sequence. Keep this list explicit so newer H-prefixed models such
+# as H215 are never classified as legacy H1 by a broad prefix check.
+H1_GENERATION_MODELS: Final[frozenset[str]] = frozenset(
+    {
+        "H500",
+        "H500E",
+        "H800",
+        "H800E",
+        "H1500",
+        "H1500E",
+        "H3000",
+        "H3000E",
+    }
+)
+
+# Observed on the H1500 diagnostics. Retain this as a fallback for entries whose
+# model name is missing or formatted differently by the account endpoint.
+H1_GENERATION_VEHICLE_TYPES: Final[frozenset[int]] = frozenset({20000002})
+
+
+def is_h1_generation(model: str | None, vehicle_type: int | None = None) -> bool:
+    """Return whether this mower belongs to the first-generation H series."""
+    normalized = str(model or "").strip().upper().replace(" ", "")
+    try:
+        parsed_vehicle_type = int(vehicle_type or 0)
+    except (TypeError, ValueError):
+        parsed_vehicle_type = 0
+    return (
+        normalized in H1_GENERATION_MODELS
+        or parsed_vehicle_type in H1_GENERATION_VEHICLE_TYPES
+    )
+
+
+def supports_ordered_zone_mowing(
+    model: str | None, vehicle_type: int | None = None
+) -> bool:
+    """Return whether the mower accepts a user-defined zone sequence."""
+    return not is_h1_generation(model, vehicle_type)

--- a/custom_components/navimower/services.py
+++ b/custom_components/navimower/services.py
@@ -4,9 +4,10 @@
   time periods, each optionally restricted to zones) via the proven
   save-set-data format.
 - ``navimower.mow`` starts mowing now: chosen zones and a ``reset`` flag
-  (True = riparti da zero / clear progress, False = continua). Listing zones
-  explicitly also fixes the ORDER they are mowed in (like the app's zone-click
-  sequence); omitting them means all zones with the robot choosing its own route.
+  (True = riparti da zero / clear progress, False = continua). On models that
+  support custom sequencing, listing zones explicitly also fixes their mowing
+  order. First-generation H-series mowers still accept the selected zones but
+  choose their order themselves.
 
 These back the graphical cards (and automations).
 """
@@ -27,6 +28,7 @@ from .const import (
     encode_partition_ids,
     mow_setup,
 )
+from .model_support import supports_ordered_zone_mowing
 
 SERVICE_SET_SCHEDULE = "set_schedule"
 SERVICE_MOW = "mow"
@@ -205,9 +207,12 @@ def async_setup_services(hass: HomeAssistant) -> None:
         coordinator = _resolve_coordinator(call)
         requested_zones = [int(z) for z in call.data.get("zones") or []]
         zones = list(requested_zones)
-        # An explicit click sequence means "mow these zones in this order".
-        # Omitting zones means all known zones with the robot choosing the route.
-        ordered = bool(zones)
+        requested_ordered = bool(zones)
+        ordered = requested_ordered and supports_ordered_zone_mowing(
+            (coordinator.data or {}).get("model")
+            or coordinator.entry.data.get("model"),
+            coordinator.vehicle_type,
+        )
         if not zones:
             zones = [
                 z["id"]
@@ -232,7 +237,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         )
         coordinator.set_pending_activity(ACTIVITY_MOWING)
         coordinator.set_command_target(
-            requested_zones if ordered else [], source="navimower.mow"
+            requested_zones if requested_ordered else [], source="navimower.mow"
         )
         try:
             result = await coordinator.async_send(
@@ -249,7 +254,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         except Exception as err:  # noqa: BLE001 - surface a clean error to the UI
             coordinator.record_mow_command_error(err)
             coordinator.clear_pending_activity()
-            if ordered:
+            if requested_ordered:
                 coordinator.clear_command_target()
             raise HomeAssistantError(f"Navimow mow failed: {err}") from err
 

--- a/custom_components/navimower/services.yaml
+++ b/custom_components/navimower/services.yaml
@@ -46,8 +46,9 @@ set_schedule:
 mow:
   name: Mow now
   description: >-
-    Start mowing immediately: the chosen zones, in the order given, with a
-    restart-vs-continue choice.
+    Start mowing immediately in the chosen zones, with a restart-vs-continue
+    choice. Models that support custom sequencing follow the listed zone order.
+    First-generation H-series mowers mow the selected zones in their own order.
   fields:
     device_id:
       name: Mower
@@ -59,9 +60,10 @@ mow:
     zones:
       name: Zones
       description: >-
-        Internal map zone IDs to mow, in the order they should be mowed (for
-        example [13,24]). Leave empty to mow all zones and let the mower choose
-        its own route.
+        Internal map zone IDs to mow (for example [13,24]). On models that support
+        custom sequencing, the list order is used. First-generation H-series
+        mowers still restrict mowing to the selected zones but choose their order
+        automatically. Leave empty to mow all zones.
       required: false
       example: "[1]"
       selector:

--- a/tests/test_v033_features.py
+++ b/tests/test_v033_features.py
@@ -1,4 +1,4 @@
-"""Dependency-free regressions for Navimower v0.3.3."""
+"""Dependency-free regressions for Navimower v0.3.3 and later."""
 from __future__ import annotations
 
 import ast
@@ -19,15 +19,33 @@ def _load_const():
     return module
 
 
-def test_selected_zone_order_remains_enabled_for_every_model() -> None:
+def _load_model_support():
+    spec = importlib.util.spec_from_file_location(
+        "navimower_test_model_support", COMPONENT / "model_support.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_selected_zone_order_falls_back_to_robot_order_for_h1() -> None:
     services = (COMPONENT / "services.py").read_text()
     mower = (COMPONENT / "lawn_mower.py").read_text()
-    const = (COMPONENT / "const.py").read_text()
-    assert "ordered = bool(zones)" in services
-    assert "ordered = bool(sel)" in mower
-    assert "is_h1_generation" not in services
-    assert "is_h1_generation" not in mower
-    assert "H1_GENERATION_MODELS" not in const
+    support = _load_model_support()
+
+    assert support.is_h1_generation("H1500", 20000002) is True
+    assert support.is_h1_generation("H800E", 0) is True
+    assert support.is_h1_generation("H215", 400000459) is False
+    assert support.supports_ordered_zone_mowing("H1500", 20000002) is False
+    assert support.supports_ordered_zone_mowing("H215", 400000459) is True
+
+    for source in (services, mower):
+        assert "requested_ordered" in source
+        assert "supports_ordered_zone_mowing(" in source
+        assert "ordered = requested_ordered and" in source
+    assert "requested_zones if requested_ordered else []" in services
+    assert "sel if requested_ordered else []" in mower
 
 
 def test_mow_command_trace_is_exported_with_live_status_lookup() -> None:
@@ -51,7 +69,6 @@ def test_mow_command_trace_is_exported_with_live_status_lookup() -> None:
     assert "self.coordinator.begin_mow_command_trace(" in mower
 
 
-
 def test_command_number_extraction_handles_known_response_shapes() -> None:
     source = (COMPONENT / "coordinator.py").read_text()
     tree = ast.parse(source)
@@ -68,6 +85,7 @@ def test_command_number_extraction_handles_known_response_shapes() -> None:
     assert extract({"data": {"cmdNum": 456}}) == "456"
     assert extract("789") == "789"
     assert extract({"data": {"status": 1}}) is None
+
 
 def test_card_route_simplifier_uses_30_cm_and_keeps_endpoints() -> None:
     const = _load_const()

--- a/tests/test_v034_release.py
+++ b/tests/test_v034_release.py
@@ -1,4 +1,4 @@
-"""Stable v0.3.4 and next-beta regressions for Navimower."""
+"""Stable v0.3.4 and v0.4.0 regressions for Navimower."""
 from __future__ import annotations
 
 import ast
@@ -11,17 +11,24 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_current_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.0-beta2"
-    notes = (ROOT / ".github" / "release-notes" / "0.4.0-beta2.md").read_text()
-    assert notes.startswith("title: Navimower 0.4.0-beta2")
+    assert manifest["version"] == "0.4.0"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.0.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.0")
+    assert "completed-session" in notes
     assert "include_sessions=0" in notes
     assert "include_daily_trails=0" in notes
-    assert "H215" in notes
-    assert "X390" in notes
+    assert "H1" in notes
+    assert "selected zones" in notes
+    assert "custom zone order" in notes
 
     beta1_notes = (ROOT / ".github" / "release-notes" / "0.4.0-beta1.md").read_text()
     assert beta1_notes.startswith("title: Navimower 0.4.0-beta1")
     assert "completed-session" in beta1_notes
+
+    beta2_notes = (ROOT / ".github" / "release-notes" / "0.4.0-beta2.md").read_text()
+    assert beta2_notes.startswith("title: Navimower 0.4.0-beta2")
+    assert "include_sessions=0" in beta2_notes
+    assert "include_daily_trails=0" in beta2_notes
 
     stable_notes = (ROOT / ".github" / "release-notes" / "0.3.4.md").read_text()
     assert stable_notes.startswith("title: Navimower 0.3.4")


### PR DESCRIPTION
## Summary

Promote the tested `0.4.0` beta line to the latest stable release and add first-generation H-series mowing compatibility.

### Included from 0.4.0 betas

- Persistent SVG-ready completed-session render archives with separate mowed-footprint and travel layers.
- Dedicated authenticated completed-session render endpoint.
- Lightweight Map Card payload flags `include_sessions=0` and `include_daily_trails=0`, preserving backward compatibility for older cards.

### H1 zone selection

- H500/H800/H1500/H3000 family mowers continue to accept one, several or all selected zones.
- H1 mowers no longer receive the custom zone-order bit; the robot chooses the order of the selected zones automatically.
- Newer models, including H215, keep ordered-zone behavior.
- The check is explicit by known H1 model names and the observed H1 vehicle type, not by a broad `H` prefix.

### Release and validation

- Bump the manifest to stable `0.4.0`.
- Add consolidated stable release notes covering beta1, beta2 and H1 behavior.
- Update service documentation and regression contracts.
- CI must compile the integration, pass the full pytest suite, HACS validation and hassfest before merge. After merge the guarded release workflow creates tag and latest GitHub release `v0.4.0`.