### PR TITLE
Prepare Navimower 0.4.1-beta1

### DIFF
--- a/.github/release-notes/0.4.1-beta1.md
+++ b/.github/release-notes/0.4.1-beta1.md
@@ -1,0 +1,37 @@
+title: Navimower 0.4.1-beta1
+
+## Docked live-position and channel stability
+
+This beta fixes a field-reported i105 case where a mower that was stationary in the charging station could make `Live position valid` and a custom camera/channel binary sensor appear to toggle.
+
+- `Live position valid` now reports an unknown/not-applicable state when the mower is confirmed docked and the live pose stream is not expected, even if the robot emits an occasional fresh dock pose.
+- User-defined channel sensors now stay OFF while the mower is confirmed docked, including when the physical charging station sits inside the configured channel rectangle.
+- The optimistic start exception is preserved so a freshly issued mowing command is not hidden while the private-cloud docked state is still catching up.
+
+## Private-cloud polling starvation fix
+
+Dense official MQTT location traffic previously called Home Assistant's coordinator push-update path often enough to restart the normal private-cloud refresh timer continuously. During active mowing this could leave `index2`, settings, schedule, map/coverage and other private-cloud data at their startup values for several minutes even though the configured active polling interval was 5 seconds.
+
+This beta adds a guarded private polling task that:
+
+- follows the coordinator's current polling interval;
+- checks the age of the last successful private-cloud poll before refreshing;
+- guarantees a due private refresh even when MQTT pose messages arrive more frequently than the polling interval;
+- skips redundant refreshes when the normal coordinator schedule has already completed a recent poll;
+- is cancelled and restarted safely with config-entry unload/reload handling.
+
+## Diagnostics used for this fix
+
+The reported i105 diagnostics showed a healthy standalone Navimower MQTT connection with no recovery/rebuilds, while private-cloud endpoint timestamps remained about 247 seconds old despite a 5 second active polling profile. This confirmed that the remaining behavior was inside Navimower itself rather than requiring the older NavimowHA integration to be active.
+
+## Testing
+
+Regression coverage is included for:
+
+- docked channel sensors remaining OFF with a fresh pose;
+- the pending-start exception;
+- `Live position valid` respecting whether the stream is expected before pose freshness;
+- the private polling guard and its last-success-age gate;
+- release version and notes contracts.
+
+This is a prerelease intended for field validation before promoting the fixes to a stable 0.4.1 release.

--- a/custom_components/navimower/__init__.py
+++ b/custom_components/navimower/__init__.py
@@ -59,6 +59,43 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 # from the separate navimower-map-card HACS dashboard repository.
 
 
+async def _async_private_poll_guard(coordinator: NavimowCoordinator) -> None:
+    """Guarantee private-cloud polling even while dense MQTT pushes arrive.
+
+    DataUpdateCoordinator.async_set_updated_data() intentionally restarts the
+    coordinator refresh timer.  Live mower position can arrive more frequently
+    than the private-cloud interval, so the normal timer can otherwise be pushed
+    forward forever.  This guard only refreshes when the last successful private
+    poll is actually due, which also avoids duplicate idle refreshes when the
+    normal coordinator schedule is already working.
+    """
+    try:
+        while not coordinator._shutdown_complete:
+            interval = (
+                coordinator.update_interval.total_seconds()
+                if coordinator.update_interval is not None
+                else 30.0
+            )
+            interval = max(1.0, float(interval))
+            await asyncio.sleep(interval)
+            if coordinator._shutdown_complete:
+                return
+            age = coordinator.private_poll_age()
+            if age is not None and age < interval * 0.9:
+                continue
+            try:
+                await coordinator.async_refresh()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Private polling guard refresh failed; normal retry continues",
+                    exc_info=True,
+                )
+    except asyncio.CancelledError:
+        raise
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up OAuth, services and authenticated map/history HTTP resources."""
     hass.data.setdefault(DOMAIN, {})
@@ -200,6 +237,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not coordinator.data:
         coordinator.async_set_updated_data(coordinator.bootstrap_snapshot())
 
+    coordinator.private_poll_guard_task = hass.async_create_background_task(
+        _async_private_poll_guard(coordinator),
+        f"Navimower private poll guard {entry.entry_id}",
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
@@ -213,6 +255,14 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     session_archive = (
         getattr(coordinator, "session_archive", None) if coordinator else None
     )
+    private_poll_guard = (
+        getattr(coordinator, "private_poll_guard_task", None) if coordinator else None
+    )
+
+    if private_poll_guard is not None:
+        private_poll_guard.cancel()
+        await asyncio.gather(private_poll_guard, return_exceptions=True)
+        coordinator.private_poll_guard_task = None
 
     # Stop watchdog/recovery work and invalidate old callback generations before
     # entities disappear. This prevents a late Paho callback from writing into a
@@ -222,6 +272,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if not unload_ok:
+        if coordinator is not None and private_poll_guard is not None:
+            coordinator.private_poll_guard_task = hass.async_create_background_task(
+                _async_private_poll_guard(coordinator),
+                f"Navimower private poll guard {entry.entry_id}",
+            )
         if bridge is not None:
             try:
                 await bridge.async_resume()

--- a/custom_components/navimower/binary_sensor.py
+++ b/custom_components/navimower/binary_sensor.py
@@ -69,14 +69,10 @@ BINARY_SENSORS: tuple[NavimowBinaryDescription, ...] = (
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda d: (
-            True
-            if d.get("mqtt_pose_valid")
-            else (
-                None
-                if not d.get("mqtt_configured")
-                or d.get("mqtt_stream_expected") is False
-                else False
-            )
+            None
+            if not d.get("mqtt_configured")
+            or d.get("mqtt_stream_expected") is False
+            else (True if d.get("mqtt_pose_valid") else False)
         ),
     ),
     NavimowBinaryDescription(
@@ -146,11 +142,20 @@ class NavimowerChannelBinarySensor(NavimowEntity, BinarySensorEntity):
 
     @property
     def is_on(self) -> bool | None:
+        # A dock can physically sit inside a user-defined channel box.  A fresh
+        # stationary pose from that dock must not briefly turn the channel ON.
+        # Keep the optimistic start exception so a just-issued mowing command is
+        # not suppressed while the private-cloud docked state catches up.
+        if (
+            self.data.get("docked") is True
+            and self.coordinator._pending_activity_value() is None
+        ):
+            return False
         return self.coordinator.channel_state(self.channel)
 
     @property
     def available(self) -> bool:
-        return super().available and self.coordinator.channel_state(self.channel) is not None
+        return super().available and self.is_on is not None
 
     @property
     def extra_state_attributes(self) -> dict:

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.0"
+  "version": "0.4.1-beta1"
 }

--- a/tests/test_v034_release.py
+++ b/tests/test_v034_release.py
@@ -1,4 +1,4 @@
-"""Stable v0.3.4 and v0.4.0 regressions for Navimower."""
+"""Stable v0.3.4, v0.4.0 and v0.4.1 beta regressions for Navimower."""
 from __future__ import annotations
 
 import ast
@@ -11,15 +11,22 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_current_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.0"
-    notes = (ROOT / ".github" / "release-notes" / "0.4.0.md").read_text()
-    assert notes.startswith("title: Navimower 0.4.0")
-    assert "completed-session" in notes
-    assert "include_sessions=0" in notes
-    assert "include_daily_trails=0" in notes
-    assert "H1" in notes
-    assert "selected zones" in notes
-    assert "custom zone order" in notes
+    assert manifest["version"] == "0.4.1-beta1"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta1.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta1")
+    assert "Live position valid" in notes
+    assert "channel" in notes
+    assert "Private-cloud polling starvation fix" in notes
+    assert "5 seconds" in notes
+
+    stable_040 = (ROOT / ".github" / "release-notes" / "0.4.0.md").read_text()
+    assert stable_040.startswith("title: Navimower 0.4.0")
+    assert "completed-session" in stable_040
+    assert "include_sessions=0" in stable_040
+    assert "include_daily_trails=0" in stable_040
+    assert "H1" in stable_040
+    assert "selected zones" in stable_040
+    assert "custom zone order" in stable_040
 
     beta1_notes = (ROOT / ".github" / "release-notes" / "0.4.0-beta1.md").read_text()
     assert beta1_notes.startswith("title: Navimower 0.4.0-beta1")

--- a/tests/test_v041_beta1.py
+++ b/tests/test_v041_beta1.py
@@ -1,0 +1,61 @@
+"""Regression contracts for Navimower 0.4.1-beta1."""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_pose_valid_checks_stream_expectation_before_pose_freshness() -> None:
+    source = (COMPONENT / "binary_sensor.py").read_text()
+    block = source.split('key="pose_valid"', 1)[1].split("NavimowBinaryDescription(", 1)[0]
+    assert 'd.get("mqtt_stream_expected") is False' in block
+    assert 'True if d.get("mqtt_pose_valid") else False' in block
+    assert block.index('d.get("mqtt_stream_expected") is False') < block.index(
+        'd.get("mqtt_pose_valid")'
+    )
+    ast.parse(source)
+
+
+def test_docked_channel_is_off_before_live_pose_membership() -> None:
+    source = (COMPONENT / "binary_sensor.py").read_text()
+    block = source.split("class NavimowerChannelBinarySensor", 1)[1].split(
+        "class NavimowerGateRequiredBinarySensor", 1
+    )[0]
+    assert 'self.data.get("docked") is True' in block
+    assert "self.coordinator._pending_activity_value() is None" in block
+    assert "return False" in block
+    assert "return self.coordinator.channel_state(self.channel)" in block
+    assert block.index('self.data.get("docked") is True') < block.index(
+        "return self.coordinator.channel_state(self.channel)"
+    )
+    assert "return super().available and self.is_on is not None" in block
+
+
+def test_private_poll_guard_prevents_mqtt_timer_starvation() -> None:
+    source = (COMPONENT / "__init__.py").read_text()
+    guard = source.split("async def _async_private_poll_guard", 1)[1].split(
+        "async def async_setup", 1
+    )[0]
+    assert "coordinator.update_interval.total_seconds()" in guard
+    assert "age = coordinator.private_poll_age()" in guard
+    assert "if age is not None and age < interval * 0.9:" in guard
+    assert "await coordinator.async_refresh()" in guard
+    assert "await asyncio.sleep(interval)" in guard
+
+    setup = source.split("async def async_setup_entry", 1)[1].split(
+        "async def async_unload_entry", 1
+    )[0]
+    assert "coordinator.private_poll_guard_task = hass.async_create_background_task(" in setup
+    assert "_async_private_poll_guard(coordinator)" in setup
+
+    unload = source.split("async def async_unload_entry", 1)[1].split(
+        "async def async_remove_entry", 1
+    )[0]
+    assert "private_poll_guard.cancel()" in unload
+    assert "await asyncio.gather(private_poll_guard, return_exceptions=True)" in unload
+    assert "if not unload_ok:" in unload
+    assert "_async_private_poll_guard(coordinator)" in unload
+    ast.parse(source)


### PR DESCRIPTION
## Summary

Prepare `0.4.1-beta1` to fix the field-reported i105 dock/channel instability and the private-cloud polling starvation exposed by the latest diagnostics.

### Docked sensor stability

- `Live position valid` now respects whether the live pose stream is expected before treating a fresh pose as valid.
- A confirmed docked mower keeps user-defined channel sensors OFF even if the charging station lies inside the channel rectangle and the robot emits an occasional fresh stationary pose.
- Preserve the pending-start exception so a newly issued mowing command is not suppressed while docked state catches up.

### Private-cloud polling

- Add a guarded private polling task so dense MQTT location pushes cannot continuously postpone the coordinator refresh timer.
- Follow the current dynamic polling interval and skip the guard refresh when a normal private poll completed recently.
- Cancel and restore the guard safely across config-entry unload/reload handling.

### Diagnostics behind the fix

The latest i105 diagnostics showed a healthy standalone MQTT stream with no recovery/rebuilds while private-cloud endpoint timestamps remained roughly 247 seconds old despite the active 5 second polling profile. This isolates the remaining issue to Navimower rather than requiring the legacy NavimowHA integration to be active.

### Validation

- Add release-contract tests for `0.4.1-beta1`.
- Add regressions for docked channel handling, pose-valid stream semantics and the private polling guard.
- CI must compile the integration and pass the full pytest suite plus repository validation before merge.
- After merge, the release workflow should publish prerelease `v0.4.1-beta1`.