### PR TITLE
Release Navimower 0.4.1-beta2

### DIFF
--- a/.github/release-notes/0.4.1-beta2.md
+++ b/.github/release-notes/0.4.1-beta2.md
@@ -1,0 +1,39 @@
+title: Navimower 0.4.1-beta2
+
+## Zone progress and coverage ownership
+
+This beta fixes the field-reported i105 case where coverage percentages could move to the wrong zone while the mower crossed between mapped areas. The vendor work-progress counter is now owned only by its explicit work-target zone; the physical polygon under the mower remains a separate position signal and can no longer steal that progress value.
+
+- Zone coverage/progress no longer follows `current_physical_zone_id` or the last visited polygon.
+- The previous explicit work target is retained briefly when a live target packet is missing instead of falling back to physical position.
+- The central zone model uses the resolved progress owner for active progress while keeping physical-zone and gate/channel logic separate.
+
+## Session and daily-trail stability
+
+Per-zone vendor progress resets no longer split an entire multi-zone mowing task into a chain of tiny history sessions. A confirmed reset is recorded as a boundary for that zone inside the existing session.
+
+- Multi-zone mowing remains one history session across normal zone transitions.
+- Confirmed vendor resets are accepted only for the explicit progress-owner zone while a task is active.
+- Daily trails clear only the affected zone when the new zone cycle actually reaches its boundary.
+- Completed trails in unrelated zones remain visible for the rest of the local day.
+
+## Cutting-height compatibility
+
+A vendor-specific raw zone height must no longer disable cutting-height support for the whole mower. Known global or per-zone millimetre values prove support; unknown encoded markers are handled only for the affected zone.
+
+- Raw markers such as `316` are not decoded into an invented millimetre value.
+- When an encoded marker is unknown, the current global cutting height is used as the safe effective display value while inheritance remains unknown.
+
+## Mowing-footprint width
+
+Completed-session SVG footprints now use the mower's reported `mowingPathWidth` instead of assuming a universal 0.25 m swath. This fixes visible unmowed-looking stripes on wider-path models such as the X-series. Existing cached render archives are versioned forward and rebuilt lazily.
+
+## Carried forward from 0.4.1-beta1
+
+The beta1 fixes remain included: docked `Live position valid`/custom Channel stability, the pending-start exception, and the guarded private-cloud polling task that prevents dense MQTT pose pushes from starving normal private-cloud refreshes.
+
+## Testing
+
+Regression coverage includes progress-owner isolation, in-session zone-cycle boundaries, same-day trail replacement for only the affected zone, dynamic SVG swath width, encoded cutting-height handling, the beta1 stability contracts, compile checks and the full existing pytest suite.
+
+This is a prerelease intended for field validation before stable 0.4.1.

--- a/custom_components/navimower/coordinator.py
+++ b/custom_components/navimower/coordinator.py
@@ -1386,7 +1386,9 @@ class NavimowCoordinator(DataUpdateCoordinator[dict]):
             dict(item) for item in (map_data or {}).get("zones") or []
             if isinstance(item, dict)
         ]
-        active_zone_id = _as_int(snapshot.get("current_physical_zone_id"))
+        active_zone_id = _as_int(snapshot.get("active_zone_progress_zone_id"))
+        if active_zone_id is None:
+            active_zone_id = _as_int(snapshot.get("current_physical_zone_id"))
         if active_zone_id is None:
             candidates = snapshot.get("current_zone_ids") or []
             if len(candidates) == 1:
@@ -1935,11 +1937,20 @@ class NavimowCoordinator(DataUpdateCoordinator[dict]):
                 continue
             boundary = zone.get("boundary") or {}
             raw_height = _as_int(boundary.get("height_set"))
-            inherits = raw_height in (None, 0, 256)
-            configured_height = None if inherits else _normalize_cutting_height_mm(raw_height)
+            normalized_height = _normalize_cutting_height_mm(raw_height)
+            known_inherit = raw_height in (None, 0, 256)
+            unknown_encoded = (
+                raw_height not in (None, 0, 256) and normalized_height is None
+            )
+            configured_height = None if known_inherit or unknown_encoded else normalized_height
             effective_height = None
             if cutting_height_supported:
-                effective_height = global_height if inherits else configured_height
+                effective_height = (
+                    global_height
+                    if known_inherit or unknown_encoded
+                    else configured_height
+                )
+            inherits = True if known_inherit else None if unknown_encoded else False
             row = coverage_by_id.get(zone_id) or {}
             start_time = _as_int(row.get("start_time"))
             end_time = _as_int(row.get("end_time"))
@@ -2068,6 +2079,20 @@ class NavimowCoordinator(DataUpdateCoordinator[dict]):
             else "All"
         )
         map_geom = self._map_geometry or {}
+        device_info = raw.get("device_info") or {}
+        mowing_extend = _find(device_info, "mowingExtend", "mowing_extend") or {}
+        mowing_path_width_raw = _as_float(
+            _find(mowing_extend, "mowingPathWidth", "mowing_path_width")
+        )
+        mowing_path_width_m = None
+        if mowing_path_width_raw is not None and mowing_path_width_raw > 0:
+            candidate_width = (
+                mowing_path_width_raw / 1000.0
+                if mowing_path_width_raw > 10
+                else mowing_path_width_raw
+            )
+            if 0.1 <= candidate_width <= 2.0:
+                mowing_path_width_m = candidate_width
 
         # Coverage and position. MQTT is authoritative while fresh; private
         # get-location remains a fallback when MQTT is absent/stale.
@@ -2172,17 +2197,12 @@ class NavimowCoordinator(DataUpdateCoordinator[dict]):
         zone_height_values = [
             _normalize_cutting_height_mm(value) for value in raw_zone_heights
         ]
-        encoded_zone_height = any(
-            value not in (None, 0, 256)
-            and _normalize_cutting_height_mm(value) is None
-            for value in raw_zone_heights
-        )
+        # A vendor-specific/encoded zone value must not disable cutting-height
+        # support for the whole mower. Known global/zone heights prove the
+        # feature exists; unknown raw zone markers are handled per-zone below.
         cutting_height_supported = bool(
-            not encoded_zone_height
-            and (
-                normalized_cut_height is not None
-                or any(value is not None for value in zone_height_values)
-            )
+            normalized_cut_height is not None
+            or any(value is not None for value in zone_height_values)
         )
 
         settings = {
@@ -2334,6 +2354,7 @@ class NavimowCoordinator(DataUpdateCoordinator[dict]):
                 map_geom, cutting_height_supported=cutting_height_supported
             ) if map_geom else None,
             "cutting_height_supported": cutting_height_supported,
+            "mowing_path_width_m": mowing_path_width_m,
             # groups
             "settings": settings,
             "maintenance": maint,
@@ -2598,7 +2619,16 @@ class NavimowCoordinator(DataUpdateCoordinator[dict]):
         physical_zone_id = _valid_zone_id(
             snapshot.get("current_physical_zone_id")
         )
-        active_progress_zone = mqtt_zone_id or cloud_zone_id or physical_zone_id
+        # Work/zone progress belongs only to an explicit work target.
+        active_progress_zone = mqtt_zone_id or cloud_zone_id
+        if active_progress_zone is None and active:
+            active_progress_zone = previous_zone_id = _valid_zone_id(
+                previous.get("active_zone_progress_zone_id")
+            )
+        else:
+            previous_zone_id = _valid_zone_id(
+                previous.get("active_zone_progress_zone_id")
+            )
         private_zone_progress = _progress_percent(snapshot.get("work_progress"))
         zone_progress_candidates = (
             [
@@ -2620,9 +2650,6 @@ class NavimowCoordinator(DataUpdateCoordinator[dict]):
                 active_zone_progress = value
                 active_zone_progress_source = source
                 break
-        previous_zone_id = _valid_zone_id(
-            previous.get("active_zone_progress_zone_id")
-        )
         previous_zone_progress = _progress_percent(
             previous.get("active_zone_progress")
         )

--- a/custom_components/navimower/history.py
+++ b/custom_components/navimower/history.py
@@ -305,6 +305,13 @@ def _merge_session_records(
         previous.get("cycle_reset_zone_ids"),
         continuation.get("cycle_reset_zone_ids"),
     )
+    merged["zone_cycle_boundaries"] = sorted(
+        [dict(item) for item in [
+            *(previous.get("zone_cycle_boundaries") or []),
+            *(continuation.get("zone_cycle_boundaries") or []),
+        ] if isinstance(item, dict)],
+        key=lambda item: _as_int(item.get("at_ms")) or 0,
+    )
 
     points = [
         list(point)
@@ -1187,16 +1194,19 @@ class NavimowerHistory:
         *,
         pose_time: Any,
     ) -> bool:
-        """Split the active route when vendor progress starts a new cycle."""
+        """Record confirmed per-zone vendor cycle boundaries without splitting a task."""
         rows = self._progress_rows(snapshot)
         if not rows:
             return False
+        owner_zone_id = _as_int(snapshot.get("active_zone_progress_zone_id"))
         reset_rows: list[tuple[dict[str, Any], dict[str, Any], int]] = []
         with self._lock:
             active = self._cache.get(self._active_id or "")
             for row in rows:
                 zone_id = _as_int(row.get("id"))
                 if zone_id is None:
+                    continue
+                if active is not None and owner_zone_id is not None and zone_id != owner_zone_id:
                     continue
                 previous = dict(self._zone_progress_state.get(str(zone_id)) or {})
                 old_progress = _as_int(previous.get("progress"))
@@ -1206,83 +1216,38 @@ class NavimowerHistory:
                 new_progress = _as_int(row.get("progress"))
                 old_start = _as_int(previous.get("start_time"))
                 new_start = _as_int(row.get("start_time"))
-                drop = (
-                    peak_progress - new_progress
-                    if peak_progress is not None and new_progress is not None
-                    else None
-                )
-                hard_reset = bool(
-                    drop is not None and (
-                        (peak_progress >= 15 and new_progress <= 5 and drop >= 15)
-                        or (peak_progress >= 50 and new_progress <= 20 and drop >= 30)
-                    )
-                )
-                timestamp_reset = bool(
-                    old_progress is not None and new_progress is not None
-                    and old_start is not None and new_start is not None
-                    and new_start > old_start and new_progress <= 25
-                    and old_progress - new_progress >= 10
-                )
+                drop = peak_progress - new_progress if peak_progress is not None and new_progress is not None else None
+                hard_reset = bool(drop is not None and ((peak_progress >= 15 and new_progress <= 5 and drop >= 15) or (peak_progress >= 50 and new_progress <= 20 and drop >= 30)))
+                timestamp_reset = bool(old_progress is not None and new_progress is not None and old_start is not None and new_start is not None and new_start > old_start and new_progress <= 25 and old_progress - new_progress >= 10)
                 if active is not None and (hard_reset or timestamp_reset):
                     reset_rows.append((previous, row, peak_progress or old_progress or 0))
-
             if reset_rows and active is not None:
+                boundary_ms = _timestamp_ms(pose_time)
+                reset_zone_ids: list[int] = []
                 final_progress: dict[str, int] = {}
-                completion_ms = _timestamp_ms(pose_time)
-                completion_flags: list[bool] = []
+                completed_flags: list[bool] = []
+                boundaries = active.setdefault("zone_cycle_boundaries", [])
                 for _previous, row, previous_peak in reset_rows:
                     zone_id = _as_int(row.get("id"))
                     if zone_id is None:
                         continue
+                    new_start = _as_int(row.get("start_time"))
+                    at_ms = _timestamp_ms(new_start) if new_start is not None else boundary_ms
+                    duplicate = any(_as_int(item.get("zone_id")) == zone_id and abs((_as_int(item.get("at_ms")) or 0) - at_ms) <= 60_000 for item in boundaries if isinstance(item, dict))
+                    if not duplicate:
+                        boundaries.append({"zone_id": zone_id, "at_ms": at_ms, "at": _iso(at_ms), "reason": "vendor_progress_reset", "previous_peak": previous_peak})
+                    reset_zone_ids.append(zone_id)
                     final_progress[str(zone_id)] = previous_peak
                     completed_zone = previous_peak >= VENDOR_COMPLETION_PROGRESS_MIN
-                    completion_flags.append(completed_zone)
-                    new_start = _as_int(row.get("start_time"))
-                    if new_start is not None:
-                        completion_ms = min(completion_ms, _timestamp_ms(new_start))
+                    completed_flags.append(completed_zone)
                     if completed_zone:
                         record = dict(self._zone_history.get(str(zone_id)) or {})
-                        record.update({
-                            "id": zone_id,
-                            "name": row.get("name") or record.get("name") or f"Zone {zone_id}",
-                            "last_completed_at": _iso(completion_ms),
-                            "last_completed_progress": previous_peak,
-                        })
+                        record.update({"id": zone_id, "name": row.get("name") or record.get("name") or f"Zone {zone_id}", "last_completed_at": _iso(at_ms), "last_completed_progress": previous_peak})
                         self._zone_history[str(zone_id)] = record
-                completed_cycle = bool(completion_flags) and all(completion_flags)
-                active["completed"] = completed_cycle
-                active["completion_reason"] = (
-                    "vendor_cycle_reset"
-                    if completed_cycle
-                    else "vendor_cycle_reset_partial"
-                )
-                active["final_progress"] = final_progress
                 self._update_active_metadata_locked(active)
-                reset_zone_ids = [
-                    _as_int(row.get("id"))
-                    for _previous, row, _peak in reset_rows
-                    if _as_int(row.get("id")) is not None
-                ]
-                self._force_new_session_once = True
-                self._force_new_cycle_zone_ids = _unique_ints(reset_zone_ids)
-                if self._is_provisional_session(active):
-                    self._discard_active_locked()
-                else:
-                    self._finish_active_locked(pose_time)
-                self._last_cycle_event = {
-                    "reason": active["completion_reason"],
-                    "at_ms": completion_ms,
-                    "at": _iso(completion_ms),
-                    "zone_ids": reset_zone_ids,
-                    "completed": completed_cycle,
-                    "final_progress": final_progress,
-                    "source": "vendor_progress",
-                }
-                _LOGGER.info(
-                    "Started a new Navimower mowing cycle after progress reset in zone(s) %s",
-                    ", ".join(str(row.get("id")) for _previous, row, _peak in reset_rows),
-                )
-
+                self._last_cycle_event = {"reason": "vendor_zone_cycle_reset", "at_ms": boundary_ms, "at": _iso(boundary_ms), "zone_ids": _unique_ints(reset_zone_ids), "completed": bool(completed_flags) and all(completed_flags), "final_progress": final_progress, "source": "vendor_progress"}
+                self._trail_revision += 1
+                self._schedule_active_save()
             reset_zone_ids = {_as_int(row.get("id")) for _previous, row, _peak in reset_rows}
             for row in rows:
                 zone_id = _as_int(row.get("id"))
@@ -1298,13 +1263,7 @@ class NavimowerHistory:
                 else:
                     known = [value for value in (previous_peak, progress) if value is not None]
                     peak = max(known) if known else None
-                self._zone_progress_state[str(zone_id)] = {
-                    "progress": progress,
-                    "peak_progress": peak,
-                    "start_time": _as_int(row.get("start_time")),
-                    "end_time": _as_int(row.get("end_time")),
-                    "observed_at_ms": _timestamp_ms(pose_time),
-                }
+                self._zone_progress_state[str(zone_id)] = {"progress": progress, "peak_progress": peak, "start_time": _as_int(row.get("start_time")), "end_time": _as_int(row.get("end_time")), "observed_at_ms": _timestamp_ms(pose_time)}
         self._schedule_index_save()
         return bool(reset_rows)
 
@@ -1325,6 +1284,7 @@ class NavimowerHistory:
         zone_details: list[dict[str, Any]],
         *,
         active_zone_progress: Any = None,
+        active_progress_zone_id: Any = None,
         cycle_reset_pending: bool = False,
     ) -> None:
         """Persist the latest known timestamps/progress for every zone."""
@@ -1386,9 +1346,7 @@ class NavimowerHistory:
                 task_progress = active.setdefault("task_zone_progress", {})
                 for zone_id in active.get("zone_ids") or []:
                     task_progress.setdefault(str(zone_id), 0)
-                active_zone_id = None
-                if active.get("visited_zone_ids"):
-                    active_zone_id = _as_int(active.get("visited_zone_ids")[-1])
+                active_zone_id = _as_int(active_progress_zone_id)
                 if active_zone_id is not None:
                     active_detail = next(
                         (
@@ -1482,6 +1440,7 @@ class NavimowerHistory:
             snapshot.get("coverage"),
             snapshot.get("zone_details") or [],
             active_zone_progress=snapshot.get("active_zone_progress"),
+            active_progress_zone_id=snapshot.get("active_zone_progress_zone_id"),
             cycle_reset_pending=bool(snapshot.get("cycle_value_reset_pending")),
         )
 

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta1"
+  "version": "0.4.1-beta2"
 }

--- a/custom_components/navimower/session_archive.py
+++ b/custom_components/navimower/session_archive.py
@@ -144,9 +144,14 @@ class SessionArchiveManager:
             if render_matches_session(cached, session):
                 return deepcopy(cached)
 
+            render_session = deepcopy(session)
+            if render_session.get("mowing_path_width_m") is None:
+                width = (self.coordinator.data or {}).get("mowing_path_width_m")
+                if width is not None:
+                    render_session["mowing_path_width_m"] = width
             artifact = await self.hass.async_add_executor_job(
                 build_session_svg_archive,
-                deepcopy(session),
+                render_session,
             )
             if artifact is None:
                 return None

--- a/custom_components/navimower/session_svg.py
+++ b/custom_components/navimower/session_svg.py
@@ -23,7 +23,7 @@ from .const import (
 )
 from .zone_state import simplify_xy_points
 
-SESSION_SVG_ARCHIVE_VERSION = 1
+SESSION_SVG_ARCHIVE_VERSION = 2
 SESSION_SVG_GRID_M = 0.025
 SESSION_SVG_MAX_ESTIMATED_CELLS = 1_500_000
 
@@ -158,9 +158,12 @@ def _polyline_length(segments: Iterable[list[list[float]]]) -> float:
     return total
 
 
-def _adaptive_grid_size(cutting_segments: list[list[list[float]]]) -> float:
+def _adaptive_grid_size(
+    cutting_segments: list[list[list[float]]],
+    width_m: float = SWATH_WIDTH_M,
+) -> float:
     length = _polyline_length(cutting_segments)
-    estimated_area = max(SWATH_WIDTH_M * length, SWATH_WIDTH_M**2)
+    estimated_area = max(width_m * length, width_m**2)
     needed = math.sqrt(estimated_area / SESSION_SVG_MAX_ESTIMATED_CELLS)
     return min(0.20, max(SESSION_SVG_GRID_M, needed))
 
@@ -190,7 +193,7 @@ def _rasterize_swath(
     *,
     width_m: float = SWATH_WIDTH_M,
 ) -> tuple[set[tuple[int, int]], float]:
-    cell = _adaptive_grid_size(cutting_segments)
+    cell = _adaptive_grid_size(cutting_segments, width_m)
     radius = max(0.01, float(width_m) / 2.0)
     # Cell-centre sampling keeps the stored footprint close to the requested
     # swath width. The adaptive grid always retains several cells across the
@@ -426,7 +429,10 @@ def build_session_svg_archive(session: dict[str, Any]) -> dict[str, Any] | None:
     if not all_segments:
         return None
 
-    occupied, grid_size = _rasterize_swath(cutting_segments)
+    swath_width = _as_float(session.get("mowing_path_width_m"))
+    if swath_width is None or not 0.1 <= swath_width <= 2.0:
+        swath_width = SWATH_WIDTH_M
+    occupied, grid_size = _rasterize_swath(cutting_segments, width_m=swath_width)
     loops = _boundary_loops(occupied) if occupied else []
     mowed_path = _loops_path(loops, grid_size) if loops else ""
     travel_path, travel_points = _polyline_path(travel_segments)
@@ -440,7 +446,7 @@ def build_session_svg_archive(session: dict[str, Any]) -> dict[str, Any] | None:
         "mowed_area": {
             "path_d": mowed_path,
             "fill_rule": "evenodd",
-            "swath_width_m": SWATH_WIDTH_M,
+            "swath_width_m": swath_width,
             "grid_size_m": round(grid_size, 4),
             "loop_count": len(loops),
             "occupied_cell_count": len(occupied),

--- a/custom_components/navimower/zone_state.py
+++ b/custom_components/navimower/zone_state.py
@@ -426,38 +426,12 @@ def zone_model_signature(
 
 
 def build_daily_trails(
-    *,
-    sessions: list[dict[str, Any]],
-    map_zones: list[dict[str, Any]],
-    local_date: date,
-    to_local_date,
-    revision: int,
+    *, sessions: list[dict[str, Any]], map_zones: list[dict[str, Any]], local_date: date, to_local_date, revision: int,
 ) -> dict[str, Any]:
-    """Keep today's route for the latest mowing cycle of every zone.
-
-    A persistent history *session* ends whenever the mower docks, but docking for
-    an intermediate charge does not start a new mowing *cycle*.  Therefore
-    consecutive incomplete sessions are accumulated for the same zone.  The old
-    daily route is replaced only when a confirmed cycle boundary reaches that
-    zone: practical completion, a vendor progress reset, or an explicit reset
-    command recorded on the first session of the new cycle.
-
-    The active session is rendered by the card's dedicated live-trail layer.  It
-    is intentionally not copied into ``daily_trails``.  During a charge-return
-    continuation the previous completed fragments remain visible underneath the
-    live route; at a real new-cycle boundary they are cleared as soon as the new
-    active session first enters that zone.
-    """
+    """Keep today's route for the latest confirmed mowing cycle of every zone."""
     by_zone: dict[int, dict[str, Any]] = {}
-    # A completed/reset session closes the current zone cycle.  The replacement
-    # is delayed until a later session actually enters that zone, matching the
-    # Navimow app and preserving unrelated zones.
     boundary_before_next: set[int] = set()
-    ordered = sorted(
-        (item for item in sessions if isinstance(item, dict)),
-        key=lambda item: as_int(item.get("started_at_ms")) or 0,
-    )
-
+    ordered = sorted((item for item in sessions if isinstance(item, dict)), key=lambda item: as_int(item.get("started_at_ms")) or 0)
     for session in ordered:
         session_id = str(session.get("id") or "")
         if not session_id:
@@ -465,138 +439,56 @@ def build_daily_trails(
         points = session.get("points") or []
         if not isinstance(points, list) or not points:
             continue
-
-        starts = {
-            value
-            for value in (
-                as_int(item) for item in session.get("segment_starts_ms") or []
-            )
-            if value is not None
-        }
-        session_by_zone: dict[int, dict[str, Any]] = {}
-        current_zone: int | None = None
-        current_segment: list[list[float]] = []
-
+        active = bool(session.get("active"))
+        starts = {value for value in (as_int(item) for item in session.get("segment_starts_ms") or []) if value is not None}
+        explicit_reset_zones = {value for value in (as_int(item) for item in session.get("cycle_reset_zone_ids") or []) if value is not None}
+        boundary_times: dict[int, list[int]] = {}
+        for item in session.get("zone_cycle_boundaries") or []:
+            if not isinstance(item, dict): continue
+            zone_id = as_int(item.get("zone_id")); at_ms = as_int(item.get("at_ms"))
+            if zone_id is not None and at_ms is not None: boundary_times.setdefault(zone_id, []).append(at_ms)
+        for values in boundary_times.values(): values.sort()
+        boundary_index = {zone_id: 0 for zone_id in boundary_times}
+        encountered_zones: set[int] = set(); current_zone: int | None = None; current_segment: list[list[float]] = []
         def flush() -> None:
             nonlocal current_segment
-            if current_zone is not None and current_segment:
-                row = session_by_zone.setdefault(
-                    current_zone, {"segments": [], "point_count": 0}
-                )
-                row["segments"].append(simplify_xy_points(current_segment))
+            if current_zone is not None and len(current_segment) >= 2 and not active:
+                simplified = simplify_xy_points(current_segment)
+                if len(simplified) >= 2:
+                    row = by_zone.get(current_zone)
+                    if row is None:
+                        row = {"zone_id": current_zone, "cycle_id": session_id, "active": False, "segments": [], "point_count": 0}
+                        by_zone[current_zone] = row
+                    row["segments"].append(simplified); row["point_count"] += len(current_segment)
             current_segment = []
-
         for raw in points:
-            if not isinstance(raw, list) or len(raw) < 3:
-                continue
-            stamp = as_int(raw[0])
-            x, y = as_float(raw[1]), as_float(raw[2])
-            if (
-                stamp is None
-                or x is None
-                or y is None
-                or to_local_date(stamp) != local_date
-            ):
-                flush()
-                current_zone = None
-                continue
+            if not isinstance(raw, list) or len(raw) < 3: continue
+            stamp = as_int(raw[0]); x, y = as_float(raw[1]), as_float(raw[2])
+            if stamp is None or x is None or y is None or to_local_date(stamp) != local_date:
+                flush(); current_zone = None; continue
             zone_id = as_int(raw[7]) if len(raw) > 7 else None
+            if zone_id is None: zone_id = zone_id_for_point(x, y, map_zones)
             if zone_id is None:
-                zone_id = zone_id_for_point(x, y, map_zones)
-            if zone_id is None:
-                flush()
-                current_zone = None
-                continue
-            boundary = stamp in starts and current_segment
-            if zone_id != current_zone or boundary:
-                flush()
-                current_zone = zone_id
-            current_segment.append([x, y])
-            session_by_zone.setdefault(
-                zone_id, {"segments": [], "point_count": 0}
-            )["point_count"] += 1
-        flush()
-
-        explicit_reset_zones = {
-            value
-            for value in (
-                as_int(item) for item in session.get("cycle_reset_zone_ids") or []
-            )
-            if value is not None
-        }
-        active = bool(session.get("active"))
-        encountered_zones = set(session_by_zone)
-
-        for zone_id, session_row in session_by_zone.items():
+                flush(); current_zone = None; continue
+            encountered_zones.add(zone_id)
             if zone_id in boundary_before_next or zone_id in explicit_reset_zones:
-                by_zone.pop(zone_id, None)
-                boundary_before_next.discard(zone_id)
-
-            # The live layer already owns the active route. Keeping it out of the
-            # daily payload prevents duplicate drawing while allowing completed
-            # pre-charge fragments to remain visible.
-            if active:
-                continue
-
-            row = by_zone.get(zone_id)
-            if row is None:
-                row = {
-                    "zone_id": zone_id,
-                    "cycle_id": session_id,
-                    "active": False,
-                    "segments": [],
-                    "point_count": 0,
-                }
-                by_zone[zone_id] = row
-            row["segments"].extend(session_row["segments"])
-            row["point_count"] += int(session_row["point_count"])
-
+                flush(); by_zone.pop(zone_id, None); boundary_before_next.discard(zone_id); explicit_reset_zones.discard(zone_id); current_zone = None
+            values = boundary_times.get(zone_id) or []; index = boundary_index.get(zone_id, 0)
+            while index < len(values) and stamp >= values[index]:
+                flush(); by_zone.pop(zone_id, None); current_zone = None; index += 1
+            boundary_index[zone_id] = index
+            fragment_boundary = stamp in starts and current_segment
+            if zone_id != current_zone or fragment_boundary:
+                flush(); current_zone = zone_id
+            current_segment.append([x, y])
+        flush()
         reason = str(session.get("completion_reason") or "").lower()
-        final_progress_zone_ids = {
-            value
-            for value in (
-                as_int(item) for item in (session.get("final_progress") or {}).keys()
-            )
-            if value is not None
-        }
-        if "reset" in reason:
-            boundary_zones = (
-                final_progress_zone_ids
-                or encountered_zones
-                or {
-                    value
-                    for value in (
-                        as_int(item) for item in session.get("zone_ids") or []
-                    )
-                    if value is not None
-                }
-            )
+        final_progress_zone_ids = {value for value in (as_int(item) for item in (session.get("final_progress") or {}).keys()) if value is not None}
+        if "reset" in reason or session.get("completed") is True:
+            boundary_zones = final_progress_zone_ids or encountered_zones or {value for value in (as_int(item) for item in session.get("zone_ids") or []) if value is not None}
             boundary_before_next.update(boundary_zones)
-        elif session.get("completed") is True:
-            boundary_zones = (
-                final_progress_zone_ids
-                or encountered_zones
-                or {
-                    value
-                    for value in (
-                        as_int(item) for item in session.get("zone_ids") or []
-                    )
-                    if value is not None
-                }
-            )
-            boundary_before_next.update(boundary_zones)
-
     result = []
     for zone_id in sorted(by_zone):
-        row = deepcopy(by_zone[zone_id])
-        row["segments"] = [
-            segment for segment in row["segments"] if len(segment) >= 2
-        ]
-        row["render_point_count"] = sum(len(segment) for segment in row["segments"])
-        if row["segments"]:
-            result.append(row)
-    return {
-        "date": local_date.isoformat(),
-        "revision": revision,
-        "zones": result,
-    }
+        row = deepcopy(by_zone[zone_id]); row["segments"] = [segment for segment in row["segments"] if len(segment) >= 2]; row["render_point_count"] = sum(len(segment) for segment in row["segments"])
+        if row["segments"]: result.append(row)
+    return {"date": local_date.isoformat(), "revision": revision, "zones": result}

--- a/tests/test_history_merge.py
+++ b/tests/test_history_merge.py
@@ -342,29 +342,22 @@ async def cycle_reset_split_test() -> None:
         },
         "zone_details": [{"id": 24, "name": "Yard", "progress": 4, "percentage": 4}],
     }
-    # The vendor can publish the reset during the brief non-cutting handover
-    # between two scheduled passes. The old route must still be finalized.
+    reset["active_zone_progress_zone_id"] = 24
     assert manager.prepare_cycle(reset, pose_time=2_200_000_020) is True
-    assert manager._active_id is None
+    assert manager._active_id == first_id
 
     manager.process_pose(
-        position={"x": 1.2, "y": 1.2},
-        pose_time=2_200_000_021,
-        heading=0.1,
-        activity="mowing",
-        cutting=True,
-        docked=False,
-        returning=False,
-        zone_ids=[24],
+        position={"x": 1.2, "y": 1.2}, pose_time=2_200_000_021, heading=0.1, activity="mowing", cutting=True, docked=False, returning=False, zone_ids=[24],
     )
-    second_id = manager._active_id
-    assert second_id and second_id != first_id
-    assert len(manager._sessions) == 2
+    assert manager._active_id == first_id
+    assert len(manager._sessions) == 1
     first = manager._cache[first_id]
-    assert first["completed"] is True
-    assert first["completion_reason"] == "vendor_cycle_reset"
-    assert first["final_progress"] == {"24": 98}
-    assert not history._sessions_can_merge(first, manager._cache[second_id])
+    assert first["completed"] is None
+    assert first["completion_reason"] is None
+    boundaries = first.get("zone_cycle_boundaries") or []
+    assert len(boundaries) == 1
+    assert boundaries[0]["zone_id"] == 24
+    assert boundaries[0]["previous_peak"] == 98
     zone_history = manager.zone_history()["24"]
     assert zone_history["last_completed_progress"] == 98
     assert zone_history["last_completed_at"]
@@ -402,10 +395,11 @@ async def provisional_cycle_reset_stub_test() -> None:
         "zone_details": [{"id": 24, "name": "Yard", "progress": 4}],
     }
     assert manager.prepare_cycle(high, pose_time=2_250_000_010) is False
+    low["active_zone_progress_zone_id"] = 24
     assert manager.prepare_cycle(low, pose_time=2_250_000_020) is True
-    assert manager._active_id is None
-    assert stub_id not in manager._cache
-    assert manager._sessions == []
+    assert manager._active_id == stub_id
+    assert stub_id in manager._cache
+    assert len(manager._sessions) == 1
     manager.process_pose(
         position={"x": 4.1, "y": 4.1},
         pose_time=2_250_000_021,
@@ -417,6 +411,8 @@ async def provisional_cycle_reset_stub_test() -> None:
         zone_ids=[24],
     )
     assert len(manager._sessions) == 1
+    assert manager._active_id == stub_id
+    assert (manager._cache[stub_id].get("zone_cycle_boundaries") or [])[0]["zone_id"] == 24
     if hass.tasks:
         await asyncio.gather(*hass.tasks)
 
@@ -442,6 +438,7 @@ def practical_completion_threshold_test() -> None:
         {"zones": [{"id": 13, "pct": 97}]},
         [{"id": 13, "name": "Street", "percentage": 97}],
         active_zone_progress=97,
+        active_progress_zone_id=13,
     )
     active = manager.active_session
     assert active is not None
@@ -472,6 +469,7 @@ async def dock_completion_history_test() -> None:
         {"zones": [{"id": 24, "pct": 97}]},
         [{"id": 24, "name": "Yard", "progress": 97, "percentage": 23}],
         active_zone_progress=97,
+        active_progress_zone_id=24,
     )
     manager.prepare_cycle(
         {
@@ -605,11 +603,20 @@ async def vendor_partial_reset_test() -> None:
         "coverage": {"zones": [{"id": 13, "name": "Street", "pct": 3}]},
         "zone_details": [{"id": 13, "name": "Street", "progress": 3}],
     }
+    high["active_zone_progress_zone_id"] = 13
+    low["active_zone_progress_zone_id"] = 13
+    first_id = manager._active_id
     assert manager.prepare_cycle(high, pose_time=2_600_000_010) is False
     assert manager.prepare_cycle(low, pose_time=2_600_000_020) is True
-    first = manager._sessions[0]
-    assert first["completed"] is False
-    assert first["completion_reason"] == "vendor_cycle_reset_partial"
+    assert manager._active_id == first_id
+    assert len(manager._sessions) == 1
+    first = manager._cache[first_id]
+    assert first["completed"] is None
+    assert first["completion_reason"] is None
+    boundaries = first.get("zone_cycle_boundaries") or []
+    assert len(boundaries) == 1
+    assert boundaries[0]["zone_id"] == 13
+    assert boundaries[0]["previous_peak"] == 50
     assert "last_completed_at" not in manager.zone_history().get("13", {})
     if hass.tasks:
         await asyncio.gather(*hass.tasks)

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -95,6 +95,7 @@ def test_completed_session_archive_manager() -> None:
             def __init__(self):
                 self.history = History()
                 self.listeners = []
+                self.data = {}
             def async_add_listener(self, callback):
                 self.listeners.append(callback)
                 return lambda: self.listeners.remove(callback)

--- a/tests/test_session_svg.py
+++ b/tests/test_session_svg.py
@@ -72,7 +72,7 @@ def test_completed_session_svg_archive() -> None:
         }
         artifact = target.build_session_svg_archive(session)
         assert artifact is not None
-        assert artifact["version"] == 1
+        assert artifact["version"] == 2
         assert artifact["coordinate_space"] == "map_xy_m"
         assert artifact["source"]["point_count"] == 5
         assert artifact["mowed_area"]["path_d"].startswith("M")

--- a/tests/test_v033_features.py
+++ b/tests/test_v033_features.py
@@ -136,9 +136,9 @@ def test_daily_trail_cycle_markers_survive_storage_and_prevent_merge() -> None:
 def test_daily_trails_do_not_treat_every_dock_session_as_new_cycle() -> None:
     source = (COMPONENT / "zone_state.py").read_text()
     assert "boundary_before_next" in source
-    assert 'if active:' in source
-    assert 'if "reset" in reason:' in source
-    assert 'elif session.get("completed") is True:' in source
+    assert "and not active" in source
+    assert 'if "reset" in reason or session.get("completed") is True:' in source
+    assert "zone_cycle_boundaries" in source
     assert "by_zone.pop(zone_id, None)" in source
 
 

--- a/tests/test_v034_release.py
+++ b/tests/test_v034_release.py
@@ -11,13 +11,13 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_current_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta1"
-    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta1.md").read_text()
-    assert notes.startswith("title: Navimower 0.4.1-beta1")
-    assert "Live position valid" in notes
-    assert "channel" in notes
-    assert "Private-cloud polling starvation fix" in notes
-    assert "5 seconds" in notes
+    assert manifest["version"] == "0.4.1-beta2"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta2.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta2")
+    assert "Zone progress and coverage ownership" in notes
+    assert "Session and daily-trail stability" in notes
+    assert "Mowing-footprint width" in notes
+    assert "316" in notes
 
     stable_040 = (ROOT / ".github" / "release-notes" / "0.4.0.md").read_text()
     assert stable_040.startswith("title: Navimower 0.4.0")
@@ -133,9 +133,9 @@ def test_v040_beta1_completed_session_archive_contract() -> None:
     api = (COMPONENT / "map_api.py").read_text()
     setup = (COMPONENT / "__init__.py").read_text()
 
-    assert "SESSION_SVG_ARCHIVE_VERSION = 1" in svg
+    assert "SESSION_SVG_ARCHIVE_VERSION = 2" in svg
     assert '"fill_rule": "evenodd"' in svg
-    assert '"swath_width_m": SWATH_WIDTH_M' in svg
+    assert '"swath_width_m": swath_width' in svg
     assert '"travel"' in svg
     assert "MQTT_CUTTING_ACTIONS" in svg
     assert "render_matches_session" in archive

--- a/tests/test_v041_beta2.py
+++ b/tests/test_v041_beta2.py
@@ -1,0 +1,35 @@
+"""Regression contracts for Navimower 0.4.1-beta2."""
+from __future__ import annotations
+from datetime import date
+import importlib.util, json, sys, types
+from pathlib import Path
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+PACKAGE = "navimower_v041_beta2_test"
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path); assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec); sys.modules[name] = module; spec.loader.exec_module(module); return module
+def test_release_version_and_notes():
+    manifest = json.loads((COMPONENT / "manifest.json").read_text()); assert manifest["version"] == "0.4.1-beta2"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta2.md").read_text(); assert "Zone progress and coverage ownership" in notes; assert "Mowing-footprint width" in notes; assert "316" in notes
+def test_progress_owner_never_falls_back_to_physical_zone():
+    source = (COMPONENT / "coordinator.py").read_text(); block = source.split("mqtt_zone_id = _valid_zone_id", 1)[1].split('snapshot["coverage"]', 1)[0]
+    assert "active_progress_zone = mqtt_zone_id or cloud_zone_id" in block; assert "or physical_zone_id" not in block
+    refresh = source.split("def _refresh_zone_model", 1)[1].split("def _session_completed", 1)[0]; assert 'snapshot.get("active_zone_progress_zone_id")' in refresh
+def test_history_uses_explicit_progress_owner_and_does_not_split_session():
+    source = (COMPONENT / "history.py").read_text(); update = source.split("def update_zone_history", 1)[1].split("def update_from_snapshot", 1)[0]
+    assert "active_progress_zone_id" in update; assert 'active.get("visited_zone_ids")[-1]' not in update
+    prepare = source.split("def prepare_cycle", 1)[1].split("def cycle_diagnostics", 1)[0]; assert 'snapshot.get("active_zone_progress_zone_id")' in prepare; assert 'active.setdefault("zone_cycle_boundaries", [])' in prepare; assert "_finish_active_locked" not in prepare; assert "_discard_active_locked" not in prepare
+def test_unknown_zone_height_does_not_disable_whole_mower():
+    source = (COMPONENT / "coordinator.py").read_text(); capability = source.split("raw_zone_heights =", 1)[1].split("settings =", 1)[0]
+    assert "encoded_zone_height" not in capability; assert "any(value is not None for value in zone_height_values)" in capability
+    detail = source.split("def _build_zone_details", 1)[1].split("def _apply_active_zone_progress", 1)[0]; assert "unknown_encoded" in detail; assert "global_height" in detail
+def test_daily_trail_zone_boundary_replaces_only_that_zone_inside_one_session():
+    package = types.ModuleType(PACKAGE); package.__path__ = [str(COMPONENT)]; sys.modules.setdefault(PACKAGE, package); _load(f"{PACKAGE}.const", COMPONENT / "const.py"); zone_state = _load(f"{PACKAGE}.zone_state", COMPONENT / "zone_state.py"); day = date(2026, 8, 7)
+    def point(stamp, x, zone): return [stamp, x, 1.0, 0.0, "mowing", 4, -1, zone]
+    payload = zone_state.build_daily_trails(sessions=[{"id":"one-task","started_at_ms":1000,"active":False,"completed":False,"segment_starts_ms":[1000],"zone_cycle_boundaries":[{"zone_id":13,"at_ms":5000}],"points":[point(1000,1.0,13),point(2000,2.0,13),point(3000,10.0,24),point(4000,11.0,24),point(5000,3.0,13),point(6000,4.0,13)]}], map_zones=[], local_date=day, to_local_date=lambda _stamp: day, revision=1)
+    zones = {row["zone_id"]: row for row in payload["zones"]}; assert zones[13]["segments"] == [[[3.0,1.0],[4.0,1.0]]]; assert zones[24]["segments"] == [[[10.0,1.0],[11.0,1.0]]]
+def test_session_svg_uses_reported_swath_width():
+    package = types.ModuleType(PACKAGE + "_svg"); package.__path__ = [str(COMPONENT)]; sys.modules.setdefault(PACKAGE + "_svg", package); _load(f"{PACKAGE}_svg.const", COMPONENT / "const.py"); _load(f"{PACKAGE}_svg.zone_state", COMPONENT / "zone_state.py"); svg = _load(f"{PACKAGE}_svg.session_svg", COMPONENT / "session_svg.py")
+    session = {"id":"x-series","active":False,"ended_at_ms":3000,"segment_starts_ms":[1000],"mowing_path_width_m":0.5,"points":[[1000,0.0,0.0,0.0,"mowing",4,5,1],[2000,2.0,0.0,0.0,"mowing",4,5,1],[3000,4.0,0.0,0.0,"mowing",4,5,1]]}
+    artifact = svg.build_session_svg_archive(session); assert artifact is not None; assert artifact["version"] == 2; assert artifact["mowed_area"]["swath_width_m"] == 0.5


### PR DESCRIPTION
Clean 0.4.1-beta2 release candidate. Includes explicit work-target ownership for zone progress/coverage, in-session per-zone cycle boundaries and daily-trail retention, safe unknown encoded cutting-height handling without decoding 316, reported mowing-path width for session footprints, and the beta1 position/channel/private-polling fixes. Release regressions were updated to the beta2 contracts.