### PR TITLE
Release Navimower 0.4.1-beta11 with Zstandard runtime

### DIFF
--- a/.github/release-notes/0.4.1-beta11.md
+++ b/.github/release-notes/0.4.1-beta11.md
@@ -1,0 +1,13 @@
+title: Navimower 0.4.1-beta11
+
+## Zstandard runtime support for hint-error diagnostics
+
+Beta10 identified `/vehicle/vehicle/get-hint-error-compress` as Base64-wrapped Zstandard data on the X390, but Home Assistant did not have a usable Zstandard decoder at runtime.
+
+- Add `zstandard==0.25.0` as an integration runtime requirement so Home Assistant can decompress the vendor payload on Python 3.14 hosts.
+- Keep the existing bounded decoder safety limits and diagnostics sanitization/redaction.
+- Add a regression that Base64 + Zstandard payloads decode into structured JSON and expose error-code candidates.
+- Keep **Problem** and **Error** entity semantics unchanged until field captures show how the decompressed catalog/payload maps to active faults.
+- Keep the endpoint read-only; no mower or map write behavior changes.
+
+After installing beta11, capture **Download diagnostics** while a real problem such as Lifted is active. The `endpoints.errors.data.inspection` block should now include the decompressed result instead of `zstd decoder unavailable`.

--- a/.github/workflows/publish-prerelease.yaml
+++ b/.github/workflows/publish-prerelease.yaml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install test dependencies
-        run: python -m pip install --upgrade pytest voluptuous cryptography pyyaml
+        run: python -m pip install --upgrade pytest voluptuous cryptography pyyaml zstandard==0.25.0
 
       - name: Compile integration
         run: python -m compileall -q custom_components/navimower

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install test dependencies
-        run: python -m pip install --upgrade pytest voluptuous cryptography pyyaml
+        run: python -m pip install --upgrade pytest voluptuous cryptography pyyaml zstandard==0.25.0
 
       - name: Compile integration
         run: python -m compileall -q custom_components/navimower

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -14,7 +14,8 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/vahesoo/NaviMower/issues",
   "requirements": [
-    "navimow-sdk>=0.1.2"
+    "navimow-sdk>=0.1.2",
+    "zstandard==0.25.0"
   ],
-  "version": "0.4.1-beta10"
+  "version": "0.4.1-beta11"
 }

--- a/tests/test_v034_release.py
+++ b/tests/test_v034_release.py
@@ -11,11 +11,13 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_current_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta10"
-    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta10.md").read_text()
-    assert notes.startswith("title: Navimower 0.4.1-beta10")
+    assert manifest["version"] == "0.4.1-beta11"
+    assert "zstandard==0.25.0" in manifest["requirements"]
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta11.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta11")
     assert "get-hint-error-compress" in notes
-    assert "Base64" in notes
+    assert "Zstandard" in notes
+    assert "runtime" in notes
     assert "Problem" in notes
     assert "Error" in notes
 

--- a/tests/test_v041_beta10.py
+++ b/tests/test_v041_beta10.py
@@ -21,9 +21,7 @@ def _probe():
     return module
 
 
-def test_beta10_version_and_notes() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta10"
+def test_beta10_notes_remain_available() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta10.md").read_text()
     assert "get-hint-error-compress" in notes
     assert "Base64" in notes

--- a/tests/test_v041_beta11.py
+++ b/tests/test_v041_beta11.py
@@ -1,0 +1,57 @@
+"""Regression contracts for Navimower 0.4.1-beta11."""
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+from pathlib import Path
+
+import zstandard
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _probe():
+    path = COMPONENT / "error_payload.py"
+    spec = importlib.util.spec_from_file_location("navimower_beta11_error_payload", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_beta11_runtime_dependency_and_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta11"
+    assert "zstandard==0.25.0" in manifest["requirements"]
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta11.md").read_text()
+    assert "Zstandard" in notes
+    assert "runtime" in notes
+    assert "Problem" in notes
+    assert "Error" in notes
+
+
+def test_hint_error_probe_decodes_base64_zstd_json() -> None:
+    probe = _probe()
+    payload = {
+        "errors": [
+            {"code": 6113, "message": "Mower docking error"},
+            {"code": 1105, "message": "Mowing motor stall protection"},
+        ],
+        "catalog": True,
+    }
+    compressed = zstandard.ZstdCompressor().compress(json.dumps(payload).encode())
+    raw = base64.b64encode(compressed).decode()
+    result = probe.inspect_hint_error_payload(raw)
+    assert [layer["operation"] for layer in result["layers"]] == ["base64", "zstd"]
+    assert result["decoded"]["kind"] == "json"
+    assert result["decoded"]["decoded_data"] == payload
+    assert "6113" in result["decoded"]["code_candidates"]
+    assert "1105" in result["decoded"]["code_candidates"]
+
+
+def test_runtime_probe_keeps_problem_entities_diagnostic_only() -> None:
+    coordinator = (COMPONENT / "coordinator.py").read_text()
+    assert "hint catalog is diagnostic only" in coordinator
+    assert "authoritative problem signals are inline private errors, private 0302" in coordinator


### PR DESCRIPTION
Adds `zstandard==0.25.0` as a Home Assistant runtime requirement so the Base64-wrapped Zstandard payload returned by `/vehicle/vehicle/get-hint-error-compress` can be decompressed on Python 3.14 hosts. Updates CI/release dependencies, moves current-version regressions to beta11, adds an explicit Base64+Zstandard JSON decoder regression, and keeps Problem/Error semantics diagnostic-only pending field confirmation. Release notes included.