### PR TITLE
Hotfix Navimower 0.4.1-beta12 for Python 3.14 Zstd

### DIFF
--- a/.github/release-notes/0.4.1-beta12.md
+++ b/.github/release-notes/0.4.1-beta12.md
@@ -1,0 +1,13 @@
+title: Navimower 0.4.1-beta12
+
+## Python 3.14 Zstandard hotfix
+
+This beta fixes the beta11 startup failure on Home Assistant installations running Python 3.14.
+
+- Remove the external `zstandard==0.25.0` runtime requirement that Home Assistant could not resolve for the observed `cp314` environment.
+- Use Python 3.14's built-in `compression.zstd` decoder, which the existing hint-error inspection code already prefers before its optional third-party fallback.
+- Move the integration and release regression workflows to Python 3.14 so the same standard-library decoder path is exercised before publishing.
+- Keep `/vehicle/vehicle/get-hint-error-compress` inspection limits and redaction unchanged.
+- Keep **Problem** and **Error** entity semantics unchanged; the decoded payload remains diagnostic-only until field evidence confirms its meaning.
+
+After upgrading, restart or reload Navimower and download diagnostics while a real problem such as Lifted is active. The Zstandard layer should now decode instead of reporting `zstd decoder unavailable`.

--- a/.github/workflows/publish-prerelease.yaml
+++ b/.github/workflows/publish-prerelease.yaml
@@ -24,10 +24,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install test dependencies
-        run: python -m pip install --upgrade pytest voluptuous cryptography pyyaml zstandard==0.25.0
+        run: python -m pip install --upgrade pytest voluptuous cryptography pyyaml
 
       - name: Compile integration
         run: python -m compileall -q custom_components/navimower

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,10 +21,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install test dependencies
-        run: python -m pip install --upgrade pytest voluptuous cryptography pyyaml zstandard==0.25.0
+        run: python -m pip install --upgrade pytest voluptuous cryptography pyyaml
 
       - name: Compile integration
         run: python -m compileall -q custom_components/navimower

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -14,8 +14,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/vahesoo/NaviMower/issues",
   "requirements": [
-    "navimow-sdk>=0.1.2",
-    "zstandard==0.25.0"
+    "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta11"
+  "version": "0.4.1-beta12"
 }

--- a/tests/test_v034_release.py
+++ b/tests/test_v034_release.py
@@ -11,13 +11,12 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_current_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta11"
-    assert "zstandard==0.25.0" in manifest["requirements"]
-    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta11.md").read_text()
-    assert notes.startswith("title: Navimower 0.4.1-beta11")
-    assert "get-hint-error-compress" in notes
-    assert "Zstandard" in notes
-    assert "runtime" in notes
+    assert manifest["version"] == "0.4.1-beta12"
+    assert "zstandard==0.25.0" not in manifest["requirements"]
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta12.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta12")
+    assert "Python 3.14" in notes
+    assert "compression.zstd" in notes
     assert "Problem" in notes
     assert "Error" in notes
 

--- a/tests/test_v041_beta11.py
+++ b/tests/test_v041_beta11.py
@@ -6,7 +6,7 @@ import importlib.util
 import json
 from pathlib import Path
 
-import zstandard
+from compression import zstd
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
@@ -21,10 +21,7 @@ def _probe():
     return module
 
 
-def test_beta11_runtime_dependency_and_notes() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta11"
-    assert "zstandard==0.25.0" in manifest["requirements"]
+def test_beta11_notes_record_runtime_decoder_attempt() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta11.md").read_text()
     assert "Zstandard" in notes
     assert "runtime" in notes
@@ -41,7 +38,7 @@ def test_hint_error_probe_decodes_base64_zstd_json() -> None:
         ],
         "catalog": True,
     }
-    compressed = zstandard.ZstdCompressor().compress(json.dumps(payload).encode())
+    compressed = zstd.compress(json.dumps(payload).encode())
     raw = base64.b64encode(compressed).decode()
     result = probe.inspect_hint_error_payload(raw)
     assert [layer["operation"] for layer in result["layers"]] == ["base64", "zstd"]

--- a/tests/test_v041_beta12.py
+++ b/tests/test_v041_beta12.py
@@ -1,0 +1,37 @@
+"""Regression contracts for Navimower 0.4.1-beta12."""
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+from pathlib import Path
+
+from compression import zstd
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _probe():
+    path = COMPONENT / "error_payload.py"
+    spec = importlib.util.spec_from_file_location("navimower_beta12_error_payload", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_beta12_uses_python314_stdlib_zstd() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta12"
+    assert all(not requirement.startswith("zstandard") for requirement in manifest["requirements"])
+
+    payload = {"code": 6108, "message": "Mower got stuck"}
+    raw = base64.b64encode(zstd.compress(json.dumps(payload).encode())).decode()
+    result = _probe().inspect_hint_error_payload(raw)
+
+    assert [layer["operation"] for layer in result["layers"]] == ["base64", "zstd"]
+    assert all("decode_error" not in layer for layer in result["layers"])
+    assert result["decoded"]["kind"] == "json"
+    assert result["decoded"]["decoded_data"] == payload
+    assert "6108" in result["decoded"]["code_candidates"]


### PR DESCRIPTION
Fixes beta11 startup failure on Home Assistant/Python 3.14 by removing the external `zstandard==0.25.0` requirement and using the built-in `compression.zstd` decoder already preferred by the integration. Moves regression/release workflows to Python 3.14, updates current-version contracts, keeps beta11 as historical coverage, and adds an explicit stdlib Zstd decoding regression. Problem/Error semantics remain unchanged and diagnostic-only for the hint-error payload.