### PR TITLE
Add beta13 native libzstd fallback

### DIFF
--- a/.github/release-notes/0.4.1-beta13.md
+++ b/.github/release-notes/0.4.1-beta13.md
@@ -1,0 +1,15 @@
+title: Navimower 0.4.1-beta13
+
+## Native Zstandard fallback for hint-error diagnostics
+
+This beta keeps the `get-hint-error-compress` investigation moving on Home Assistant runtimes where neither Python's optional `compression.zstd` module nor the third-party `zstandard` package is available.
+
+- Add a third, dependency-free Zstandard decoder backend using `ctypes` and the system `libzstd` C API.
+- Keep decoder preference conservative: `compression.zstd` first, optional `zstandard` second, native `libzstd` third.
+- Keep the Home Assistant manifest free of a mandatory Zstandard pip requirement, so a missing decoder cannot block Navimower startup.
+- Bound native decompression with the existing 2 MB diagnostic safety limit and reject invalid or oversized frames.
+- Record the successful Zstandard `backend` in the diagnostic layer so field captures show exactly which decoder handled the payload.
+- Preserve Base64 detection, hashes, redaction and decoded JSON/text limits.
+- Keep **Problem** and **Error** entity semantics unchanged. The hint-error payload remains diagnostic-only until real field data confirms how active error codes and texts are represented.
+
+After upgrading, restart or reload Navimower and download diagnostics while a real problem such as Lifted is active. Under `endpoints -> errors -> data -> inspection -> layers`, the Zstandard layer should either identify the decoder backend and expose decoded content, or report a more specific backend-availability/decode error without breaking the integration.

--- a/custom_components/navimower/error_payload.py
+++ b/custom_components/navimower/error_payload.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import base64
 import binascii
 import bz2
+import ctypes
+import ctypes.util
 import hashlib
 import json
 import lzma
@@ -16,6 +18,8 @@ _MAX_INPUT_CHARS = 1_000_000
 _MAX_DECODED_BYTES = 2_000_000
 _MAX_JSON_EXPORT_BYTES = 1_000_000
 _MAX_TEXT_PREVIEW = 2_048
+_ZSTD_CONTENTSIZE_UNKNOWN = (1 << 64) - 1
+_ZSTD_CONTENTSIZE_ERROR = (1 << 64) - 2
 _CODE_RE = re.compile(r"(?<!\d)(\d{4,6})(?!\d)")
 _BASE64_RE = re.compile(r"^[A-Za-z0-9+/=_-]+$")
 _HEX_RE = re.compile(r"^[0-9A-Fa-f]+$")
@@ -99,33 +103,119 @@ def _zlib(data: bytes, wbits: int) -> bytes:
     return out
 
 
-def _decompress(data: bytes, kind: str) -> bytes:
+def _zstd_stdlib(data: bytes) -> bytes:
+    import compression.zstd as zstd  # type: ignore[import-not-found]
+
+    return zstd.decompress(data)
+
+
+def _zstd_third_party(data: bytes) -> bytes:
+    import zstandard  # type: ignore[import-not-found]
+
+    return zstandard.ZstdDecompressor().decompress(
+        data, max_output_size=_MAX_DECODED_BYTES + 1
+    )
+
+
+def _load_libzstd() -> ctypes.CDLL:
+    candidates = [
+        ctypes.util.find_library("zstd"),
+        "libzstd.so.1",
+        "libzstd.so",
+        "libzstd.dylib",
+        "zstd.dll",
+    ]
+    errors: list[str] = []
+    for candidate in dict.fromkeys(item for item in candidates if item):
+        try:
+            return ctypes.CDLL(candidate)
+        except OSError as err:
+            errors.append(f"{candidate}: {err}")
+    detail = "; ".join(errors[-3:]) if errors else "library not found"
+    raise ImportError(f"native libzstd unavailable: {detail}")
+
+
+def _zstd_native(data: bytes) -> bytes:
+    """Decompress one Zstandard frame through the system libzstd C API."""
+    lib = _load_libzstd()
+    size_t = ctypes.c_size_t
+    source = ctypes.create_string_buffer(data)
+    source_ptr = ctypes.cast(source, ctypes.c_void_p)
+
+    lib.ZSTD_getFrameContentSize.argtypes = [ctypes.c_void_p, size_t]
+    lib.ZSTD_getFrameContentSize.restype = ctypes.c_ulonglong
+    frame_size = int(lib.ZSTD_getFrameContentSize(source_ptr, len(data)))
+    if frame_size == _ZSTD_CONTENTSIZE_ERROR:
+        raise ValueError("invalid zstd frame")
+    if frame_size == _ZSTD_CONTENTSIZE_UNKNOWN:
+        if not hasattr(lib, "ZSTD_decompressBound"):
+            raise ValueError("zstd frame size is unknown and decompress bound is unavailable")
+        lib.ZSTD_decompressBound.argtypes = [ctypes.c_void_p, size_t]
+        lib.ZSTD_decompressBound.restype = ctypes.c_ulonglong
+        frame_size = int(lib.ZSTD_decompressBound(source_ptr, len(data)))
+    if frame_size < 0 or frame_size > _MAX_DECODED_BYTES:
+        raise ValueError("decoded output exceeds safety limit")
+
+    capacity = max(frame_size, 1)
+    destination = ctypes.create_string_buffer(capacity)
+    lib.ZSTD_decompress.argtypes = [ctypes.c_void_p, size_t, ctypes.c_void_p, size_t]
+    lib.ZSTD_decompress.restype = size_t
+    lib.ZSTD_isError.argtypes = [size_t]
+    lib.ZSTD_isError.restype = ctypes.c_uint
+    lib.ZSTD_getErrorName.argtypes = [size_t]
+    lib.ZSTD_getErrorName.restype = ctypes.c_char_p
+
+    written = int(
+        lib.ZSTD_decompress(
+            ctypes.cast(destination, ctypes.c_void_p),
+            capacity,
+            source_ptr,
+            len(data),
+        )
+    )
+    if lib.ZSTD_isError(written):
+        raw_name = lib.ZSTD_getErrorName(written)
+        name = raw_name.decode("utf-8", errors="replace") if raw_name else "unknown"
+        raise ValueError(f"libzstd decode failed: {name}")
+    if written > _MAX_DECODED_BYTES:
+        raise ValueError("decoded output exceeds safety limit")
+    return destination.raw[:written]
+
+
+def _zstd(data: bytes) -> tuple[bytes, str]:
+    unavailable: list[str] = []
+    for backend, decoder in (
+        ("compression.zstd", _zstd_stdlib),
+        ("zstandard", _zstd_third_party),
+        ("libzstd", _zstd_native),
+    ):
+        try:
+            return decoder(data), backend
+        except (ImportError, ModuleNotFoundError) as err:
+            unavailable.append(f"{backend}: {err}")
+    detail = "; ".join(unavailable) if unavailable else "no backend available"
+    raise RuntimeError(f"zstd decoder unavailable ({detail})")
+
+
+def _decompress(data: bytes, kind: str) -> tuple[bytes, str | None]:
     if kind == "gzip":
-        return _zlib(data, 16 + zlib.MAX_WBITS)
+        return _zlib(data, 16 + zlib.MAX_WBITS), None
     if kind == "zlib":
-        return _zlib(data, zlib.MAX_WBITS)
+        return _zlib(data, zlib.MAX_WBITS), None
     if kind == "bzip2":
         out = bz2.BZ2Decompressor().decompress(data, max_length=_MAX_DECODED_BYTES + 1)
     elif kind == "xz":
         out = lzma.LZMADecompressor().decompress(data, max_length=_MAX_DECODED_BYTES + 1)
     elif kind == "zstd":
-        try:
-            import compression.zstd as zstd  # type: ignore[import-not-found]
-
-            out = zstd.decompress(data)
-        except ImportError:
-            try:
-                import zstandard  # type: ignore[import-not-found]
-            except ImportError as err:
-                raise RuntimeError("zstd decoder unavailable") from err
-            out = zstandard.ZstdDecompressor().decompress(
-                data, max_output_size=_MAX_DECODED_BYTES + 1
-            )
+        out, backend = _zstd(data)
+        if len(out) > _MAX_DECODED_BYTES:
+            raise ValueError("decoded output exceeds safety limit")
+        return out, backend
     else:
         raise ValueError(f"unsupported compression: {kind}")
     if len(out) > _MAX_DECODED_BYTES:
         raise ValueError("decoded output exceeds safety limit")
-    return out
+    return out, None
 
 
 def _text(data: bytes) -> tuple[str | None, str | None]:
@@ -263,7 +353,7 @@ def inspect_hint_error_payload(
         if kind is None:
             break
         try:
-            decoded = _decompress(raw, kind)
+            decoded, backend = _decompress(raw, kind)
         except Exception as err:  # noqa: BLE001 - report the failed probe diagnostically.
             result["layers"].append(
                 {
@@ -273,14 +363,15 @@ def inspect_hint_error_payload(
                 }
             )
             break
-        result["layers"].append(
-            {
-                "operation": kind,
-                "input_length": len(raw),
-                "output_length": len(decoded),
-                "output_sha256": _sha(decoded),
-            }
-        )
+        layer = {
+            "operation": kind,
+            "input_length": len(raw),
+            "output_length": len(decoded),
+            "output_sha256": _sha(decoded),
+        }
+        if backend:
+            layer["backend"] = backend
+        result["layers"].append(layer)
         raw = decoded
 
     decoded_meta: dict[str, Any] = {

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta12"
+  "version": "0.4.1-beta13"
 }

--- a/tests/test_v034_release.py
+++ b/tests/test_v034_release.py
@@ -11,12 +11,12 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_current_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta12"
+    assert manifest["version"] == "0.4.1-beta13"
     assert "zstandard==0.25.0" not in manifest["requirements"]
-    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta12.md").read_text()
-    assert notes.startswith("title: Navimower 0.4.1-beta12")
-    assert "Python 3.14" in notes
-    assert "compression.zstd" in notes
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta13.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta13")
+    assert "libzstd" in notes
+    assert "ctypes" in notes
     assert "Problem" in notes
     assert "Error" in notes
 

--- a/tests/test_v041_beta12.py
+++ b/tests/test_v041_beta12.py
@@ -1,4 +1,4 @@
-"""Regression contracts for Navimower 0.4.1-beta12."""
+"""Historical regression contracts for Navimower 0.4.1-beta12."""
 from __future__ import annotations
 
 import base64
@@ -23,8 +23,10 @@ def _probe():
 
 def test_beta12_uses_python314_stdlib_zstd() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta12"
     assert all(not requirement.startswith("zstandard") for requirement in manifest["requirements"])
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta12.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta12")
+    assert "compression.zstd" in notes
 
     payload = {"code": 6108, "message": "Mower got stuck"}
     raw = base64.b64encode(zstd.compress(json.dumps(payload).encode())).decode()

--- a/tests/test_v041_beta13.py
+++ b/tests/test_v041_beta13.py
@@ -1,0 +1,65 @@
+"""Regression contracts for Navimower 0.4.1-beta13."""
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+from pathlib import Path
+
+from compression import zstd
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _probe():
+    path = COMPONENT / "error_payload.py"
+    spec = importlib.util.spec_from_file_location("navimower_beta13_error_payload", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_beta13_manifest_has_no_zstd_runtime_requirement() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta13"
+    assert all(not requirement.startswith("zstandard") for requirement in manifest["requirements"])
+
+
+def test_beta13_normal_decoder_reports_backend() -> None:
+    payload = {"code": 6113, "message": "Mower docking error"}
+    raw = base64.b64encode(zstd.compress(json.dumps(payload).encode())).decode()
+    result = _probe().inspect_hint_error_payload(raw)
+
+    assert [layer["operation"] for layer in result["layers"]] == ["base64", "zstd"]
+    assert result["layers"][1]["backend"] == "compression.zstd"
+    assert result["decoded"]["kind"] == "json"
+    assert result["decoded"]["decoded_data"] == payload
+    assert "6113" in result["decoded"]["code_candidates"]
+
+
+def test_beta13_native_backend_is_third_optional_fallback(monkeypatch) -> None:
+    probe = _probe()
+    expected = b'{"code":6108,"message":"Mower got stuck"}'
+
+    def unavailable(_data: bytes) -> bytes:
+        raise ImportError("not available in target runtime")
+
+    monkeypatch.setattr(probe, "_zstd_stdlib", unavailable)
+    monkeypatch.setattr(probe, "_zstd_third_party", unavailable)
+    monkeypatch.setattr(probe, "_zstd_native", lambda _data: expected)
+
+    decoded, backend = probe._zstd(b"zstd-frame-placeholder")
+    assert decoded == expected
+    assert backend == "libzstd"
+
+
+def test_beta13_native_backend_uses_bounded_libzstd_api() -> None:
+    source = (COMPONENT / "error_payload.py").read_text()
+    assert 'ctypes.util.find_library("zstd")' in source
+    assert "ZSTD_getFrameContentSize" in source
+    assert "ZSTD_decompressBound" in source
+    assert "ZSTD_decompress" in source
+    assert "ZSTD_isError" in source
+    assert "_MAX_DECODED_BYTES" in source


### PR DESCRIPTION
Prepare Navimower 0.4.1-beta13 for field testing of `get-hint-error-compress` on Home Assistant runtimes where `compression.zstd` is unavailable. Adds a dependency-free native `libzstd` fallback through `ctypes`, preserves the existing 2 MB decode safety limit, reports the actual Zstd backend in diagnostics, adds beta13 regression coverage and release notes, and leaves Problem/Error semantics unchanged. No mandatory Zstandard pip dependency is added, so decoder availability cannot block integration startup.