### PR TITLE
Add beta14 vendor error catalog discovery

### DIFF
--- a/.github/release-notes/0.4.1-beta14.md
+++ b/.github/release-notes/0.4.1-beta14.md
@@ -1,0 +1,13 @@
+title: Navimower 0.4.1-beta14
+
+## Vendor error catalog and notification discovery
+
+This beta turns the successfully decoded `get-hint-error-compress` payload into a normalized vendor code lookup and focuses passive MQTT discovery on the notification fields needed to correlate live events with that catalog.
+
+- Normalize decoded `vehicleErrorData`, `vehicleEventData`, `mapErrorData` and `warningData` entries into an exact vendor-code lookup containing section, title, content, level, name and update metadata.
+- Cache the latest lookup on the private-cloud client and expose exact code resolution for later Problem/Error integration without guessing relationships between mower state codes and notification/event codes.
+- Include the normalized catalog in diagnostics together with the original decoded payload so field captures can be compared directly.
+- Expand passive MQTT schema observation for `error`, `fault`, `event`, `notification`, `message`, `title`, `warning`, `alarm`, `reason` and code-like fields, including hexadecimal-looking event codes such as `180D`.
+- Add bounded `code_candidate=...` observations to passive discovery so live notification traffic is easier to correlate with vendor catalog entries.
+- Preserve existing redaction, topic/sample limits and opt-in behavior. Passive discovery remains disabled by default.
+- Keep **Problem** and **Error** entity semantics unchanged in this beta. The purpose is to capture at least one real live notification/event code before wiring the catalog into entity state.

--- a/custom_components/navimower/api/__init__.py
+++ b/custom_components/navimower/api/__init__.py
@@ -1,8 +1,10 @@
 """Navimow private cloud API package (crypto + passport + client)."""
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
 
+from ..error_catalog import build_error_catalog, resolve_error_code
 from ..error_payload import inspect_hint_error_payload
 from .client import (
     NavimowAuthError,
@@ -25,10 +27,24 @@ class NavimowCloudClient(_NavimowCloudClient):
             self.tokens.refresh_token,
             self.tokens.uuid,
         )
+        inspection = inspect_hint_error_payload(raw, redactions=redactions)
+        catalog = build_error_catalog(inspection)
+        self._navimow_error_catalog = catalog
         return {
             "endpoint": "/vehicle/vehicle/get-hint-error-compress",
-            "inspection": inspect_hint_error_payload(raw, redactions=redactions),
+            "inspection": inspection,
+            "catalog": deepcopy(catalog),
         }
+
+    @property
+    def error_catalog(self) -> dict[str, Any]:
+        """Return the latest decoded vendor code lookup, if available."""
+        catalog = getattr(self, "_navimow_error_catalog", None)
+        return deepcopy(catalog) if isinstance(catalog, dict) else {}
+
+    def resolve_error_code(self, code: Any) -> list[dict[str, Any]]:
+        """Resolve one exact vendor code against the latest decoded catalog."""
+        return resolve_error_code(getattr(self, "_navimow_error_catalog", None), code)
 
 
 __all__ = [

--- a/custom_components/navimower/discovery.py
+++ b/custom_components/navimower/discovery.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 import hashlib
 import json
+import re
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
@@ -17,12 +18,21 @@ _SENSITIVE_EXACT = {
     "antitheftpoint", "origin_gps", "center_gps", "ne_gps", "sw_gps",
 }
 _OBSERVED_VALUE_KEYS = {
-    "type", "action", "subAction", "vehicleState", "eventCode", "code", "status",
-    "state", "messageType", "notificationType",
+    "type", "action", "subaction", "vehiclestate", "eventcode", "code", "status",
+    "state", "messagetype", "notificationtype", "errorcode", "error_code",
+    "faultcode", "fault_code", "warningcode", "warning_code", "alarmcode",
+    "alarm_code", "event", "eventtype", "event_type", "notification",
+    "message", "title", "reason",
 }
+_SIGNAL_KEY_MARKERS = (
+    "error", "fault", "event", "notification", "message", "title", "warning",
+    "alarm", "reason", "code",
+)
+_CODE_TOKEN_RE = re.compile(r"(?i)(?<![0-9a-f])([0-9a-f]{3,8})(?![0-9a-f])")
 _MAX_DEPTH = 8
 _MAX_ITEMS = 50
 _MAX_STRING = 512
+_MAX_OBSERVED_VALUE = 180
 
 
 def mqtt_discovery_topic(device_id: str) -> str:
@@ -36,8 +46,16 @@ def mqtt_discovery_topics(device_id: str) -> tuple[str, ...]:
     return ("/downlink/#",)
 
 
+def _normalize_key(key: str) -> str:
+    return str(key).strip().lower().replace("-", "_")
+
+
+def _compact_key(key: str) -> str:
+    return "".join(ch for ch in _normalize_key(key) if ch.isalnum())
+
+
 def _is_sensitive_key(key: str) -> bool:
-    normalized = str(key).strip().lower().replace("-", "_")
+    normalized = _normalize_key(key)
     return (
         normalized in _SENSITIVE_EXACT
         or "token" in normalized
@@ -125,12 +143,44 @@ def sanitize_discovery_payload(payload: bytes) -> Any:
     return sanitize_discovery_value(parsed)
 
 
+def _signal_key(key: str) -> bool:
+    compact = _compact_key(key)
+    return compact in {_compact_key(item) for item in _OBSERVED_VALUE_KEYS} or any(
+        marker in compact for marker in _SIGNAL_KEY_MARKERS
+    )
+
+
+def _render_observed(key: str, value: Any) -> str | None:
+    if _is_sensitive_key(key) or isinstance(value, (Mapping, list, tuple, bytes, bytearray)):
+        return None
+    safe = sanitize_discovery_value(value, key=key)
+    if isinstance(safe, (dict, list)):
+        return None
+    rendered = " ".join(str(safe).split())
+    if len(rendered) > _MAX_OBSERVED_VALUE:
+        rendered = rendered[: _MAX_OBSERVED_VALUE - 3] + "..."
+    return rendered
+
+
+def _code_candidates(value: Any) -> set[str]:
+    if value is None or isinstance(value, (Mapping, list, tuple, bytes, bytearray)):
+        return set()
+    text = str(value).upper()
+    out: set[str] = set()
+    for match in _CODE_TOKEN_RE.finditer(text):
+        token = match.group(1).upper()
+        if any(ch.isdigit() for ch in token):
+            out.add(token)
+    return out
+
+
 def structure_summary(value: Any) -> dict[str, list[str]]:
-    """Describe JSON structure without retaining ordinary field values."""
+    """Describe JSON structure and retain bounded notification/error signal values."""
     parsed_types: set[str] = set()
     top_level_keys: set[str] = set()
     key_paths: set[str] = set()
     observed_values: set[str] = set()
+    code_candidates: set[str] = set()
 
     def walk(current: Any, path: str = "", depth: int = 0) -> None:
         if depth >= _MAX_DEPTH:
@@ -145,14 +195,20 @@ def structure_summary(value: Any) -> dict[str, list[str]]:
                 key_paths.add(child_path)
                 if not path:
                     top_level_keys.add(key)
-                if key in _OBSERVED_VALUE_KEYS and isinstance(child, (str, int, float, bool)):
-                    observed_values.add(f"{key}={child}")
+                compact = _compact_key(key)
+                legacy_observed = compact in {_compact_key(item) for item in _OBSERVED_VALUE_KEYS}
+                if (legacy_observed or _signal_key(key)) and isinstance(child, (str, int, float, bool)):
+                    rendered = _render_observed(key, child)
+                    if rendered is not None:
+                        observed_values.add(f"{key}={rendered}")
+                    code_candidates.update(_code_candidates(child))
                 walk(child, child_path, depth + 1)
         elif isinstance(current, (list, tuple)):
             for child in current[:_MAX_ITEMS]:
                 walk(child, f"{path}[]" if path else "[]", depth + 1)
 
     walk(value)
+    observed_values.update(f"code_candidate={code}" for code in code_candidates)
     return {
         "parsed_types": sorted(parsed_types),
         "top_level_keys": sorted(top_level_keys),

--- a/custom_components/navimower/error_catalog.py
+++ b/custom_components/navimower/error_catalog.py
@@ -1,0 +1,106 @@
+"""Normalize Navimow vendor hint/error catalog data for diagnostics and lookup."""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from typing import Any
+
+_CATALOG_SECTIONS = (
+    "vehicleErrorData",
+    "vehicleEventData",
+    "mapErrorData",
+    "warningData",
+)
+_MAX_LOOKUP_ENTRIES = 1024
+
+
+def normalize_vendor_code(value: Any) -> str | None:
+    """Return a stable uppercase vendor code without guessing its meaning."""
+    if value is None:
+        return None
+    text = str(value).strip().upper()
+    if not text or len(text) > 32:
+        return None
+    return text
+
+
+def _clean_text(value: Any, *, limit: int) -> str:
+    text = " ".join(str(value or "").split())
+    return text[:limit]
+
+
+def _entry(section: str, raw: Mapping[str, Any]) -> dict[str, Any] | None:
+    code = normalize_vendor_code(raw.get("error_code"))
+    if not code:
+        return None
+    return {
+        "code": code,
+        "section": section,
+        "title": _clean_text(raw.get("title"), limit=240),
+        "content": _clean_text(raw.get("content"), limit=1000),
+        "level": _clean_text(raw.get("level"), limit=32),
+        "name": _clean_text(raw.get("name"), limit=120),
+        "relate_id": _clean_text(raw.get("relate_id"), limit=32),
+        "updatetime": raw.get("updatetime"),
+    }
+
+
+def build_error_catalog(inspection: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Build a bounded code lookup from a decoded get-hint-error-compress result."""
+    decoded = inspection.get("decoded") if isinstance(inspection, Mapping) else None
+    data = decoded.get("decoded_data") if isinstance(decoded, Mapping) else None
+    if not isinstance(data, Mapping):
+        return {
+            "available": False,
+            "code_count": 0,
+            "section_counts": {},
+            "lookup": {},
+        }
+
+    lookup: dict[str, list[dict[str, Any]]] = {}
+    section_counts: dict[str, int] = {}
+    dropped = 0
+    for section in _CATALOG_SECTIONS:
+        rows = data.get(section)
+        if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes, bytearray)):
+            continue
+        count = 0
+        for raw in rows:
+            if not isinstance(raw, Mapping):
+                continue
+            normalized = _entry(section, raw)
+            if normalized is None:
+                continue
+            count += 1
+            code = normalized["code"]
+            if code not in lookup and len(lookup) >= _MAX_LOOKUP_ENTRIES:
+                dropped += 1
+                continue
+            entries = lookup.setdefault(code, [])
+            if normalized not in entries:
+                entries.append(normalized)
+        section_counts[section] = count
+
+    return {
+        "available": bool(lookup),
+        "code_count": len(lookup),
+        "section_counts": section_counts,
+        "dropped_codes": dropped,
+        "vehicle_update_time": data.get("vehicle_update_time"),
+        "map_update_time": data.get("map_update_time"),
+        "lookup": lookup,
+    }
+
+
+def resolve_error_code(catalog: Mapping[str, Any] | None, code: Any) -> list[dict[str, Any]]:
+    """Resolve one exact vendor code without fuzzy matching or state inference."""
+    normalized = normalize_vendor_code(code)
+    if not normalized or not isinstance(catalog, Mapping):
+        return []
+    lookup = catalog.get("lookup")
+    if not isinstance(lookup, Mapping):
+        return []
+    matches = lookup.get(normalized)
+    if not isinstance(matches, list):
+        return []
+    return deepcopy(matches)

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta13"
+  "version": "0.4.1-beta14"
 }

--- a/tests/test_v034_release.py
+++ b/tests/test_v034_release.py
@@ -11,12 +11,12 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_current_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta13"
+    assert manifest["version"] == "0.4.1-beta14"
     assert "zstandard==0.25.0" not in manifest["requirements"]
-    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta13.md").read_text()
-    assert notes.startswith("title: Navimower 0.4.1-beta13")
-    assert "libzstd" in notes
-    assert "ctypes" in notes
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta14.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta14")
+    assert "vendor code lookup" in notes.lower()
+    assert "Passive discovery" in notes
     assert "Problem" in notes
     assert "Error" in notes
 

--- a/tests/test_v041_beta13.py
+++ b/tests/test_v041_beta13.py
@@ -21,10 +21,12 @@ def _probe():
     return module
 
 
-def test_beta13_manifest_has_no_zstd_runtime_requirement() -> None:
+def test_beta13_release_keeps_zstd_optional() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta13"
     assert all(not requirement.startswith("zstandard") for requirement in manifest["requirements"])
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta13.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta13")
+    assert "libzstd" in notes
 
 
 def test_beta13_normal_decoder_reports_backend() -> None:

--- a/tests/test_v041_beta14.py
+++ b/tests/test_v041_beta14.py
@@ -1,0 +1,104 @@
+"""Regression contracts for Navimower 0.4.1-beta14."""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _load(name: str, filename: str):
+    path = COMPONENT / filename
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_beta14_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta14"
+    assert all(not requirement.startswith("zstandard") for requirement in manifest["requirements"])
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta14.md").read_text()
+    assert "vehicleErrorData" in notes
+    assert "vehicleEventData" in notes
+    assert "180D" in notes
+
+
+def test_beta14_builds_exact_catalog_for_fault_and_event_codes() -> None:
+    catalog_module = _load("navimower_beta14_error_catalog", "error_catalog.py")
+    inspection = {
+        "decoded": {
+            "decoded_data": {
+                "vehicleErrorData": [
+                    {
+                        "error_code": "6113",
+                        "title": "Failed to dock (error: 6113)",
+                        "content": "Check the charging station.",
+                        "level": "0",
+                        "name": "",
+                        "relate_id": "0",
+                        "updatetime": 1782219533,
+                    }
+                ],
+                "vehicleEventData": [
+                    {
+                        "error_code": "180d",
+                        "title": "Mower got stuck or lifted",
+                        "content": "Find the mower and place it on the lawn.",
+                        "level": "0",
+                        "name": "",
+                        "relate_id": "0",
+                        "updatetime": 1782219584,
+                    }
+                ],
+                "warningData": [],
+                "vehicle_update_time": "1784886451",
+            }
+        }
+    }
+
+    catalog = catalog_module.build_error_catalog(inspection)
+    assert catalog["available"] is True
+    assert catalog["code_count"] == 2
+    assert catalog["section_counts"]["vehicleErrorData"] == 1
+    assert catalog["section_counts"]["vehicleEventData"] == 1
+    assert catalog_module.resolve_error_code(catalog, "6113")[0]["title"].startswith("Failed to dock")
+    event = catalog_module.resolve_error_code(catalog, "180D")[0]
+    assert event["section"] == "vehicleEventData"
+    assert event["title"] == "Mower got stuck or lifted"
+    assert catalog_module.resolve_error_code(catalog, "0302") == []
+
+
+def test_beta14_passive_discovery_retains_error_notification_signals() -> None:
+    discovery = _load("navimower_beta14_discovery", "discovery.py")
+    summary = discovery.structure_summary(
+        {
+            "notificationType": "alarm",
+            "eventCode": "180D",
+            "title": "Mower got stuck or lifted",
+            "message": "Failed to dock (error: 6113)",
+            "nested": {"error_code": 1105, "faultReason": "blade motor stalled"},
+            "device_id": "secret-device-id",
+        }
+    )
+    observed = set(summary["observed_type_values"])
+    assert "eventCode=180D" in observed
+    assert "code_candidate=180D" in observed
+    assert "code_candidate=6113" in observed
+    assert "code_candidate=1105" in observed
+    assert any(item.startswith("title=Mower got stuck or lifted") for item in observed)
+    assert any(item.startswith("message=Failed to dock") for item in observed)
+    assert not any("secret-device-id" in item for item in observed)
+
+
+def test_beta14_catalog_is_cached_by_private_cloud_wrapper_contract() -> None:
+    source = (COMPONENT / "api" / "__init__.py").read_text()
+    assert "build_error_catalog(inspection)" in source
+    assert "self._navimow_error_catalog = catalog" in source
+    assert "def error_catalog" in source
+    assert "def resolve_error_code" in source
+    assert '"catalog": deepcopy(catalog)' in source


### PR DESCRIPTION
Prepare Navimower 0.4.1-beta14 for field correlation of live notification/event traffic with the decoded vendor catalog. Adds a normalized exact-code lookup for vehicle errors/events/map errors/warnings, caches it on the private-cloud client, expands passive MQTT schema observation for error/fault/event/notification/message/title/reason/code fields including hexadecimal event codes such as 180D, and adds bounded code candidates. Problem/Error entity semantics remain unchanged until a real live event code is captured. No new runtime dependency is added.