### PR TITLE
Navimower 0.4.1-beta16 live error semantics

### DIFF
--- a/.github/release-notes/0.4.1-beta16.md
+++ b/.github/release-notes/0.4.1-beta16.md
@@ -1,0 +1,17 @@
+title: Navimower 0.4.1-beta16
+
+Beta16 promotes the state/error behavior proven by H215 field captures while keeping beta15 transition diagnostics available for further reverse engineering.
+
+- Maps private-cloud `0103` to **Idle**. Home Assistant's lawn-mower activity has no Idle enum, so the native mower activity uses Paused while the Navimower State sensor exposes Idle.
+- Keeps `0211` as Paused, `0210` as Mowing, `0220` as Returning, `0302` as the separate Lifted safety state, and recognizes `0301` as the generic active numeric-fault state.
+- Stops treating official MQTT numeric `vehicleState=3` as docked/charging. Field captures show the same coarse stopped value with both `isIdel`/`0103` and `isPaused`/`0211`.
+- Uses live plain-JSON `index2.error_data` as the authoritative active numeric-fault detail source. The existing Error sensor now exposes the vendor `error_code`, title, content, kind and source as attributes and uses the vendor title as its state.
+- Verified field examples include `6108` (`Mower got stuck`) and `6106` (`Motion planning error`), both reported as `0301` plus a populated `error_data` object.
+- Treats MQTT named state `Error` as an early fault trigger and immediately makes `index2`/`auth-list` due for refresh, so Home Assistant does not wait for the normal private-cloud TTL before resolving the numeric code and text.
+- Uses MQTT `Self-Checking` and transitions away from Error/Lifted as fast refresh triggers for clear/recovery confirmation. No unobserved private-cloud Self-Checking state code is invented.
+- Keeps ordinary Lifted as `0302` + safety problem with no fabricated numeric/event code. The integration does **not** translate it to `180D` or `6007` unless a future live source actually reports such a code.
+- STOP/Paused remains a control state and does not become a Problem merely because MQTT numeric state is 3.
+- The compressed hint-error catalog remains diagnostic/fallback data; active numeric errors no longer depend on decoding it because the current error object is already supplied uncompressed by `index2`.
+- No new pip requirements are added.
+
+Please keep passive discovery and beta15 transition capture enabled while testing additional errors; new numeric faults should now appear directly on the Error sensor with their vendor code/title/content.

--- a/custom_components/navimower/beta16_runtime.py
+++ b/custom_components/navimower/beta16_runtime.py
@@ -1,0 +1,256 @@
+"""Beta16 runtime corrections derived from live H215 state/error captures.
+
+This module deliberately keeps the beta15 diagnostic capture intact while
+promoting only field observations that are now repeated/proven enough for
+public entity semantics:
+
+* private state 0103 is Idle (not docked),
+* official MQTT numeric vehicleState=3 is a coarse stopped state and must not
+  imply docked/charging by itself,
+* private state 0301 is the generic numeric-fault state,
+* index2.error_data is the authoritative source for active numeric fault code,
+  title and content,
+* official MQTT named state Error is an early trigger for an immediate index2
+  refresh; Self-Checking / leaving Error triggers a clear-confirmation refresh.
+
+Lifted remains a separate safety state (0302) unless a real numeric error is
+reported in error_data. No 180D/6007 mapping is invented here.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import replace
+from typing import Any
+
+from . import const as _const
+from . import coordinator as _coordinator
+
+_STATE_IDLE = "0103"
+_STATE_FAULT = "0301"
+_STATE_LIFTED = "0302"
+_MQTT_STOPPED = 3
+
+
+def _first_error(raw: dict[str, Any]) -> dict[str, Any] | None:
+    index2 = raw.get("index2") or {}
+    errors = (
+        index2.get("error_data")
+        or index2.get("errorData")
+        or index2.get("error_list")
+        or []
+    )
+    if not isinstance(errors, list) or not errors or not isinstance(errors[0], dict):
+        return None
+    first = errors[0]
+    code = first.get("error_code") or first.get("errorCode") or first.get("code")
+    title = first.get("title") or first.get("desc") or first.get("message")
+    content = (
+        first.get("content")
+        or first.get("detail")
+        or first.get("description")
+    )
+    return {
+        "code": str(code).strip() if code is not None else None,
+        "title": str(title).strip() if title is not None else None,
+        "content": str(content).strip() if content is not None else None,
+    }
+
+
+def _raw_for_existing_parser(raw: dict[str, Any], error: dict[str, Any] | None) -> dict[str, Any]:
+    """Let the existing parser consume the live vendor title without data loss."""
+    if not error:
+        return raw
+    index2 = raw.get("index2")
+    if not isinstance(index2, dict):
+        return raw
+    errors = index2.get("error_data")
+    if not isinstance(errors, list) or not errors or not isinstance(errors[0], dict):
+        return raw
+    first = dict(errors[0])
+    # beta15's parser understands message/desc/code. Prefer the vendor title,
+    # falling back to content/code, while retaining every original field.
+    if not (first.get("desc") or first.get("message") or first.get("code")):
+        first["message"] = error.get("title") or error.get("content") or error.get("code")
+    copied_errors = list(errors)
+    copied_errors[0] = first
+    copied_index2 = dict(index2)
+    copied_index2["error_data"] = copied_errors
+    copied_raw = dict(raw)
+    copied_raw["index2"] = copied_index2
+    return copied_raw
+
+
+def _copy_problem_details(snapshot: dict[str, Any], problem: dict[str, Any] | None) -> None:
+    if not isinstance(problem, dict):
+        return
+    for key in ("error_code", "error_title", "error_content", "error_kind"):
+        if snapshot.get(key) is None and problem.get(key) is not None:
+            snapshot[key] = problem.get(key)
+
+
+def _mark_endpoints_due(coordinator: Any, *keys: str) -> None:
+    """Bypass only the endpoint TTL; the normal coordinator performs the read."""
+    for key in keys:
+        status = coordinator._endpoint_status.get(key)  # noqa: SLF001 - beta shim
+        if isinstance(status, dict):
+            status["last_attempt_mono"] = None
+
+
+def _install_error_sensor_attributes() -> None:
+    """Expose live code/title/content on the existing Error sensor."""
+    from . import sensor as sensor_platform
+
+    def attrs(data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "code": data.get("error_code"),
+            "title": data.get("error_title"),
+            "content": data.get("error_content"),
+            "kind": data.get("error_kind"),
+            "source": data.get("problem_source"),
+            "state_code": data.get("state_code"),
+        }
+
+    sensor_platform.SENSORS = tuple(
+        replace(description, attrs_fn=attrs)
+        if description.key == "error_text"
+        else description
+        for description in sensor_platform.SENSORS
+    )
+
+
+def install_beta16_runtime() -> None:
+    """Install beta16 state/error semantics once per interpreter."""
+    cls = _coordinator.NavimowCoordinator
+    if getattr(cls, "_beta16_runtime_installed", False):
+        return
+
+    # The coordinator imported these mutable objects by reference, so mutating
+    # them fixes both the constants module and already-imported coordinator code.
+    _const.VEHICLE_STATE_TO_ACTIVITY[_STATE_IDLE] = _const.ACTIVITY_PAUSED
+    _const.VEHICLE_STATE_LABELS[_STATE_IDLE] = "Idle"
+    _const.VEHICLE_STATE_TO_ACTIVITY[_STATE_FAULT] = _const.ACTIVITY_ERROR
+    _const.VEHICLE_STATE_LABELS[_STATE_FAULT] = "Error"
+
+    # Observed H215 MQTT numeric state 3 accompanies both isIdel/0103 and
+    # isPaused/0211. It is therefore neutral stopped context, not charging.
+    _const.MQTT_DOCKED_STATES.discard(_MQTT_STOPPED)
+
+    original_parse = cls._parse
+    original_apply_problem = cls._apply_problem_latch
+    original_ingest_state = cls.ingest_mqtt_state
+
+    def parse(self: Any, raw: dict[str, Any]) -> dict[str, Any]:
+        previous_problem = deepcopy(self._last_problem)  # noqa: SLF001
+        live_error = _first_error(raw)
+        snapshot = original_parse(self, _raw_for_existing_parser(raw, live_error))
+        state_code = str(snapshot.get("state_code") or "")
+
+        if live_error:
+            title = live_error.get("title") or live_error.get("content") or live_error.get("code") or "Error"
+            snapshot["error_text"] = title
+            snapshot["error_code"] = live_error.get("code")
+            snapshot["error_title"] = live_error.get("title") or title
+            snapshot["error_content"] = live_error.get("content")
+            snapshot["error_kind"] = "fault"
+        elif state_code == _STATE_LIFTED or self._fresh_mqtt_named_state() == "isLifted":  # noqa: SLF001
+            snapshot["error_code"] = None
+            snapshot["error_title"] = "Lifted"
+            snapshot["error_content"] = None
+            snapshot["error_kind"] = "safety"
+            snapshot["error_text"] = "Lifted"
+        elif state_code == _STATE_FAULT and snapshot.get("error"):
+            # Preserve details across a short endpoint race where 0301 remains
+            # visible but error_data momentarily disappears.
+            prior = previous_problem if isinstance(previous_problem, dict) else {}
+            snapshot["error_code"] = prior.get("error_code")
+            snapshot["error_title"] = prior.get("error_title") or snapshot.get("error_text") or "Error"
+            snapshot["error_content"] = prior.get("error_content")
+            snapshot["error_kind"] = "fault"
+        else:
+            snapshot["error_code"] = None
+            snapshot["error_title"] = None
+            snapshot["error_content"] = None
+            snapshot["error_kind"] = None
+
+        if self._problem_latched and isinstance(self._last_problem, dict):  # noqa: SLF001
+            self._last_problem.update(  # noqa: SLF001
+                {
+                    "error_code": snapshot.get("error_code"),
+                    "error_title": snapshot.get("error_title"),
+                    "error_content": snapshot.get("error_content"),
+                    "error_kind": snapshot.get("error_kind"),
+                    "error_text": snapshot.get("error_text"),
+                }
+            )
+            snapshot["last_problem"] = deepcopy(self._last_problem)  # noqa: SLF001
+        return snapshot
+
+    def apply_problem_latch(self: Any, snapshot: dict[str, Any]) -> None:
+        original_apply_problem(self, snapshot)
+        if self._problem_latched:  # noqa: SLF001
+            _copy_problem_details(snapshot, self._last_problem)  # noqa: SLF001
+
+    def ingest_mqtt_state(self: Any, state: dict[str, Any]) -> None:
+        if not isinstance(state, dict):
+            return original_ingest_state(self, state)
+        state_name = str(state.get("state") or "").strip()
+        previous_named = self._fresh_mqtt_named_state()  # noqa: SLF001
+        important = bool(
+            state_name in {"Error", "Self-Checking", "isLifted"}
+            or previous_named in {"Error", "isLifted"}
+        )
+        if important:
+            _mark_endpoints_due(self, "index2", "auth_list")
+
+        result = original_ingest_state(self, state)
+
+        if state_name == "Error":
+            self._set_problem_latch(  # noqa: SLF001
+                True,
+                source="mqtt_state",
+                state="Problem",
+                state_code=(
+                    _STATE_FAULT
+                    if str((self.data or {}).get("state_code") or "") == _STATE_FAULT
+                    else ""
+                ),
+                error_text="Error",
+            )
+            if isinstance(self._last_problem, dict):  # noqa: SLF001
+                self._last_problem.update(  # noqa: SLF001
+                    {
+                        "error_code": None,
+                        "error_title": "Error",
+                        "error_content": None,
+                        "error_kind": "fault",
+                    }
+                )
+            snapshot = dict(self.data or self._bootstrap_snapshot())  # noqa: SLF001
+            snapshot["state"] = "Error"
+            snapshot["activity"] = _const.ACTIVITY_ERROR
+            snapshot["error"] = True
+            snapshot["error_text"] = "Error"
+            snapshot["error_code"] = None
+            snapshot["error_title"] = "Error"
+            snapshot["error_content"] = None
+            snapshot["error_kind"] = "fault"
+            snapshot["docked"] = False
+            snapshot["docked_source"] = "mqtt_error_state"
+            snapshot["last_problem"] = deepcopy(self._last_problem)  # noqa: SLF001
+            self.async_set_updated_data(snapshot)
+            self.request_fast_refresh("MQTT state changed to Error")
+        elif state_name == "Self-Checking":
+            self.request_fast_refresh("MQTT entered Self-Checking")
+        elif previous_named == "Error" and state_name and state_name != "Error":
+            self.request_fast_refresh("MQTT state changed away from Error")
+        elif previous_named == "isLifted" and state_name and state_name != "isLifted":
+            # beta15/original code already asks for a refresh; this call is
+            # throttled, but the forced endpoint due flag remains in place.
+            self.request_fast_refresh("MQTT state changed away from isLifted")
+        return result
+
+    cls._parse = parse
+    cls._apply_problem_latch = apply_problem_latch
+    cls.ingest_mqtt_state = ingest_mqtt_state
+    cls._beta16_runtime_installed = True
+    _install_error_sensor_attributes()

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta15"
+  "version": "0.4.1-beta16"
 }

--- a/custom_components/navimower/services.py
+++ b/custom_components/navimower/services.py
@@ -28,12 +28,14 @@ from .const import (
     encode_partition_ids,
     mow_setup,
 )
+from .beta16_runtime import install_beta16_runtime
 from .model_support import supports_ordered_zone_mowing
 from .state_transition_capture import install_state_transition_capture
 
-# Beta15 diagnostic hook: capture private-cloud state immediately around MQTT
-# state/action transitions without changing any public Problem/Error semantics.
+# Keep beta15's diagnostic transition capture for further field testing, then
+# layer the beta16 public state/error semantics over the already-wrapped methods.
 install_state_transition_capture()
+install_beta16_runtime()
 
 SERVICE_SET_SCHEDULE = "set_schedule"
 SERVICE_MOW = "mow"
@@ -53,8 +55,8 @@ _WEEKDAY_TO_NUM = {
 
 _PERIOD_SCHEMA = vol.Schema(
     {
-        vol.Required("start"): cv.string,  # "HH:MM"
-        vol.Required("end"): cv.string,  # "HH:MM"
+        vol.Required("start"): cv.string,
+        vol.Required("end"): cv.string,
         vol.Optional("zones", default=list): vol.All(cv.ensure_list, [vol.Coerce(int)]),
     }
 )
@@ -71,9 +73,7 @@ SET_SCHEDULE_SCHEMA = vol.Schema(
 MOW_SCHEMA = vol.Schema(
     {
         vol.Optional("device_id"): cv.string,
-        # Region ids to mow; empty = all available zones.
         vol.Optional("zones", default=list): vol.All(cv.ensure_list, [vol.Coerce(int)]),
-        # True = riparti da zero (clear progress); False = continua.
         vol.Optional("reset", default=True): cv.boolean,
     }
 )
@@ -109,9 +109,6 @@ def async_setup_services(hass: HomeAssistant) -> None:
 
     def _resolve_coordinator(call: ServiceCall):
         store = hass.data.get(DOMAIN) or {}
-        # ``hass.data[DOMAIN]`` also contains private helper state such as the
-        # options snapshot. Only config-entry coordinators are valid service
-        # targets.
         coords = [
             value
             for key, value in store.items()
@@ -151,7 +148,6 @@ def async_setup_services(hass: HomeAssistant) -> None:
                 raise ServiceValidationError(
                     f"Invalid schedule time; use HH:MM: {err}"
                 ) from err
-            # An end of "00:00" means end-of-day (24:00 = slot 96), never 0.
             if end_min == 0:
                 end_min = 1440
             if start_min % 15 or end_min % 15:
@@ -192,7 +188,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
                 enabled,
                 periods,
             )
-        except Exception as err:  # noqa: BLE001 - surface a clean error to the UI
+        except Exception as err:
             raise HomeAssistantError(f"Navimow set_schedule failed: {err}") from err
 
     async def _export_diagnostics(call: ServiceCall) -> None:
@@ -203,7 +199,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
                 coordinator,
                 include_compressed_map=call.data["include_compressed_map"],
             )
-        except Exception as err:  # noqa: BLE001
+        except Exception as err:
             raise HomeAssistantError(f"Navimower diagnostics export failed: {err}") from err
         persistent_notification.async_create(
             hass,
@@ -275,7 +271,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
                 coordinator.start_new_mowing_cycle(
                     zones, source="navimower.mow_reset"
                 )
-        except Exception as err:  # noqa: BLE001 - surface a clean error to the UI
+        except Exception as err:
             coordinator.record_mow_command_error(err)
             coordinator.clear_pending_activity()
             if requested_ordered:

--- a/tests/test_v041_beta15.py
+++ b/tests/test_v041_beta15.py
@@ -1,4 +1,4 @@
-"""Regression contracts for Navimower 0.4.1-beta15."""
+"""Historical regression contracts for Navimower 0.4.1-beta15."""
 from __future__ import annotations
 
 import json
@@ -8,11 +8,12 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta15_manifest_and_release_notes() -> None:
+def test_beta15_release_notes_remain_historical() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta15"
+    assert manifest["version"].startswith("0.4.1-") or manifest["version"] == "0.4.1"
     assert all(not requirement.startswith("zstandard") for requirement in manifest["requirements"])
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta15.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta15")
     assert "state transition" in notes.lower()
     assert "index2" in notes
     assert "boolState" in notes

--- a/tests/test_v041_beta16.py
+++ b/tests/test_v041_beta16.py
@@ -1,0 +1,66 @@
+"""Regression contracts for Navimower 0.4.1-beta16."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta16_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta16"
+    assert all(not requirement.startswith("zstandard") for requirement in manifest["requirements"])
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta16.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta16")
+    for phrase in ("0103", "0301", "error_data", "Self-Checking", "6106", "6108"):
+        assert phrase in notes
+
+
+def test_beta16_runtime_state_and_error_contract() -> None:
+    source = (COMPONENT / "beta16_runtime.py").read_text()
+    ast.parse(source)
+    assert '_STATE_IDLE = "0103"' in source
+    assert '_STATE_FAULT = "0301"' in source
+    assert '_STATE_LIFTED = "0302"' in source
+    assert '_MQTT_STOPPED = 3' in source
+    assert 'MQTT_DOCKED_STATES.discard(_MQTT_STOPPED)' in source
+    assert 'VEHICLE_STATE_LABELS[_STATE_IDLE] = "Idle"' in source
+    assert 'VEHICLE_STATE_LABELS[_STATE_FAULT] = "Error"' in source
+    assert '"error_code"' in source
+    assert '"error_title"' in source
+    assert '"error_content"' in source
+    assert '"error_kind"' in source
+    assert '"fault"' in source
+    assert '"safety"' in source
+
+
+def test_beta16_mqtt_error_forces_private_detail_refresh() -> None:
+    source = (COMPONENT / "beta16_runtime.py").read_text()
+    assert 'state_name == "Error"' in source
+    assert 'state_name == "Self-Checking"' in source
+    assert '_mark_endpoints_due(self, "index2", "auth_list")' in source
+    assert 'request_fast_refresh("MQTT state changed to Error")' in source
+    assert 'request_fast_refresh("MQTT entered Self-Checking")' in source
+    assert 'request_fast_refresh("MQTT state changed away from Error")' in source
+
+
+def test_beta16_keeps_lifted_separate_from_numeric_fault_codes() -> None:
+    source = (COMPONENT / "beta16_runtime.py").read_text()
+    lifted_block = source.split("elif state_code == _STATE_LIFTED", 1)[1].split(
+        "elif state_code == _STATE_FAULT", 1
+    )[0]
+    assert 'snapshot["error_code"] = None' in lifted_block
+    assert 'snapshot["error_kind"] = "safety"' in lifted_block
+    assert "180D" in source  # documentation explicitly says it is not mapped
+    assert "6007" in source  # documentation explicitly says it is not mapped
+
+
+def test_beta16_runtime_is_installed_after_transition_capture() -> None:
+    services = (COMPONENT / "services.py").read_text()
+    assert "from .beta16_runtime import install_beta16_runtime" in services
+    assert services.index("install_state_transition_capture()") < services.index(
+        "install_beta16_runtime()"
+    )


### PR DESCRIPTION
## Summary

- map proven private state `0103` to Idle and stop treating MQTT numeric state `3` as docked/charging
- recognize `0301` as the generic numeric-fault state while keeping `0302` Lifted as a separate safety state
- use live plain-JSON `index2.error_data` for active fault code/title/content (`6108`, `6106` field-tested)
- expose code/title/content/kind/source on the existing Error sensor
- use MQTT named `Error`, `Self-Checking`, and recovery transitions to make `index2`/`auth-list` immediately due for refresh
- retain beta15 transition diagnostics for further error simulations
- add beta16 regression contracts and release notes

No new dependency is added and no unobserved Lifted `180D`/`6007` mapping is fabricated.