### PR TITLE
Navimower 0.4.1-beta17 i2 AWD capabilities and route dedupe

### DIFF
--- a/.github/release-notes/0.4.1-beta17.md
+++ b/.github/release-notes/0.4.1-beta17.md
@@ -1,0 +1,14 @@
+title: Navimower 0.4.1-beta17 — i2 AWD capabilities and route/history dedupe
+
+This beta adds the first capability profile derived from a real **Navimow i208 AWD** diagnostic and the i2 user manual.
+
+- Adds i2 AWD controls for **Eco mode**, Narrow zone adapt, Advanced slope mode, Grass pattern enhancement, Progress retention, Progress retention duration, Mowing cycle interval, Headlight and Night animal protection.
+- Extends Terrain adapt, Edge sense and Edge sense mode to the observed i2 AWD family.
+- Uses the manual-facing names **Channel Obstacle Avoidance**, **Animal friendly**, **Traction Control System (TCS)**, **Camera-assisted positioning** and **Positioning mode** where the corresponding vendor fields are known.
+- Exposes both observed i2 light controls as **Light brightness** and **Light brightness (alternate)** so field testing can establish which control is authoritative on each firmware.
+- Adds **Global cutting height** when the mower reports both a global `height` and `mowingHeightList`. The slider range and step come from the mower's supported-height list; writes use the same transactional MowerSettingBean path as other numeric settings.
+- Corrects default battery setting ranges to **5–20% return battery** and **70–100% charging limit**, while preferring each mower's reported `batteryConfig` min/max limits when available.
+- Fixes the previously observed **route/history dedupe** issue: repeated deliveries of one vendor pose no longer create extra trail points merely because MQTT state/action/zone metadata changes between values and `null`. Missing metadata enriches the existing point instead.
+- Compacts already persisted beta15/beta16 duplicate route samples when session files are loaded. A real activity transition such as mowing → error remains a separate history point.
+
+Several i2-only controls are intentionally experimental in beta17 because their vendor field names are visible but their final app labels/wire semantics still need live before/after testing. Please report which of the two light controls and the new terrain/progress controls visibly change the mower/app state.

--- a/custom_components/navimower/beta16_runtime.py
+++ b/custom_components/navimower/beta16_runtime.py
@@ -24,6 +24,7 @@ from typing import Any
 
 from . import const as _const
 from . import coordinator as _coordinator
+from .beta17_runtime import install_beta17_runtime
 
 _STATE_IDLE = "0103"
 _STATE_FAULT = "0301"
@@ -122,6 +123,7 @@ def install_beta16_runtime() -> None:
     """Install beta16 state/error semantics once per interpreter."""
     cls = _coordinator.NavimowCoordinator
     if getattr(cls, "_beta16_runtime_installed", False):
+        install_beta17_runtime()
         return
 
     # The coordinator imported these mutable objects by reference, so mutating
@@ -254,3 +256,4 @@ def install_beta16_runtime() -> None:
     cls.ingest_mqtt_state = ingest_mqtt_state
     cls._beta16_runtime_installed = True
     _install_error_sensor_attributes()
+    install_beta17_runtime()

--- a/custom_components/navimower/beta17_runtime.py
+++ b/custom_components/navimower/beta17_runtime.py
@@ -1,0 +1,469 @@
+"""Beta17 capability extensions from the first captured Navimow i2 AWD.
+
+The i208 AWD diagnostic proves a second modern capability family whose settings
+are mostly field-identical to existing H215 experiments but were hidden by
+model-name gates. Beta17 deliberately exposes the observed user-facing fields
+for field testing, keeps both observed light controls available on i2 AWD, uses
+vendor battery limits when supplied, and adds a global cutting-height number
+when the mower reports a real height plus a supported-height list.
+
+Names that are documented in the i2 manual use Navimow terminology. Settings
+whose only evidence is the vendor field name remain intentionally literal and
+experimental until live before/after captures confirm their exact app labels.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import replace
+from math import gcd
+from typing import Any
+
+from homeassistant.components.number import NumberMode
+from homeassistant.const import EntityCategory, PERCENTAGE, UnitOfLength, UnitOfTime
+
+from . import coordinator as _coordinator
+from . import history as _history
+from .route_dedupe import append_or_coalesce, compact_route_points
+
+_I2_AWD_MODELS = ("i205 AWD", "i206 AWD", "i208 AWD", "i210 AWD")
+_EXTENDED_TERRAIN_MODELS = ("H215", *_I2_AWD_MODELS)
+
+
+def _merge_models(existing: tuple[str, ...], additions: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys((*existing, *additions)))
+
+
+def _raw(data: dict[str, Any], key: str) -> Any:
+    raw = data.get("raw") or {}
+    set_list = raw.get("set_list") or {}
+    return set_list.get(key) if isinstance(set_list, dict) else None
+
+
+def _device_info(data: dict[str, Any]) -> dict[str, Any]:
+    raw = data.get("raw") or {}
+    value = raw.get("device_info") or {}
+    return value if isinstance(value, dict) else {}
+
+
+def _battery_config(data: dict[str, Any]) -> dict[str, Any]:
+    device = _device_info(data)
+    nonstandard = device.get("nonstandardVehicleConfig") or {}
+    config = nonstandard.get("batteryConfig") or {}
+    return config if isinstance(config, dict) else {}
+
+
+def _as_float(value: Any, fallback: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(fallback)
+
+
+def _height_options(data: dict[str, Any]) -> list[int]:
+    values = _device_info(data).get("mowingHeightList") or []
+    out: list[int] = []
+    for value in values if isinstance(values, list) else []:
+        try:
+            parsed = int(float(value))
+        except (TypeError, ValueError):
+            continue
+        if 10 <= parsed <= 150 and parsed not in out:
+            out.append(parsed)
+    return sorted(out)
+
+
+def _height_step(values: list[int]) -> int:
+    differences = [right - left for left, right in zip(values, values[1:]) if right > left]
+    if not differences:
+        return 1
+    step = differences[0]
+    for value in differences[1:]:
+        step = gcd(step, value)
+    return max(1, step)
+
+
+def _install_switch_capabilities() -> None:
+    from . import switch as platform
+
+    rewritten = []
+    for description in platform.SWITCHES:
+        if description.key in {"terrain_adapt", "edge_sense"}:
+            description = replace(
+                description,
+                models=_merge_models(description.models, _I2_AWD_MODELS),
+            )
+        elif description.key == "obstacle_avoidance":
+            description = replace(
+                description,
+                name="Channel Obstacle Avoidance",
+                translation_key=None,
+            )
+        elif description.key == "animal_protection":
+            description = replace(
+                description,
+                name="Animal friendly",
+                translation_key=None,
+            )
+        elif description.key == "traction_control":
+            description = replace(
+                description,
+                name="Traction Control System (TCS)",
+                translation_key=None,
+            )
+        elif description.key == "efls":
+            description = replace(
+                description,
+                name="Camera-assisted positioning",
+                translation_key=None,
+            )
+        rewritten.append(description)
+
+    existing = {description.key for description in rewritten}
+    extras = (
+        platform.NavimowSwitchDescription(
+            key="eco_mode",
+            name="Eco mode",
+            icon="mdi:leaf-circle-outline",
+            entity_category=EntityCategory.CONFIG,
+            value_fn=lambda s: None,
+            raw_read_key="powerSaveShutdownSwitch",
+            write_key="powerSaveShutdownSwitch",
+            iot=True,
+            numeric=True,
+            models=_I2_AWD_MODELS,
+        ),
+        platform.NavimowSwitchDescription(
+            key="narrow_zone_adapt",
+            name="Narrow zone adapt",
+            icon="mdi:arrow-collapse-horizontal",
+            entity_category=EntityCategory.CONFIG,
+            value_fn=lambda s: None,
+            raw_read_key="narrowZoneAdaptSwitch",
+            write_key="narrowZoneAdaptSwitch",
+            iot=True,
+            numeric=True,
+            models=_I2_AWD_MODELS,
+        ),
+        platform.NavimowSwitchDescription(
+            key="advanced_slope_mode",
+            name="Advanced slope mode",
+            icon="mdi:slope-uphill",
+            entity_category=EntityCategory.CONFIG,
+            value_fn=lambda s: None,
+            raw_read_key="advancedSlopeMode",
+            write_key="advancedSlopeMode",
+            iot=True,
+            numeric=True,
+            models=_I2_AWD_MODELS,
+        ),
+        platform.NavimowSwitchDescription(
+            key="grass_pattern_enhancement",
+            name="Grass pattern enhancement",
+            icon="mdi:grass",
+            entity_category=EntityCategory.CONFIG,
+            value_fn=lambda s: None,
+            raw_read_key="grassPatternEnhancement",
+            write_key="grassPatternEnhancement",
+            iot=True,
+            numeric=True,
+            models=_I2_AWD_MODELS,
+        ),
+        platform.NavimowSwitchDescription(
+            key="progress_retention",
+            name="Progress retention",
+            icon="mdi:progress-clock",
+            entity_category=EntityCategory.CONFIG,
+            value_fn=lambda s: None,
+            raw_read_key="progressRetentionSwitch",
+            write_key="progressRetentionSwitch",
+            iot=True,
+            numeric=True,
+            models=_I2_AWD_MODELS,
+        ),
+        platform.NavimowSwitchDescription(
+            key="headlight",
+            name="Headlight",
+            icon="mdi:car-light-high",
+            entity_category=EntityCategory.CONFIG,
+            value_fn=lambda s: None,
+            raw_read_key="headlightSwitch",
+            write_key="headlightSwitch",
+            iot=True,
+            numeric=True,
+            models=_I2_AWD_MODELS,
+        ),
+        platform.NavimowSwitchDescription(
+            key="night_animal_protection",
+            name="Night animal protection",
+            icon="mdi:weather-night-partly-cloudy",
+            entity_category=EntityCategory.CONFIG,
+            value_fn=lambda s: None,
+            raw_read_key="nightAnimalProtection",
+            write_key="nightAnimalProtection",
+            iot=True,
+            numeric=True,
+            models=_I2_AWD_MODELS,
+        ),
+    )
+    platform.SWITCHES = tuple(rewritten) + tuple(
+        description for description in extras if description.key not in existing
+    )
+
+
+def _install_select_capabilities() -> None:
+    from . import select as platform
+
+    rewritten = []
+    for description in platform.SETTING_SELECTS:
+        if description.key == "night_light_level":
+            description = replace(
+                description,
+                name="Light brightness",
+                models=_merge_models(description.models, _I2_AWD_MODELS),
+            )
+        elif description.key == "light_brightness":
+            description = replace(
+                description,
+                name="Light brightness (alternate)",
+                models=_merge_models(description.models, _I2_AWD_MODELS),
+            )
+        elif description.key == "edge_sense_mode":
+            description = replace(
+                description,
+                models=_merge_models(description.models, _I2_AWD_MODELS),
+            )
+        rewritten.append(description)
+
+    existing = {description.key for description in rewritten}
+    positioning = platform.NavimowSelectDescription(
+        key="positioning_mode",
+        name="Positioning mode",
+        icon="mdi:crosshairs-gps",
+        entity_category=EntityCategory.CONFIG,
+        value_fn=lambda s: None,
+        raw_read_key="rtkDataSource",
+        write_key="rtkDataSource",
+        # i2 AWD is antenna-free Network RTK by default; the captured mower
+        # reports rtkDataSource=1, leaving 0 as the Local RTK alternative.
+        value_map={"Network RTK": 1, "Local RTK": 0},
+        robot_numeric=True,
+        models=_I2_AWD_MODELS,
+    )
+    platform.SETTING_SELECTS = tuple(rewritten) + (
+        () if positioning.key in existing else (positioning,)
+    )
+
+
+def _install_number_capabilities() -> None:
+    from . import number as platform
+
+    rewritten = []
+    for description in platform.NUMBERS:
+        if description.key == "return_battery_level":
+            description = replace(
+                description,
+                native_min_value=5,
+                native_max_value=20,
+                native_step=5,
+            )
+        elif description.key == "charging_limit":
+            description = replace(
+                description,
+                native_min_value=70,
+                native_max_value=100,
+                native_step=5,
+            )
+        rewritten.append(description)
+
+    existing = {description.key for description in rewritten}
+    extras = (
+        platform.NavimowNumberDescription(
+            key="cutting_height",
+            name="Global cutting height",
+            icon="mdi:arrow-expand-vertical",
+            entity_category=EntityCategory.CONFIG,
+            native_unit_of_measurement=UnitOfLength.MILLIMETERS,
+            native_min_value=20,
+            native_max_value=70,
+            native_step=5,
+            mode=NumberMode.SLIDER,
+            value_fn=lambda s: None,
+            raw_read_key="height",
+            write_key="height",
+            robot_hex=True,
+        ),
+        platform.NavimowNumberDescription(
+            key="progress_retention_duration",
+            name="Progress retention duration",
+            icon="mdi:progress-clock",
+            entity_category=EntityCategory.CONFIG,
+            native_unit_of_measurement=UnitOfTime.HOURS,
+            native_min_value=1,
+            native_max_value=168,
+            native_step=1,
+            mode=NumberMode.SLIDER,
+            value_fn=lambda s: None,
+            raw_read_key="progressRetentionDuration",
+            write_key="progressRetentionDuration",
+            robot_hex=True,
+        ),
+        platform.NavimowNumberDescription(
+            key="mowing_cycle_interval",
+            name="Mowing cycle interval",
+            icon="mdi:calendar-sync",
+            entity_category=EntityCategory.CONFIG,
+            native_unit_of_measurement=UnitOfTime.DAYS,
+            native_min_value=1,
+            native_max_value=7,
+            native_step=1,
+            mode=NumberMode.SLIDER,
+            value_fn=lambda s: None,
+            raw_read_key="cycleMowingTimeSetting",
+            write_key="cycleMowingTimeSetting",
+            robot_hex=True,
+        ),
+    )
+    platform.NUMBERS = tuple(rewritten) + tuple(
+        description for description in extras if description.key not in existing
+    )
+
+    original_wire_value = platform._wire_value
+
+    def wire_value(description: Any, data: dict[str, Any]) -> int | None:
+        if description.key == "cutting_height" and not _height_options(data):
+            return None
+        return original_wire_value(description, data)
+
+    platform._wire_value = wire_value
+
+    number_cls = platform.NavimowNumber
+    original_init = number_cls.__init__
+
+    def init(self: Any, coordinator: Any, description: Any) -> None:
+        original_init(self, coordinator, description)
+        data = coordinator.data or {}
+        if description.key in {"return_battery_level", "charging_limit"}:
+            config = _battery_config(data)
+            if description.key == "return_battery_level":
+                self._attr_native_min_value = _as_float(
+                    config.get("returnBatteryLevelMin"), description.native_min_value
+                )
+                self._attr_native_max_value = _as_float(
+                    config.get("returnBatteryLevelMax"), description.native_max_value
+                )
+            else:
+                self._attr_native_min_value = _as_float(
+                    config.get("chargingLimitMin"), description.native_min_value
+                )
+                self._attr_native_max_value = _as_float(
+                    config.get("chargingLimitMax"), description.native_max_value
+                )
+            self._attr_native_step = float(description.native_step or 1)
+        elif description.key == "cutting_height":
+            heights = _height_options(data)
+            if heights:
+                self._attr_native_min_value = float(min(heights))
+                self._attr_native_max_value = float(max(heights))
+                self._attr_native_step = float(_height_step(heights))
+
+    number_cls.__init__ = init
+
+
+def _install_history_dedupe() -> None:
+    cls = _history.NavimowerHistory
+
+    def append_point_locked(
+        session: dict[str, Any],
+        *,
+        position: dict[str, Any],
+        pose_time: Any,
+        heading: Any,
+        activity: str,
+        mqtt_vehicle_state: int | None,
+        mqtt_action: int | None,
+        physical_zone_id: int | None,
+    ) -> None:
+        x = _history._as_float(position.get("x"))  # noqa: SLF001
+        y = _history._as_float(position.get("y"))  # noqa: SLF001
+        if x is None or y is None:
+            return
+        sample = [
+            _history._timestamp_ms(pose_time),  # noqa: SLF001
+            x,
+            y,
+            _history._as_float(  # noqa: SLF001
+                heading if heading is not None else position.get("heading")
+            ),
+            str(activity or "unknown"),
+            mqtt_vehicle_state,
+            mqtt_action,
+            physical_zone_id,
+        ]
+        append_or_coalesce(session.setdefault("points", []), sample)
+
+    cls._append_point_locked = staticmethod(append_point_locked)
+
+    original_merge = _history._merge_session_records  # noqa: SLF001
+
+    def merge_session_records(
+        previous: dict[str, Any], continuation: dict[str, Any]
+    ) -> dict[str, Any]:
+        merged = original_merge(previous, continuation)
+        merged["points"] = compact_route_points(merged.get("points"))
+        return merged
+
+    _history._merge_session_records = merge_session_records  # noqa: SLF001
+
+    original_load_session = cls._async_load_session_file
+
+    async def load_session_file(self: Any, session_id: str) -> dict[str, Any] | None:
+        session = await original_load_session(self, session_id)
+        if session is None:
+            return None
+        before = session.get("points") or []
+        after = compact_route_points(before)
+        if len(after) != len(before):
+            session["points"] = after
+            changed = getattr(self, "_beta17_compacted_session_ids", set())
+            changed.add(session_id)
+            self._beta17_compacted_session_ids = changed
+            await self._session_store_for(session_id).async_save(deepcopy(session))
+        return session
+
+    cls._async_load_session_file = load_session_file
+
+    original_load = cls.async_load
+
+    async def async_load(self: Any) -> None:
+        await original_load(self)
+        changed = set(getattr(self, "_beta17_compacted_session_ids", set()))
+        if not changed:
+            return
+        with self._lock:
+            for session_id in changed:
+                session = self._cache.get(session_id)
+                if session is not None:
+                    self._update_active_metadata_locked(session)
+            self._trail_revision = max(
+                self._sequence,
+                sum(
+                    _history._as_int(item.get("point_count")) or 0  # noqa: SLF001
+                    for item in self._sessions
+                ),
+            )
+        await self._index_store.async_save(self._index_data())
+        self._beta17_compacted_session_ids = set()
+
+    cls.async_load = async_load
+
+
+def install_beta17_runtime() -> None:
+    """Install beta17 i2 capability and route-history corrections once."""
+    cls = _coordinator.NavimowCoordinator
+    if getattr(cls, "_beta17_runtime_installed", False):
+        return
+    _install_switch_capabilities()
+    _install_select_capabilities()
+    _install_number_capabilities()
+    _install_history_dedupe()
+    cls._beta17_runtime_installed = True

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta16"
+  "version": "0.4.1-beta17"
 }

--- a/custom_components/navimower/route_dedupe.py
+++ b/custom_components/navimower/route_dedupe.py
@@ -1,0 +1,73 @@
+"""Pure helpers for coalescing duplicate Navimower route samples.
+
+A vendor pose is identified by timestamp, X/Y, heading and activity. MQTT
+state/action and resolved zone are observation metadata and may legitimately be
+missing from one delivery and present in another. Metadata-only differences
+must enrich the retained point instead of creating duplicate trail geometry.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+_POSE_IDENTITY_FIELDS = 5
+_METADATA_FIELDS = (5, 6, 7)
+
+
+def _same_pose_identity(left: list[Any], right: list[Any]) -> bool:
+    """Return whether two detail points describe the same vendor pose/state."""
+    return (
+        len(left) >= _POSE_IDENTITY_FIELDS
+        and len(right) >= _POSE_IDENTITY_FIELDS
+        and left[:_POSE_IDENTITY_FIELDS] == right[:_POSE_IDENTITY_FIELDS]
+    )
+
+
+def _enrich_metadata(retained: list[Any], incoming: list[Any]) -> None:
+    """Fill missing route metadata without replacing known observations."""
+    target_len = max(len(retained), len(incoming), max(_METADATA_FIELDS) + 1)
+    if len(retained) < target_len:
+        retained.extend([None] * (target_len - len(retained)))
+    for index in _METADATA_FIELDS:
+        value = incoming[index] if index < len(incoming) else None
+        if retained[index] is None and value is not None:
+            retained[index] = value
+
+
+def append_or_coalesce(points: list[list[Any]], sample: list[Any]) -> bool:
+    """Append a new route sample, or enrich the identical latest vendor pose.
+
+    Returns True only when route geometry gained a point. A metadata-only
+    enrichment returns False so map trail revision counters do not churn.
+    """
+    if points and isinstance(points[-1], list) and _same_pose_identity(points[-1], sample):
+        _enrich_metadata(points[-1], sample)
+        return False
+    points.append(list(sample))
+    return True
+
+
+def compact_route_points(points: list[Any] | None) -> list[list[Any]]:
+    """Coalesce persisted duplicate pose identities while preserving order.
+
+    This also repairs beta15/beta16 history where the same private-cloud pose was
+    retained repeatedly as MQTT context alternated between values such as 4/5
+    and None/None. Different activities remain separate points even at the same
+    timestamp/location so real mowing/error transitions are not erased.
+    """
+    compacted: list[list[Any]] = []
+    by_identity: dict[tuple[Any, ...], list[Any]] = {}
+    for raw in points or []:
+        if not isinstance(raw, list):
+            continue
+        point = list(raw)
+        if len(point) < _POSE_IDENTITY_FIELDS:
+            compacted.append(point)
+            continue
+        identity = tuple(point[:_POSE_IDENTITY_FIELDS])
+        retained = by_identity.get(identity)
+        if retained is not None:
+            _enrich_metadata(retained, point)
+            continue
+        compacted.append(point)
+        by_identity[identity] = point
+    return compacted

--- a/tests/test_v041_beta16.py
+++ b/tests/test_v041_beta16.py
@@ -11,7 +11,9 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_beta16_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta16"
+    version = manifest["version"]
+    assert version.startswith("0.4.1-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 16
     assert all(not requirement.startswith("zstandard") for requirement in manifest["requirements"])
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta16.md").read_text()
     assert notes.startswith("title: Navimower 0.4.1-beta16")

--- a/tests/test_v041_beta17.py
+++ b/tests/test_v041_beta17.py
@@ -1,0 +1,128 @@
+"""Regression contracts for Navimower 0.4.1-beta17."""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _load_route_dedupe():
+    path = COMPONENT / "route_dedupe.py"
+    spec = importlib.util.spec_from_file_location("navimower_route_dedupe_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_beta17_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta17"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta17.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta17")
+    for phrase in (
+        "i208 AWD",
+        "Global cutting height",
+        "charging",
+        "route/history",
+        "Eco mode",
+    ):
+        assert phrase in notes
+
+
+def test_beta17_runtime_exposes_i2_awds_observed_settings() -> None:
+    source = (COMPONENT / "beta17_runtime.py").read_text()
+    ast.parse(source)
+    for model in ("i205 AWD", "i206 AWD", "i208 AWD", "i210 AWD"):
+        assert model in source
+    for vendor_key in (
+        "powerSaveShutdownSwitch",
+        "narrowZoneAdaptSwitch",
+        "advancedSlopeMode",
+        "grassPatternEnhancement",
+        "progressRetentionSwitch",
+        "progressRetentionDuration",
+        "cycleMowingTimeSetting",
+        "terrainAdaptSwitch",
+        "edgeSense",
+        "edgeSenselevel",
+        "lightIntensity",
+        "nightLightLevel",
+        "rtkDataSource",
+    ):
+        assert vendor_key in source
+    for manual_name in (
+        "Eco mode",
+        "Channel Obstacle Avoidance",
+        "Animal friendly",
+        "Traction Control System (TCS)",
+        "Camera-assisted positioning",
+        "Positioning mode",
+    ):
+        assert manual_name in source
+
+
+def test_beta17_battery_limits_and_global_cutting_height_are_dynamic() -> None:
+    source = (COMPONENT / "beta17_runtime.py").read_text()
+    assert 'key="return_battery_level"' in source
+    assert "native_max_value=20" in source
+    assert 'key="charging_limit"' in source
+    assert "native_min_value=70" in source
+    for key in (
+        "returnBatteryLevelMin",
+        "returnBatteryLevelMax",
+        "chargingLimitMin",
+        "chargingLimitMax",
+        "mowingHeightList",
+    ):
+        assert key in source
+    assert 'key="cutting_height"' in source
+    assert 'name="Global cutting height"' in source
+    assert 'raw_read_key="height"' in source
+    assert 'write_key="height"' in source
+    assert "_height_step" in source
+
+
+def test_route_point_metadata_only_changes_coalesce_and_enrich() -> None:
+    module = _load_route_dedupe()
+    points = [[1786303702000, -93.0, -8.75, -1.885, "error", 4, 5, None]]
+    appended = module.append_or_coalesce(
+        points,
+        [1786303702000, -93.0, -8.75, -1.885, "error", None, None, 73],
+    )
+    assert appended is False
+    assert len(points) == 1
+    assert points[0][5:8] == [4, 5, 73]
+
+    appended = module.append_or_coalesce(
+        points,
+        [1786303702000, -93.0, -8.75, -1.885, "mowing", 4, 5, 73],
+    )
+    assert appended is True
+    assert len(points) == 2
+
+
+def test_persisted_beta15_beta16_route_duplicates_are_compacted() -> None:
+    module = _load_route_dedupe()
+    raw = [
+        [1786303702000, -93.0, -8.75, -1.885, "error", 4, 5, None],
+        [1786303702000, -93.0, -8.75, -1.885, "error", None, None, None],
+        [1786303702000, -93.0, -8.75, -1.885, "error", 4, 5, 73],
+        [1786303702000, -93.0, -8.75, -1.885, "mowing", 4, 5, 73],
+    ]
+    compacted = module.compact_route_points(raw)
+    assert len(compacted) == 2
+    assert compacted[0][5:8] == [4, 5, 73]
+    assert compacted[1][4] == "mowing"
+
+
+def test_beta17_runtime_is_chained_after_beta16() -> None:
+    source = (COMPONENT / "beta16_runtime.py").read_text()
+    assert "from .beta17_runtime import install_beta17_runtime" in source
+    assert source.rindex("_install_error_sensor_attributes()") < source.rindex(
+        "install_beta17_runtime()"
+    )

--- a/tests/test_v041_beta17.py
+++ b/tests/test_v041_beta17.py
@@ -19,6 +19,13 @@ def _load_route_dedupe():
     return module
 
 
+def _capability_source() -> str:
+    return "\n".join(
+        (COMPONENT / filename).read_text()
+        for filename in ("beta17_runtime.py", "switch.py", "select.py", "number.py")
+    )
+
+
 def test_beta17_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
     assert manifest["version"] == "0.4.1-beta17"
@@ -35,8 +42,9 @@ def test_beta17_manifest_and_release_notes() -> None:
 
 
 def test_beta17_runtime_exposes_i2_awds_observed_settings() -> None:
-    source = (COMPONENT / "beta17_runtime.py").read_text()
-    ast.parse(source)
+    runtime = (COMPONENT / "beta17_runtime.py").read_text()
+    ast.parse(runtime)
+    source = _capability_source()
     for model in ("i205 AWD", "i206 AWD", "i208 AWD", "i210 AWD"):
         assert model in source
     for vendor_key in (
@@ -67,7 +75,7 @@ def test_beta17_runtime_exposes_i2_awds_observed_settings() -> None:
 
 
 def test_beta17_battery_limits_and_global_cutting_height_are_dynamic() -> None:
-    source = (COMPONENT / "beta17_runtime.py").read_text()
+    source = _capability_source()
     assert 'key="return_battery_level"' in source
     assert "native_max_value=20" in source
     assert 'key="charging_limit"' in source


### PR DESCRIPTION
## What changed
- add the first i2 AWD capability layer from the captured i208 AWD diagnostic and official i2 terminology
- expose both observed i2 light controls for field testing
- add Eco mode, terrain/edge, narrow-zone, slope, pattern, progress-retention, positioning and related i2 controls
- add a global cutting-height slider with mower-reported range/step
- use mower-reported battery min/max values, with corrected 5–20% return and 70–100% charging defaults
- coalesce metadata-only duplicate route samples and compact persisted beta15/beta16 duplicates on load

## Why
The new i208 AWD diagnostic exposes settings and capability ranges not covered by the H215/X390-specific gates. It also confirms that the old static battery ranges are too broad. Separately, diagnostics showed identical vendor poses being retained repeatedly when MQTT metadata alternated between populated and null values.

## Validation
The PR adds beta17 regression contracts including executable pure-Python route-dedupe tests. Normal repository CI/release checks should compile the integration and run the full pytest suite before merge/release.