### PR TITLE
Navimower 0.4.1-beta18 position fallback and gate safety

### DIFF
--- a/.github/release-notes/0.4.1-beta18.md
+++ b/.github/release-notes/0.4.1-beta18.md
@@ -1,0 +1,23 @@
+title: Navimower 0.4.1-beta18
+
+Navimower 0.4.1-beta18 adds a freshness-aware navigation position fallback for error, idle and degraded MQTT pose states.
+
+## Changed
+
+- Fresh official MQTT X/Y remains authoritative whenever available.
+- When the MQTT pose stream stops, private-cloud X/Y can keep Current physical zone and Current channel useful instead of immediately falling back to `Position unavailable`.
+- Private-cloud pose freshness is based on the mower/vendor `report_time`, not on when Home Assistant happened to poll the endpoint.
+- Stale private-cloud coordinates are display-only. They never override a fresh MQTT pose and are not allowed to make gate safety decisions.
+- Fresh private-cloud X/Y may act as a Gate / Gate-area fallback while MQTT pose is unavailable.
+- An already-open gate is not closed/cleared from the first private-cloud arrival/outside sample. Two distinct fresh vendor position reports must confirm the cloud transition before the latch may release.
+- Gate-area OFF transitions under cloud fallback use the same two-report confirmation, while an inside observation may keep/open presence immediately.
+- Current physical zone attributes now expose the selected position source, source age, stale state and MQTT pose validity.
+- Gate diagnostics expose position source/age and whether private-cloud fallback is active.
+
+## Multi-mower documentation
+
+- Corrects the README: several mower config entries may use one dedicated shared private-cloud account.
+- Entries using the same private-cloud account share the integration's stable app/device identity so parallel entries do not invalidate each other merely because the account is shared.
+- Each mower still has its own Navimower config entry, entities, map and history.
+
+No config-entry or options migration is required. Restart Home Assistant after updating and supervise the first physical-gate fallback test before relying on it unattended.

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ for making the original project available to the community.
 ## Recommended account arrangement
 
 Use a dedicated shared Navimow account for the private app-cloud session and
-share the mower to it from the primary account:
+share the mower or mowers to it from their primary owner accounts:
 
 ```text
-Primary account  -> official phone app and Smart Home OAuth
+Owner account(s) -> official phone app and Smart Home OAuth
 Shared account   -> Navimower private-cloud login only
 ```
 
@@ -58,15 +58,15 @@ long as both can access the same mower. Navimower matches the mower by its store
 identity before starting MQTT.
 
 > [!IMPORTANT]
-> For multiple mowers, use a separate dedicated private-cloud account for each
-> Navimower config entry. Reusing one private-cloud account across parallel
-> entries is currently unsupported and has caused session invalidation during
-> field testing.
+> Multiple mower config entries may use the **same dedicated private-cloud
+> account**. Add each mower as its own Navimower config entry. Entries that use
+> the same private-cloud account automatically converge on one stable app/device
+> identity, preventing parallel entries from invalidating each other merely
+> because the account is shared.
 
-Multiple-mower support is present: each mower can be added as its own Navimower
-config entry and receives its own entities, map and history. This area is still
-experimental and needs further development and broader testing, especially when
-several mowers are accessed through the same private-cloud account.
+This shared-account arrangement has been field-tested with three mowers. Each
+mower still receives its own entities, map and history, while the private-cloud
+login identity is shared at account scope.
 
 ## Main features
 
@@ -134,7 +134,8 @@ individually in Home Assistant `.storage`.
 
 ### Physical zones, mapped Channels, Gate areas and gates
 
-- current physical zone derived from fresh MQTT `X/Y` and decoded polygons;
+- current physical zone resolved from fresh MQTT `X/Y`, then private-cloud
+  `X/Y`, then a last-known display value;
 - target zone kept separate from the physical zone;
 - current mapped Channel detection;
 - zone-transition sensor;
@@ -146,9 +147,17 @@ individually in Home Assistant `.storage`.
 - gate-required sensor remains latched through the configured arrival delay.
 
 The intention-based gate sensor can open a gate before the mower reaches it.
-Gate areas remain available as a precise physical fallback. Gate and Gate-area
-safety uses only a fresh MQTT position; stale private-cloud fallback coordinates
-are never used to issue a false physical close signal.
+Fresh MQTT pose is always authoritative. If MQTT X/Y is unavailable, a recent
+private-cloud pose may be used as a Gate / Gate-area fallback. Cloud freshness
+is measured from the mower/vendor `report_time`, not from the Home Assistant HTTP
+poll time. Stale private-cloud coordinates are display-only and never override a
+fresh MQTT pose or issue a physical close decision.
+
+For an already-open gate, a cloud fallback does not close or clear the latch on
+the first arrival/outside sample. Two distinct fresh private-cloud position
+reports must confirm the transition. Gate-area OFF transitions use the same
+two-report rule. This intentionally prefers a gate remaining open slightly
+longer over closing from a single delayed cloud coordinate.
 
 When mowing is started from Home Assistant with an explicit zone list, the
 clicked zone order is sent unchanged and the first requested zone is latched
@@ -160,15 +169,13 @@ configured close delay expires.
 
 Normal empty navigation states are exposed as readable values (`No active
 target`, `Not in channel`, or a last-known/stale physical zone) rather than
-generic `unknown`. Current channel keeps its last confirmed display value when
-the pose stream ages instead of alternating with `Position unavailable`; a
-confirmed dock is reported as `Not in channel`. The sensor exposes source,
-staleness and pose age, while all Gate and Gate-area safety decisions continue
-to require a fresh MQTT position. During a brief start, pause or dock
-acknowledgement, the lawn-mower entity preserves the explicit command activity
-instead of falling back to a false Docked state. Target and gate attributes
-include the chosen source, command age, direction and pose validity for
-troubleshooting.
+generic `unknown`. Current physical zone and Current channel expose the selected
+position source, source age and stale state. The `Live position valid` diagnostic
+remains specifically about a fresh official MQTT pose. During a brief start,
+pause or dock acknowledgement, the lawn-mower entity preserves the explicit
+command activity instead of falling back to a false Docked state. Target and gate
+attributes include the chosen source, command age, direction and pose validity
+for troubleshooting.
 
 ### Mower entities and controls
 
@@ -228,12 +235,12 @@ Assistant generates the final entity IDs from the mower and entity names.
 | Zone Area, Mowed area, Last mowed and Last completed | Optional supporting entities for each zone | Created per zone and disabled by default |
 | Cutting height | Current global/effective cutting height | Models reporting a trustworthy remote height; field-tested on H215 |
 | Current physical zone, Target zone and Current channel | Physical location, intended destination and mapped-channel state | Decoded map plus live/private position data |
-| Zone transition | Previous and current physical zone transition | Mowers with decoded zones and fresh pose data |
+| Zone transition | Previous and current physical zone transition | Mowers with decoded zones and usable position context |
 | Position X/Y, Heading and source/age | Local map pose and source diagnostics | Mowers reporting position data |
 | Schedule and Next mow | Parsed weekly schedule, zones and next planned start | When schedule data is reported |
 | Blades life and Chassis life | Maintenance reminder percentage and runtime details | When maintenance data is reported |
 | Connectivity and diagnostics | Private-cloud, OAuth, MQTT, stream, signal and source status | All configured mowers; detailed fields depend on available sources |
-| Gate area and Gate required | Fresh-pose presence and intent-based gate automation state | Only for configured Gate areas or zone-pair gates |
+| Gate area and Gate required | MQTT-primary presence/intent with fresh private-cloud fallback | Only for configured Gate areas or zone-pair gates |
 | Map data and SVG camera | Lightweight API metadata and renderable map image | Mowers with decoded map data |
 
 #### Setting controls
@@ -313,19 +320,18 @@ credentials before reconnecting.
 Navimower treats MQTT transport and the live position stream as separate health
 signals. `MQTT connected` means the broker connection is open; `Live position
 valid` means a real X/Y packet has arrived within the freshness window. A broker
-can remain connected while the location subscription is silent.
+can remain connected while the location subscription is silent, including while
+the mower is stopped in some error or idle states.
 
 While the mower is active, a five-second watchdog checks the pose stream. When
 the latest pose is more than 25 seconds old, Navimower first re-subscribes to the
-location topic. If no pose arrives within 10 seconds, it rebuilds only the MQTT
-client with increasing backoff. The watchdog and prolonged startup-retry loop
-are registered as Home Assistant background tasks, so they do not delay
-integration startup. The config entry, entities, active session and map APIs
-stay loaded during recovery.
+location topic. If no pose arrives within 10 seconds, it keeps the useful MQTT
+state/progress transport and lets position fall back independently instead of
+letting a missing pose overwrite the rest of MQTT state.
 
 | Data | Preferred source | Fallback |
 | --- | --- | --- |
-| X/Y, heading and exact route | official MQTT | private-cloud location |
+| X/Y, heading and exact route | official MQTT | private-cloud location for current position; exact dense route is not invented |
 | live activity changes | official MQTT | private-cloud `index2` |
 | battery while mowing/returning | fresh official MQTT state | private-cloud SOC, then last-known |
 | battery while docked/charging | private-cloud SOC | fresh MQTT state, then last-known |
@@ -336,8 +342,9 @@ stay loaded during recovery.
 | Map area | decoded map-zone geometry | persisted map cache |
 | Route progress | official MQTT/vendor route counter | unavailable; diagnostic only |
 | map, zones, settings and schedule | private cloud | persisted/local cache |
-| Current channel display | fresh MQTT pose | confirmed dock or last-known display value |
-| physical Gate-area/gate safety | fresh MQTT only | unavailable, never stale X/Y |
+| Current physical zone display | fresh MQTT pose | private-cloud X/Y, then last-known display value |
+| Current channel display | fresh MQTT pose | private-cloud X/Y, confirmed dock or last-known display value |
+| physical Gate-area/gate safety | fresh MQTT pose | fresh private-cloud pose by vendor `report_time`; stale cloud is display-only and cloud close/clear needs two distinct confirming reports |
 
 Private-cloud polling is currently intentionally aggressive while field testing:
 
@@ -359,9 +366,8 @@ does not interpolate synthetic battery percentages.
 Reauthentication is started only for a real authentication rejection. The
 diagnostic `Position source` sensor shows whether current X/Y came from `mqtt`
 or `private_cloud`; `MQTT position stream` shows states such as `live`,
-`resubscribing`, `rebuilding` or `backoff`. Battery, progress, area and Current
-channel entities expose their selected source and freshness context as
-attributes.
+`resubscribing`, `pose_degraded` or `idle`. Battery, progress, area and navigation
+entities expose their selected source and freshness context as attributes.
 
 ## Navimower Map Card
 
@@ -478,10 +484,25 @@ safety logic or automatic-close behaviour.
 ### Gate areas
 
 Gate areas are optional local-coordinate rectangles managed with Add/Edit/Delete
-steps. They can describe a gate passage or any other area that needs exact
-physical presence from fresh MQTT coordinates.
+steps. They can describe a gate passage or any other area that needs physical
+presence. Fresh MQTT coordinates remain primary; a recent private-cloud pose may
+be used when MQTT pose is unavailable. A cloud-based OFF transition requires two
+distinct fresh vendor position reports, and stale cloud coordinates remain
+display-only.
 
 ## Upgrade notes
+
+### v0.4.1-beta18
+
+- Current physical zone and Current channel now use fresh MQTT first, then
+  private-cloud X/Y, then last-known display context.
+- Fresh private-cloud X/Y may back up Gate and Gate-area logic while MQTT pose is
+  unavailable; stale cloud coordinates never override MQTT or close a gate.
+- Cloud-based gate close/clear and Gate-area OFF require two distinct confirming
+  vendor position reports.
+- Multiple mowers may share one dedicated private-cloud account; account-sharing
+  entries automatically use one stable app/device identity.
+- No configuration migration is required. Restart Home Assistant after updating.
 
 ### v0.3.4
 
@@ -535,7 +556,7 @@ physical presence from fresh MQTT coordinates.
   immediately and waits for low new-cycle telemetry.
 - Current channel no longer alternates with `Position unavailable` only because
   the idle pose exceeded its freshness window. Gate safety remains fresh-pose
-  only.
+  only in that historical release; beta18 adds a guarded private-cloud fallback.
 - Total area and the main public telemetry values survive short source outages
   and Home Assistant restarts.
 - No configuration migration or Map API change is required. Restart Home
@@ -652,10 +673,9 @@ earlier by the user.
 - This is an **alpha release** and has not been tested across all mower models,
   accounts, firmware versions or regions.
 - Current OAuth/private endpoints target the European/FRA service.
-- A dedicated private-cloud shared account is strongly recommended. Reusing
-  one private-cloud account across parallel entries is currently unsupported.
-- Multiple-mower support is available through separate config entries, but it
-  remains experimental and needs further development and broader field testing.
+- A dedicated private-cloud shared account is strongly recommended; multiple
+  mower config entries may use that same account and share one stable app/device
+  identity.
 - Exact state codes and some settings remain firmware-specific.
 - The standalone map card does not currently render temporary doodles, although
   their raw metadata remains available in the API and diagnostics.
@@ -664,6 +684,8 @@ earlier by the user.
 - The immediate target of multi-zone tasks is decoded from vendor data. When
   Home Assistant starts an explicit ordered-zone task, the first requested zone
   is latched locally so delayed vendor target fields do not delay gate opening.
+- Private-cloud navigation fallback depends on the vendor location `report_time`;
+  stale cloud points are never trusted for gate close/clear decisions.
 - Map writes, boundary edits, edge-mowing changes and `clock_direction` writes
   are deliberately not included.
 

--- a/custom_components/navimower/beta16_runtime.py
+++ b/custom_components/navimower/beta16_runtime.py
@@ -25,6 +25,7 @@ from typing import Any
 from . import const as _const
 from . import coordinator as _coordinator
 from .beta17_runtime import install_beta17_runtime
+from .beta18_runtime import install_beta18_runtime
 
 _STATE_IDLE = "0103"
 _STATE_FAULT = "0301"
@@ -124,6 +125,7 @@ def install_beta16_runtime() -> None:
     cls = _coordinator.NavimowCoordinator
     if getattr(cls, "_beta16_runtime_installed", False):
         install_beta17_runtime()
+        install_beta18_runtime()
         return
 
     # The coordinator imported these mutable objects by reference, so mutating
@@ -257,3 +259,4 @@ def install_beta16_runtime() -> None:
     cls._beta16_runtime_installed = True
     _install_error_sensor_attributes()
     install_beta17_runtime()
+    install_beta18_runtime()

--- a/custom_components/navimower/beta18_runtime.py
+++ b/custom_components/navimower/beta18_runtime.py
@@ -1,0 +1,311 @@
+"""Beta18 navigation fallback corrections.
+
+MQTT remains the primary source for physical navigation. When a fresh MQTT pose
+is unavailable, the private-cloud pose can keep physical-zone/channel display
+useful. Gate decisions may use private-cloud X/Y only while the vendor's own
+``report_time`` is recent; stale cloud coordinates are display-only.
+
+For closing/clearing an already-open gate, a private-cloud transition away from
+the origin must be confirmed by two distinct vendor pose timestamps. This keeps
+one delayed cloud sample from closing a physical gate in front of the mower.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from . import coordinator as _coordinator
+from .position_fallback import choose_position
+
+
+class _NavigationProxy:
+    """Forward coordinator state while overriding the pose used by navigation."""
+
+    def __init__(self, target: Any, position: dict[str, Any] | None, age: float | None) -> None:
+        object.__setattr__(self, "_target", target)
+        object.__setattr__(self, "_position", position)
+        object.__setattr__(self, "_age", age)
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "_fresh_mqtt_position":
+            return lambda: object.__getattribute__(self, "_position")
+        if name == "pose_age":
+            return lambda: object.__getattribute__(self, "_age")
+        return getattr(object.__getattribute__(self, "_target"), name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(object.__getattribute__(self, "_target"), name, value)
+
+
+def _cloud_report_time(snapshot: dict[str, Any]) -> Any:
+    raw = snapshot.get("raw") or {}
+    location = raw.get("location") or {}
+    if isinstance(location, dict) and location.get("report_time") is not None:
+        return location.get("report_time")
+    if snapshot.get("pose_source") == "private_cloud":
+        return snapshot.get("pose_time")
+    return None
+
+
+def _position_context(coordinator: Any, snapshot: dict[str, Any]) -> dict[str, Any]:
+    return choose_position(
+        mqtt_position=coordinator._fresh_mqtt_position(),  # noqa: SLF001
+        mqtt_age=coordinator.pose_age(),
+        cloud_position=(
+            snapshot.get("cloud_position")
+            if isinstance(snapshot.get("cloud_position"), dict)
+            else (
+                snapshot.get("position")
+                if snapshot.get("pose_source") == "private_cloud"
+                and isinstance(snapshot.get("position"), dict)
+                else None
+            )
+        ),
+        cloud_report_time=_cloud_report_time(snapshot),
+    )
+
+
+def _risky_cloud_gate_transition(coordinator: Any, snapshot: dict[str, Any], context: dict[str, Any]) -> bool:
+    """Require two cloud samples before an existing gate may close/clear."""
+    if context.get("source") != "private_cloud" or not context.get("gate_usable"):
+        return False
+    if not coordinator._gate_latches:  # noqa: SLF001
+        return False
+
+    map_data = snapshot.get("map") or {}
+    zones = map_data.get("zones") or snapshot.get("zones") or []
+    channels = map_data.get("channels") or []
+    position = context.get("position")
+    physical = _coordinator._zone_at_position(position, zones)  # noqa: SLF001
+    tunnel = None
+    if physical is None:
+        tunnel = _coordinator._tunnel_at_position(position, channels)  # noqa: SLF001
+    if tunnel is not None:
+        return False
+
+    physical_id = _coordinator._as_int((physical or {}).get("id"))  # noqa: SLF001
+    report_key = str(_cloud_report_time(snapshot) or "")
+    confirmations = getattr(coordinator, "_beta18_cloud_gate_confirmations", {})
+
+    blocked = False
+    for slug, latch in list(coordinator._gate_latches.items()):  # noqa: SLF001
+        from_id = _coordinator._as_int((latch or {}).get("from_zone_id"))  # noqa: SLF001
+        to_id = _coordinator._as_int((latch or {}).get("to_zone_id"))  # noqa: SLF001
+        pair = {value for value in (from_id, to_id) if value is not None}
+        risky = bool(
+            physical_id is not None
+            and (
+                (to_id is not None and physical_id == to_id)
+                or (pair and physical_id not in pair)
+            )
+        )
+        if not risky:
+            confirmations.pop(slug, None)
+            continue
+
+        key = f"{physical_id}:{report_key}"
+        previous = confirmations.get(slug) or {}
+        count = int(previous.get("count") or 0)
+        previous_report = str(previous.get("report") or "")
+        previous_zone = previous.get("zone")
+        if report_key and report_key != previous_report and previous_zone == physical_id:
+            count += 1
+        else:
+            count = 1
+        confirmations[slug] = {
+            "zone": physical_id,
+            "report": report_key,
+            "key": key,
+            "count": count,
+        }
+        if count < 2:
+            blocked = True
+
+    coordinator._beta18_cloud_gate_confirmations = confirmations  # noqa: SLF001
+    return blocked
+
+
+def _decorate_navigation_result(
+    coordinator: Any,
+    snapshot: dict[str, Any],
+    result: dict[str, Any],
+    context: dict[str, Any],
+) -> dict[str, Any]:
+    source = str(context.get("source") or "unavailable")
+    age = context.get("age")
+    stale = bool(context.get("stale"))
+    position = context.get("position")
+
+    # If cloud is too old for gate logic, still use it for display-only zone and
+    # channel identification. The gate result was already calculated without it.
+    if source == "private_cloud" and position is not None and not context.get("gate_usable"):
+        map_data = snapshot.get("map") or {}
+        zones = map_data.get("zones") or snapshot.get("zones") or []
+        channels = map_data.get("channels") or []
+        physical = _coordinator._zone_at_position(position, zones)  # noqa: SLF001
+        tunnel = None
+        if physical is None:
+            tunnel = _coordinator._tunnel_at_position(position, channels)  # noqa: SLF001
+        physical_id = _coordinator._as_int((physical or {}).get("id"))  # noqa: SLF001
+        physical_name = (physical or {}).get("name")
+        if physical_id is not None and physical_name:
+            result["current_physical_zone"] = str(physical_name)
+            result["current_physical_zone_id"] = physical_id
+            coordinator._last_physical_zone_id = physical_id  # noqa: SLF001
+            coordinator._last_physical_zone_name = str(physical_name)  # noqa: SLF001
+        elif tunnel is not None:
+            result["current_physical_zone"] = "Between zones"
+            result["current_physical_zone_id"] = None
+        else:
+            result["current_physical_zone"] = "Outside mapped zones"
+            result["current_physical_zone_id"] = None
+
+        if tunnel is not None:
+            result["current_channel"] = str(
+                tunnel.get("name")
+                or (f"Channel {tunnel.get('id')}" if tunnel.get("id") is not None else "Channel")
+            )
+            result["current_channel_id"] = _coordinator._as_int(tunnel.get("id"))  # noqa: SLF001
+            result["current_channel_connection"] = _coordinator._dedupe_zone_ids(  # noqa: SLF001
+                tunnel.get("connection")
+            )
+            result["current_channel_distance"] = _coordinator._as_float(tunnel.get("distance"))  # noqa: SLF001
+        else:
+            result["current_channel"] = "Not in channel"
+            result["current_channel_id"] = None
+            result["current_channel_connection"] = []
+            result["current_channel_distance"] = None
+
+    if source == "mqtt":
+        position_source = "mqtt"
+    elif source == "private_cloud":
+        position_source = "private_cloud"
+    elif result.get("current_physical_zone_source") == "last_known_stale_pose":
+        position_source = "last_known"
+        stale = True
+    else:
+        position_source = "unavailable"
+        stale = True
+
+    if result.get("current_physical_zone_id") is not None:
+        result["current_physical_zone_source"] = (
+            "mqtt_map_polygon" if position_source == "mqtt" else
+            "private_cloud_map_polygon" if position_source == "private_cloud" else
+            result.get("current_physical_zone_source")
+        )
+    result["current_physical_zone_position_source"] = position_source
+    result["current_physical_zone_position_age"] = age
+    result["current_physical_zone_stale"] = stale
+
+    if position_source == "private_cloud":
+        result["current_channel_source"] = "private_cloud_pose"
+        result["current_channel_stale"] = stale
+        result["current_channel_pose_valid"] = bool(context.get("gate_usable"))
+        result["current_channel_pose_age"] = age
+    elif position_source == "mqtt":
+        result["current_channel_pose_age"] = coordinator.pose_age()
+
+    for state in (result.get("gate_states") or {}).values():
+        if not isinstance(state, dict):
+            continue
+        state["position_source"] = position_source
+        state["position_age"] = age
+        state["position_stale"] = stale
+        state["mqtt_pose_valid"] = coordinator._fresh_mqtt_position() is not None  # noqa: SLF001
+        state["cloud_fallback"] = position_source == "private_cloud"
+
+    return result
+
+
+def _install_sensor_attributes() -> None:
+    from . import sensor as platform
+
+    def physical_attrs(data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "zone_id": data.get("current_physical_zone_id"),
+            "source": data.get("current_physical_zone_source"),
+            "position_source": data.get("current_physical_zone_position_source"),
+            "position_age": data.get("current_physical_zone_position_age"),
+            "stale": data.get("current_physical_zone_stale"),
+            "mqtt_pose_valid": data.get("mqtt_pose_valid"),
+        }
+
+    platform.SENSORS = tuple(
+        replace(description, attrs_fn=physical_attrs)
+        if description.key == "current_physical_zone"
+        else description
+        for description in platform.SENSORS
+    )
+
+
+def install_beta18_runtime() -> None:
+    """Install freshness-aware navigation fallback once per interpreter."""
+    cls = _coordinator.NavimowCoordinator
+    if getattr(cls, "_beta18_runtime_installed", False):
+        return
+
+    original_navigation = cls._navigation_fields
+    original_channel_state = cls.channel_state
+
+    def navigation_fields(self: Any, snapshot: dict[str, Any]) -> dict[str, Any]:
+        context = _position_context(self, snapshot)
+        gate_position = context.get("position") if context.get("gate_usable") else None
+        gate_age = context.get("age") if gate_position is not None else None
+        if gate_position is not None and _risky_cloud_gate_transition(self, snapshot, context):
+            gate_position = None
+            gate_age = None
+        proxy = _NavigationProxy(self, gate_position, gate_age)
+        result = original_navigation(proxy, snapshot)
+        return _decorate_navigation_result(self, snapshot, result, context)
+
+    def channel_state(self: Any, channel: Any) -> bool | None:
+        mqtt_position = self._fresh_mqtt_position()  # noqa: SLF001
+        if mqtt_position is not None:
+            states = getattr(self, "_beta18_gate_area_states", {})
+            states[channel.slug] = {
+                "value": channel.contains(mqtt_position.get("x"), mqtt_position.get("y")),
+                "report": None,
+                "outside_count": 0,
+            }
+            self._beta18_gate_area_states = states
+            return original_channel_state(self, channel)
+
+        data = self.data or {}
+        if data.get("docked") is True and self._pending_activity_value() is None:  # noqa: SLF001
+            return False
+        context = _position_context(self, data)
+        if context.get("source") != "private_cloud" or not context.get("gate_usable"):
+            return None
+        position = context.get("position") or {}
+        value = channel.contains(position.get("x"), position.get("y"))
+        if value is None:
+            return None
+
+        states = getattr(self, "_beta18_gate_area_states", {})
+        previous = states.get(channel.slug) or {}
+        report = str(_cloud_report_time(data) or "")
+        if value:
+            states[channel.slug] = {"value": True, "report": report, "outside_count": 0}
+            self._beta18_gate_area_states = states
+            return True
+
+        outside_count = int(previous.get("outside_count") or 0)
+        if report and report != str(previous.get("report") or ""):
+            outside_count += 1
+        else:
+            outside_count = max(1, outside_count)
+        states[channel.slug] = {
+            "value": previous.get("value"),
+            "report": report,
+            "outside_count": outside_count,
+        }
+        self._beta18_gate_area_states = states
+        if outside_count >= 2:
+            states[channel.slug]["value"] = False
+            return False
+        return True if previous.get("value") is True else None
+
+    cls._navigation_fields = navigation_fields
+    cls.channel_state = channel_state
+    cls._beta18_runtime_installed = True
+    _install_sensor_attributes()

--- a/custom_components/navimower/beta18_runtime.py
+++ b/custom_components/navimower/beta18_runtime.py
@@ -103,7 +103,6 @@ def _risky_cloud_gate_transition(coordinator: Any, snapshot: dict[str, Any], con
             confirmations.pop(slug, None)
             continue
 
-        key = f"{physical_id}:{report_key}"
         previous = confirmations.get(slug) or {}
         count = int(previous.get("count") or 0)
         previous_report = str(previous.get("report") or "")
@@ -115,7 +114,6 @@ def _risky_cloud_gate_transition(coordinator: Any, snapshot: dict[str, Any], con
         confirmations[slug] = {
             "zone": physical_id,
             "report": report_key,
-            "key": key,
             "count": count,
         }
         if count < 2:
@@ -136,9 +134,10 @@ def _decorate_navigation_result(
     stale = bool(context.get("stale"))
     position = context.get("position")
 
-    # If cloud is too old for gate logic, still use it for display-only zone and
-    # channel identification. The gate result was already calculated without it.
-    if source == "private_cloud" and position is not None and not context.get("gate_usable"):
+    # Display follows the best available position independently from gate safety.
+    # This also means the first cloud arrival sample may update the visible zone
+    # while a gate latch still waits for the second confirming cloud report.
+    if source == "private_cloud" and position is not None:
         map_data = snapshot.get("map") or {}
         zones = map_data.get("zones") or snapshot.get("zones") or []
         channels = map_data.get("channels") or []

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta17"
+  "version": "0.4.1-beta18"
 }

--- a/custom_components/navimower/position_fallback.py
+++ b/custom_components/navimower/position_fallback.py
@@ -1,0 +1,72 @@
+"""Dependency-free helpers for freshness-aware position fallback."""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+CLOUD_GATE_FRESH_SECONDS = 30.0
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def cloud_report_age(report_time: Any, *, now_epoch: float | None = None) -> float | None:
+    """Return age of the vendor's private-cloud pose timestamp in seconds."""
+    value = _as_float(report_time)
+    if value is None or value <= 0:
+        return None
+    if value > 10_000_000_000:
+        value /= 1000.0
+    now = time.time() if now_epoch is None else float(now_epoch)
+    # Small negative values can happen because clocks are not perfectly aligned.
+    return max(0.0, now - value)
+
+
+def choose_position(
+    *,
+    mqtt_position: dict[str, Any] | None,
+    mqtt_age: float | None,
+    cloud_position: dict[str, Any] | None,
+    cloud_report_time: Any,
+    now_epoch: float | None = None,
+    cloud_gate_max_age: float = CLOUD_GATE_FRESH_SECONDS,
+) -> dict[str, Any]:
+    """Choose display position and whether it is safe enough for gate logic.
+
+    A caller must pass only an already-fresh MQTT pose. MQTT therefore always
+    wins. Private-cloud X/Y remains useful for display even when its vendor
+    timestamp is old, but is gate-usable only while that timestamp is recent.
+    """
+    if isinstance(mqtt_position, dict):
+        return {
+            "position": mqtt_position,
+            "source": "mqtt",
+            "age": mqtt_age,
+            "stale": False,
+            "gate_usable": True,
+        }
+
+    cloud_age = cloud_report_age(cloud_report_time, now_epoch=now_epoch)
+    if isinstance(cloud_position, dict):
+        gate_usable = bool(
+            cloud_age is not None and cloud_age <= float(cloud_gate_max_age)
+        )
+        return {
+            "position": cloud_position,
+            "source": "private_cloud",
+            "age": cloud_age,
+            "stale": not gate_usable,
+            "gate_usable": gate_usable,
+        }
+
+    return {
+        "position": None,
+        "source": "unavailable",
+        "age": None,
+        "stale": True,
+        "gate_usable": False,
+    }

--- a/tests/test_v041_beta17.py
+++ b/tests/test_v041_beta17.py
@@ -28,7 +28,9 @@ def _capability_source() -> str:
 
 def test_beta17_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta17"
+    version = manifest["version"]
+    assert version.startswith("0.4.1-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 17
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta17.md").read_text()
     assert notes.startswith("title: Navimower 0.4.1-beta17")
     for phrase in (

--- a/tests/test_v041_beta18.py
+++ b/tests/test_v041_beta18.py
@@ -1,0 +1,103 @@
+"""Regression contracts for Navimower 0.4.1-beta18."""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _load_position_fallback():
+    path = COMPONENT / "position_fallback.py"
+    spec = importlib.util.spec_from_file_location("navimower_position_fallback_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_beta18_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta18"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta18.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta18")
+    for phrase in (
+        "Fresh official MQTT X/Y remains authoritative",
+        "private-cloud X/Y",
+        "Two distinct fresh vendor position reports",
+        "shared private-cloud account",
+    ):
+        assert phrase in notes
+
+
+def test_position_resolver_always_prefers_mqtt() -> None:
+    module = _load_position_fallback()
+    result = module.choose_position(
+        mqtt_position={"x": 1.0, "y": 2.0},
+        mqtt_age=3.0,
+        cloud_position={"x": 9.0, "y": 9.0},
+        cloud_report_time=990.0,
+        now_epoch=1000.0,
+    )
+    assert result["source"] == "mqtt"
+    assert result["position"] == {"x": 1.0, "y": 2.0}
+    assert result["gate_usable"] is True
+    assert result["stale"] is False
+
+
+def test_fresh_cloud_is_gate_usable_when_mqtt_pose_is_missing() -> None:
+    module = _load_position_fallback()
+    result = module.choose_position(
+        mqtt_position=None,
+        mqtt_age=None,
+        cloud_position={"x": -13.25, "y": -43.0},
+        cloud_report_time=980.0,
+        now_epoch=1000.0,
+    )
+    assert result["source"] == "private_cloud"
+    assert result["position"] == {"x": -13.25, "y": -43.0}
+    assert result["age"] == 20.0
+    assert result["gate_usable"] is True
+    assert result["stale"] is False
+
+
+def test_stale_cloud_remains_display_only() -> None:
+    module = _load_position_fallback()
+    result = module.choose_position(
+        mqtt_position=None,
+        mqtt_age=None,
+        cloud_position={"x": -13.25, "y": -43.0},
+        cloud_report_time=900.0,
+        now_epoch=1000.0,
+    )
+    assert result["source"] == "private_cloud"
+    assert result["position"] is not None
+    assert result["age"] == 100.0
+    assert result["gate_usable"] is False
+    assert result["stale"] is True
+
+
+def test_beta18_runtime_chains_and_protects_cloud_gate_release() -> None:
+    beta16 = (COMPONENT / "beta16_runtime.py").read_text()
+    runtime = (COMPONENT / "beta18_runtime.py").read_text()
+    assert "from .beta18_runtime import install_beta18_runtime" in beta16
+    assert beta16.rindex("install_beta17_runtime()") < beta16.rindex(
+        "install_beta18_runtime()"
+    )
+    assert "_risky_cloud_gate_transition" in runtime
+    assert "count < 2" in runtime
+    assert 'context.get("gate_usable")' in runtime
+    assert '"current_physical_zone_position_source"' in runtime
+    assert '"cloud_fallback"' in runtime
+    assert "outside_count >= 2" in runtime
+
+
+def test_readme_documents_shared_account_and_fallback_rules() -> None:
+    readme = (ROOT / "README.md").read_text()
+    assert "same dedicated private-cloud account" in readme
+    assert "stable app/device identity" in readme
+    assert "currently unsupported" not in readme
+    assert "private-cloud" in readme and "report_time" in readme
+    assert "two distinct" in readme.lower()

--- a/tests/test_v041_beta18.py
+++ b/tests/test_v041_beta18.py
@@ -96,7 +96,8 @@ def test_beta18_runtime_chains_and_protects_cloud_gate_release() -> None:
 
 def test_readme_documents_shared_account_and_fallback_rules() -> None:
     readme = (ROOT / "README.md").read_text()
-    assert "same dedicated private-cloud account" in readme
+    assert "Multiple mower config entries may use" in readme
+    assert "dedicated private-cloud" in readme
     assert "stable app/device identity" in readme
     assert "currently unsupported" not in readme
     assert "private-cloud" in readme and "report_time" in readme


### PR DESCRIPTION
## What changed
- keep fresh MQTT X/Y authoritative for navigation
- fall back to private-cloud X/Y for Current physical zone and Current channel when MQTT pose is absent
- evaluate private-cloud freshness from vendor `report_time`
- allow fresh private-cloud pose as a Gate/Gate-area fallback without overriding MQTT
- require two distinct fresh cloud position reports before cloud fallback can close/clear an existing gate or turn a Gate area OFF
- expose navigation position source/age/stale diagnostics
- correct README multi-mower guidance: several config entries may share one dedicated private-cloud account using the stable account-scoped app/device identity
- bump to 0.4.1-beta18 and add release notes/regression tests

## Root cause
Navimow can keep MQTT connected while stopping type=1 X/Y pose updates in error/idle states. The private cloud continues to report a valid last/current local pose, but the navigation layer previously ignored it and therefore lost the physical zone and disabled gate positioning completely.

## Validation
CI should run compile, full pytest, history/navigation/state regression checks, hassfest and HACS validation before merge. Beta18 adds dependency-free resolver tests for MQTT priority, fresh-cloud fallback and stale-cloud display-only behavior.