### PR TITLE
Navimower 0.4.1-beta19 notification event discovery

### DIFF
--- a/.github/release-notes/0.4.1-beta19.md
+++ b/.github/release-notes/0.4.1-beta19.md
@@ -1,0 +1,21 @@
+title: Navimower 0.4.1-beta19
+
+Navimower 0.4.1-beta19 adds a bounded read-only discovery probe for the Navimow app's Device notification/event timeline.
+
+## Added
+
+- Home Assistant diagnostics now include `notification_event_probe`.
+- The probe runs only when diagnostics are explicitly generated; normal coordinator polling is unchanged.
+- It tries 24 likely read-only message/notification/event endpoint paths across message, user, vehicle and push namespaces.
+- Each candidate is tried with a minimal parameter profile and, when needed, a broader pagination/type profile containing common aliases such as `page`, `pageNum`, `pageNo`, `pageSize`, `current`, `size`, `limit`, `offset`, `eventType`, `messageType` and `readStatus`.
+- Successful responses expose only sanitized structure inventory and a tiny sanitized sample so the actual notification timeline schema can be recognized.
+- Failed probes retain the vendor business code and sanitized description, which should reveal unknown routes versus missing/incorrect parameter contracts.
+
+## Safety
+
+- The probe never calls setting, mower-control or map-write endpoints.
+- No event endpoint guesses are added to normal polling yet.
+- No notification is persisted as runtime history until a real vendor feed is positively identified.
+- Existing beta18 MQTT/private-cloud navigation fallback and gate safety behavior are unchanged.
+
+After installing beta19, download an extended diagnostics file from a mower whose Navimow app already contains recent Device notifications. The new `notification_event_probe` section is the primary data needed for the next implementation step.

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .diagnostics_export import async_build_diagnostics, sanitize
+from .event_probe import probe_event_endpoints
 
 
 async def async_get_config_entry_diagnostics(
@@ -38,4 +39,15 @@ async def async_get_config_entry_diagnostics(
         document["state_transition_capture"] = sanitize(
             coordinator.state_transition_diagnostics()
         )
+
+    # Beta19: the Navimow phone app exposes a Device notification timeline, but
+    # its runtime API endpoint is still unknown. Probe likely *read* endpoints
+    # only when diagnostics are explicitly downloaded. This is intentionally not
+    # part of normal polling and never calls a setting/control/map-write route.
+    document["notification_event_probe"] = await hass.async_add_executor_job(
+        probe_event_endpoints,
+        coordinator.client,
+        coordinator.sn,
+        coordinator.vehicle_type,
+    )
     return document

--- a/custom_components/navimower/event_probe.py
+++ b/custom_components/navimower/event_probe.py
@@ -1,0 +1,168 @@
+"""Read-only Navimow notification/event endpoint discovery for diagnostics.
+
+The phone app exposes a Device notification timeline, but the runtime endpoint
+has not yet been identified. This module deliberately probes a bounded set of
+likely read endpoints only when Home Assistant diagnostics are requested.
+Nothing here runs in the normal coordinator poll and no setting/control/map
+write endpoint is used.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from .api.client import NavimowAuthError, NavimowError
+from .diagnostics_export import inventory, sanitize
+
+# Keep this list explicit and auditable. All candidates are GET-like/read naming
+# guesses around the app's Message / Notification / Event vocabulary.
+_EVENT_PATHS: tuple[str, ...] = (
+    "/message/message/list",
+    "/message/message/get-list",
+    "/message/notice/list",
+    "/message/notice/get-list",
+    "/message/notification/list",
+    "/message/notification/get-list",
+    "/message/push/list",
+    "/user/message/list",
+    "/user/message/get-list",
+    "/user/notice/list",
+    "/user/notification/list",
+    "/user/push/list",
+    "/vehicle/vehicle/event-list",
+    "/vehicle/vehicle/get-event-list",
+    "/vehicle/vehicle/message-list",
+    "/vehicle/vehicle/get-message-list",
+    "/vehicle/vehicle/notice-list",
+    "/vehicle/vehicle/get-notice-list",
+    "/vehicle/vehicle/notification-list",
+    "/vehicle/vehicle/get-notification-list",
+    "/vehicle/event/list",
+    "/vehicle/message/list",
+    "/push/message/list",
+    "/push/notification/list",
+)
+
+
+def _profiles(sn: str, vehicle_type: Any, language: str) -> tuple[tuple[str, dict[str, Any]], ...]:
+    """Return two deliberately different parameter profiles.
+
+    The broad profile contains common pagination/type aliases seen in mobile
+    APIs. Unknown keys are expected to be ignored by tolerant endpoints. The
+    minimal profile lets us distinguish an endpoint that rejects those aliases.
+    """
+    minimal = {
+        "vehicle_sn": sn,
+        "vehicle_type": vehicle_type,
+        "language": language,
+    }
+    broad = {
+        **minimal,
+        "page": 1,
+        "pageNum": 1,
+        "pageNo": 1,
+        "pageSize": 50,
+        "current": 1,
+        "size": 50,
+        "limit": 50,
+        "offset": 0,
+        "type": 0,
+        "eventType": 0,
+        "messageType": 0,
+        "readStatus": 0,
+    }
+    return (("minimal", minimal), ("broad", broad))
+
+
+def probe_event_endpoints(client: Any, sn: str, vehicle_type: Any) -> dict[str, Any]:
+    """Probe likely notification endpoints and return only sanitized metadata."""
+    language = str(getattr(client, "_language", "en") or "en")  # noqa: SLF001
+    attempts: list[dict[str, Any]] = []
+    matches: list[dict[str, Any]] = []
+
+    for path in _EVENT_PATHS:
+        for profile_name, params in _profiles(sn, vehicle_type, language):
+            row: dict[str, Any] = {
+                "path": path,
+                "profile": profile_name,
+                "parameter_keys": sorted(params),
+            }
+            try:
+                data = client.call(path, deepcopy(params))
+            except NavimowAuthError as err:
+                row.update(
+                    {
+                        "ok": False,
+                        "error_type": type(err).__name__,
+                        "business_code": sanitize(err.code),
+                        "description": sanitize(err.desc),
+                    }
+                )
+            except NavimowError as err:
+                row.update(
+                    {
+                        "ok": False,
+                        "error_type": type(err).__name__,
+                        "business_code": sanitize(err.code),
+                        "description": sanitize(err.desc),
+                    }
+                )
+            except Exception as err:  # noqa: BLE001 - diagnostics discovery
+                row.update(
+                    {
+                        "ok": False,
+                        "error_type": type(err).__name__,
+                        "description": sanitize(str(err)),
+                    }
+                )
+            else:
+                clean = sanitize(data)
+                row.update(
+                    {
+                        "ok": True,
+                        "response_type": type(data).__name__,
+                        "inventory": inventory(clean),
+                    }
+                )
+                # Preserve a tiny sanitized sample for semantic recognition. The
+                # normal sanitizer still redacts account/device/GPS identifiers.
+                if isinstance(clean, list):
+                    row["sample"] = clean[:2]
+                elif isinstance(clean, dict):
+                    row["sample"] = {
+                        key: clean[key]
+                        for key in list(clean)[:12]
+                    }
+                elif clean is not None:
+                    row["sample"] = clean
+                matches.append(
+                    {
+                        "path": path,
+                        "profile": profile_name,
+                        "response_type": row["response_type"],
+                        "key_count": row["inventory"].get("key_count"),
+                        "keyword_paths": row["inventory"].get("keyword_paths"),
+                    }
+                )
+            attempts.append(row)
+
+            # A successful minimal response is enough for this endpoint; avoid a
+            # duplicate broad call and keep diagnostics reasonably bounded.
+            if row.get("ok") and profile_name == "minimal":
+                break
+
+    return {
+        "read_only": True,
+        "normal_polling_unchanged": True,
+        "candidate_path_count": len(_EVENT_PATHS),
+        "parameter_profiles": ["minimal", "broad"],
+        "attempt_count": len(attempts),
+        "matches": matches,
+        "attempts": attempts,
+        "note": (
+            "These are bounded discovery guesses executed only while diagnostics "
+            "are generated. Successful response structure/sample fields are "
+            "sanitized; failures retain business code/description to identify "
+            "missing parameter or unknown-route responses."
+        ),
+    }

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta18"
+  "version": "0.4.1-beta19"
 }

--- a/tests/test_v041_beta18.py
+++ b/tests/test_v041_beta18.py
@@ -20,7 +20,9 @@ def _load_position_fallback():
 
 def test_beta18_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta18"
+    version = manifest["version"]
+    assert version.startswith("0.4.1-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 18
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta18.md").read_text()
     assert notes.startswith("title: Navimower 0.4.1-beta18")
     for phrase in (

--- a/tests/test_v041_beta19.py
+++ b/tests/test_v041_beta19.py
@@ -1,0 +1,73 @@
+"""Regression contracts for Navimower 0.4.1-beta19."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta19_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta19"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta19.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta19")
+    for phrase in (
+        "notification_event_probe",
+        "24 likely read-only",
+        "normal coordinator polling is unchanged",
+        "business code",
+    ):
+        assert phrase in notes
+
+
+def test_event_probe_is_bounded_and_read_only() -> None:
+    source = (COMPONENT / "event_probe.py").read_text()
+    ast.parse(source)
+    assert "_EVENT_PATHS" in source
+    assert source.count('"/message/') >= 6
+    assert source.count('"/user/') >= 4
+    assert source.count('"/vehicle/') >= 8
+    assert source.count('"/push/') >= 2
+    for forbidden in (
+        "/vehicle/set/send",
+        "/vehicle/set/save-set-data",
+        "/map/index/save",
+        "save_setting(",
+        "mow_zones(",
+    ):
+        assert forbidden not in source
+    assert '"normal_polling_unchanged": True' in source
+
+
+def test_event_probe_uses_broad_parameter_aliases() -> None:
+    source = (COMPONENT / "event_probe.py").read_text()
+    for key in (
+        '"vehicle_sn"',
+        '"vehicle_type"',
+        '"page"',
+        '"pageNum"',
+        '"pageNo"',
+        '"pageSize"',
+        '"current"',
+        '"size"',
+        '"limit"',
+        '"offset"',
+        '"eventType"',
+        '"messageType"',
+        '"readStatus"',
+    ):
+        assert key in source
+    assert '"minimal"' in source
+    assert '"broad"' in source
+
+
+def test_native_diagnostics_executes_probe_only_on_export() -> None:
+    diagnostics = (COMPONENT / "diagnostics.py").read_text()
+    coordinator = (COMPONENT / "coordinator.py").read_text()
+    assert "probe_event_endpoints" in diagnostics
+    assert 'document["notification_event_probe"]' in diagnostics
+    assert "probe_event_endpoints" not in coordinator
+    assert "async_add_executor_job" in diagnostics


### PR DESCRIPTION
## What changed
- add a bounded read-only notification/event endpoint discovery probe to native Home Assistant diagnostics
- probe 24 likely read endpoints across message, user, vehicle and push namespaces
- try minimal and broader parameter profiles with common pagination/type aliases
- retain sanitized success structure/sample data or vendor business-code/error descriptions
- keep the probe completely out of normal coordinator polling
- bump manifest to 0.4.1-beta19 and add release notes/regression coverage

## Why
The Navimow app shows a Device notification timeline (for example charging-station location changed), and the compressed vendor catalog exposes matching `vehicleEventData`, but the runtime feed endpoint has not yet been identified. Beta19 is designed to discover that feed from one extended diagnostics export without guessing it into normal polling.

## Safety
Only read-style candidate paths are used. The probe does not call mower control, settings write, or map write endpoints, and no event history is persisted until the real feed is positively identified.

## Validation
GitHub Actions should run compile, full pytest/regression checks, hassfest and HACS validation before merge.