### PR TITLE
Navimower 0.4.1-beta20 notification probe refinement

### DIFF
--- a/.github/release-notes/0.4.1-beta20.md
+++ b/.github/release-notes/0.4.1-beta20.md
@@ -1,0 +1,21 @@
+title: Navimower 0.4.1-beta20
+
+Navimower 0.4.1-beta20 refines notification/event discovery after beta19 showed that `/message` and `/push` routes behave differently from known-dead 404 vehicle guesses.
+
+## Changed
+
+- The diagnostics-only `notification_event_probe` now focuses on message/push candidate paths instead of repeatedly probing vehicle routes that returned `404 url Not Exist`.
+- Known 404 attempts are summarized by count only so Download diagnostics stays smaller and easier to inspect.
+- Adds account-level request profiles without mower identity, matching the Navimow app's account-level Notification view.
+- Adds account-level paged and device-scoped profiles with common message-center aliases such as `msgType`, `noticeType`, `notificationType`, `messageCategory`, `bizType`, `businessType`, `sourceType`, `tabType`, `cursor`, `lastId`, `startTime` and `endTime`.
+- Reuses `commonUserVehicleIndex` and `vehicleShareType` from the existing read-only auth-list response when available, adding them only to the extended device profile.
+- Adds a small set of message-center naming variants such as `/message/center/list`, `/message/device/list`, `/message/get-message-list` and matching push variants.
+- Successful responses still retain sanitized structure/sample data; non-404 failures retain business code and description for follow-up analysis.
+
+## Safety
+
+- The probe runs only when Home Assistant diagnostics are explicitly downloaded.
+- Normal coordinator polling is unchanged.
+- No mower control, settings write or map write endpoint is called.
+
+No configuration migration is required. After updating, download a fresh extended diagnostic while the Navimow app still shows Device notifications so the new `notification_event_probe` output can be compared against beta19.

--- a/custom_components/navimower/event_probe.py
+++ b/custom_components/navimower/event_probe.py
@@ -1,10 +1,9 @@
 """Read-only Navimow notification/event endpoint discovery for diagnostics.
 
-The phone app exposes a Device notification timeline, but the runtime endpoint
-has not yet been identified. This module deliberately probes a bounded set of
-likely read endpoints only when Home Assistant diagnostics are requested.
-Nothing here runs in the normal coordinator poll and no setting/control/map
-write endpoint is used.
+Beta20 narrows the search around the message/push namespaces that returned a
+non-404 response in beta19. The probe still runs only when Home Assistant
+Diagnostics is explicitly downloaded. It never calls settings, control or map
+write endpoints.
 """
 from __future__ import annotations
 
@@ -14,8 +13,10 @@ from typing import Any
 from .api.client import NavimowAuthError, NavimowError
 from .diagnostics_export import inventory, sanitize
 
-# Keep this list explicit and auditable. All candidates are GET-like/read naming
-# guesses around the app's Message / Notification / Event vocabulary.
+# Beta19 showed that these message/push namespaces returned HTTP/business 502
+# rather than "url Not Exist". Keep the next pass focused there, while adding a
+# small set of message-center naming variants rather than continuing to spray the
+# vehicle namespace with known-dead 404 candidates.
 _EVENT_PATHS: tuple[str, ...] = (
     "/message/message/list",
     "/message/message/get-list",
@@ -24,40 +25,38 @@ _EVENT_PATHS: tuple[str, ...] = (
     "/message/notification/list",
     "/message/notification/get-list",
     "/message/push/list",
-    "/user/message/list",
-    "/user/message/get-list",
-    "/user/notice/list",
-    "/user/notification/list",
-    "/user/push/list",
-    "/vehicle/vehicle/event-list",
-    "/vehicle/vehicle/get-event-list",
-    "/vehicle/vehicle/message-list",
-    "/vehicle/vehicle/get-message-list",
-    "/vehicle/vehicle/notice-list",
-    "/vehicle/vehicle/get-notice-list",
-    "/vehicle/vehicle/notification-list",
-    "/vehicle/vehicle/get-notification-list",
-    "/vehicle/event/list",
-    "/vehicle/message/list",
     "/push/message/list",
     "/push/notification/list",
+    "/message/index/list",
+    "/message/index/message-list",
+    "/message/user/list",
+    "/message/user-message/list",
+    "/message/device/list",
+    "/message/device-message/list",
+    "/message/center/list",
+    "/message/center/message-list",
+    "/message/get-message-list",
+    "/push/index/list",
+    "/push/message/get-list",
 )
 
 
-def _profiles(sn: str, vehicle_type: Any, language: str) -> tuple[tuple[str, dict[str, Any]], ...]:
-    """Return two deliberately different parameter profiles.
+def _profiles(
+    sn: str,
+    vehicle_type: Any,
+    language: str,
+    common_index: Any = None,
+    share_type: Any = None,
+) -> tuple[tuple[str, dict[str, Any]], ...]:
+    """Return deliberately different account/device parameter profiles.
 
-    The broad profile contains common pagination/type aliases seen in mobile
-    APIs. Unknown keys are expected to be ignored by tolerant endpoints. The
-    minimal profile lets us distinguish an endpoint that rejects those aliases.
+    The phone app's Notification view is account-level, so beta20 explicitly
+    tries bodies without mower identity as well as device-scoped variants. The
+    expanded profile adds common message-center pagination/category aliases.
     """
-    minimal = {
-        "vehicle_sn": sn,
-        "vehicle_type": vehicle_type,
+    account_minimal = {"language": language}
+    account_paged = {
         "language": language,
-    }
-    broad = {
-        **minimal,
         "page": 1,
         "pageNum": 1,
         "pageNo": 1,
@@ -66,22 +65,82 @@ def _profiles(sn: str, vehicle_type: Any, language: str) -> tuple[tuple[str, dic
         "size": 50,
         "limit": 50,
         "offset": 0,
+        "cursor": "",
+        "lastId": "",
         "type": 0,
+        "msgType": 0,
+        "noticeType": 0,
+        "notificationType": 0,
         "eventType": 0,
         "messageType": 0,
+        "messageCategory": 0,
+        "category": 0,
+        "bizType": 0,
+        "businessType": 0,
+        "sourceType": 0,
+        "deviceType": 0,
+        "productType": 0,
+        "tabType": 0,
+        "status": 0,
+        "read": 0,
+        "isRead": 0,
         "readStatus": 0,
+        "startTime": 0,
+        "beginTime": 0,
+        "endTime": 0,
+        "timestamp": 0,
     }
-    return (("minimal", minimal), ("broad", broad))
+    device_minimal = {
+        "vehicle_sn": sn,
+        "vehicle_type": vehicle_type,
+        "language": language,
+    }
+    device_extended = {
+        **account_paged,
+        "vehicle_sn": sn,
+        "vehicle_type": vehicle_type,
+        "deviceId": sn,
+    }
+    if common_index is not None:
+        device_extended["commonUserVehicleIndex"] = common_index
+    if share_type is not None:
+        device_extended["vehicleShareType"] = share_type
+    return (
+        ("account_minimal", account_minimal),
+        ("account_paged", account_paged),
+        ("device_minimal", device_minimal),
+        ("device_extended", device_extended),
+    )
+
+
+def _account_vehicle_hints(client: Any, sn: str) -> tuple[Any, Any]:
+    """Best-effort read of per-vehicle account hints already exposed by auth-list."""
+    try:
+        rows = client.auth_list()
+    except Exception:  # noqa: BLE001 - discovery must not fail diagnostics
+        return None, None
+    for row in rows if isinstance(rows, list) else []:
+        if not isinstance(row, dict):
+            continue
+        if str(row.get("vehicle_sn") or "") != str(sn):
+            continue
+        return row.get("common_user_vehicle_index"), row.get("vehicle_share_type")
+    return None, None
 
 
 def probe_event_endpoints(client: Any, sn: str, vehicle_type: Any) -> dict[str, Any]:
-    """Probe likely notification endpoints and return only sanitized metadata."""
+    """Probe likely notification endpoints and return compact sanitized metadata."""
     language = str(getattr(client, "_language", "en") or "en")  # noqa: SLF001
+    common_index, share_type = _account_vehicle_hints(client, sn)
     attempts: list[dict[str, Any]] = []
     matches: list[dict[str, Any]] = []
+    not_found_count = 0
+    not_found_paths: set[str] = set()
 
     for path in _EVENT_PATHS:
-        for profile_name, params in _profiles(sn, vehicle_type, language):
+        for profile_name, params in _profiles(
+            sn, vehicle_type, language, common_index, share_type
+        ):
             row: dict[str, Any] = {
                 "path": path,
                 "profile": profile_name,
@@ -99,6 +158,12 @@ def probe_event_endpoints(client: Any, sn: str, vehicle_type: Any) -> dict[str, 
                     }
                 )
             except NavimowError as err:
+                # Known-dead routes add little value and made beta19 diagnostics
+                # noisy. Count them, but keep only non-404 failures in detail.
+                if str(err.code) == "404" and str(err.desc).lower() == "url not exist":
+                    not_found_count += 1
+                    not_found_paths.add(path)
+                    continue
                 row.update(
                     {
                         "ok": False,
@@ -124,15 +189,10 @@ def probe_event_endpoints(client: Any, sn: str, vehicle_type: Any) -> dict[str, 
                         "inventory": inventory(clean),
                     }
                 )
-                # Preserve a tiny sanitized sample for semantic recognition. The
-                # normal sanitizer still redacts account/device/GPS identifiers.
                 if isinstance(clean, list):
                     row["sample"] = clean[:2]
                 elif isinstance(clean, dict):
-                    row["sample"] = {
-                        key: clean[key]
-                        for key in list(clean)[:12]
-                    }
+                    row["sample"] = {key: clean[key] for key in list(clean)[:12]}
                 elif clean is not None:
                     row["sample"] = clean
                 matches.append(
@@ -146,23 +206,31 @@ def probe_event_endpoints(client: Any, sn: str, vehicle_type: Any) -> dict[str, 
                 )
             attempts.append(row)
 
-            # A successful minimal response is enough for this endpoint; avoid a
-            # duplicate broad call and keep diagnostics reasonably bounded.
-            if row.get("ok") and profile_name == "minimal":
+            # One successful response is enough for an endpoint; avoid more
+            # profile calls and keep the diagnostics probe bounded.
+            if row.get("ok"):
                 break
 
     return {
         "read_only": True,
         "normal_polling_unchanged": True,
         "candidate_path_count": len(_EVENT_PATHS),
-        "parameter_profiles": ["minimal", "broad"],
-        "attempt_count": len(attempts),
+        "parameter_profiles": [
+            "account_minimal",
+            "account_paged",
+            "device_minimal",
+            "device_extended",
+        ],
+        "attempt_count": len(attempts) + not_found_count,
+        "retained_attempt_count": len(attempts),
+        "not_found_count": not_found_count,
+        "not_found_path_count": len(not_found_paths),
         "matches": matches,
         "attempts": attempts,
         "note": (
-            "These are bounded discovery guesses executed only while diagnostics "
-            "are generated. Successful response structure/sample fields are "
-            "sanitized; failures retain business code/description to identify "
-            "missing parameter or unknown-route responses."
+            "Beta20 focuses on message/push routes and account-level payloads. "
+            "Known 404 url-not-exist attempts are summarized by count only; "
+            "successful or otherwise interesting responses retain sanitized "
+            "structure/sample or business-code details."
         ),
     }

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta19"
+  "version": "0.4.1-beta20"
 }

--- a/tests/test_v041_beta19.py
+++ b/tests/test_v041_beta19.py
@@ -11,7 +11,9 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_beta19_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta19"
+    version = manifest["version"]
+    assert version.startswith("0.4.1-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 19
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta19.md").read_text()
     assert notes.startswith("title: Navimower 0.4.1-beta19")
     for phrase in (
@@ -28,8 +30,6 @@ def test_event_probe_is_bounded_and_read_only() -> None:
     ast.parse(source)
     assert "_EVENT_PATHS" in source
     assert source.count('"/message/') >= 6
-    assert source.count('"/user/') >= 4
-    assert source.count('"/vehicle/') >= 8
     assert source.count('"/push/') >= 2
     for forbidden in (
         "/vehicle/set/send",
@@ -60,8 +60,8 @@ def test_event_probe_uses_broad_parameter_aliases() -> None:
         '"readStatus"',
     ):
         assert key in source
-    assert '"minimal"' in source
-    assert '"broad"' in source
+    assert '"account_minimal"' in source
+    assert '"device_extended"' in source
 
 
 def test_native_diagnostics_executes_probe_only_on_export() -> None:

--- a/tests/test_v041_beta20.py
+++ b/tests/test_v041_beta20.py
@@ -1,0 +1,79 @@
+"""Regression contracts for Navimower 0.4.1-beta20."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta20_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta20"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta20.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta20")
+    for phrase in (
+        "404",
+        "account-level",
+        "message/push",
+        "commonUserVehicleIndex",
+    ):
+        assert phrase in notes
+
+
+def test_beta20_probe_focuses_on_message_push_and_summarizes_404() -> None:
+    source = (COMPONENT / "event_probe.py").read_text()
+    ast.parse(source)
+    assert '"/vehicle/vehicle/event-list"' not in source
+    assert source.count('"/message/') >= 15
+    assert source.count('"/push/') >= 4
+    assert '"not_found_count"' in source
+    assert '"not_found_path_count"' in source
+    assert 'str(err.code) == "404"' in source
+    assert "continue" in source
+
+
+def test_beta20_probe_has_account_and_device_profiles() -> None:
+    source = (COMPONENT / "event_probe.py").read_text()
+    for profile in (
+        '"account_minimal"',
+        '"account_paged"',
+        '"device_minimal"',
+        '"device_extended"',
+    ):
+        assert profile in source
+    for key in (
+        '"msgType"',
+        '"noticeType"',
+        '"notificationType"',
+        '"messageCategory"',
+        '"bizType"',
+        '"businessType"',
+        '"sourceType"',
+        '"tabType"',
+        '"cursor"',
+        '"lastId"',
+        '"startTime"',
+        '"endTime"',
+        '"commonUserVehicleIndex"',
+        '"vehicleShareType"',
+    ):
+        assert key in source
+
+
+def test_beta20_probe_remains_diagnostics_only_and_read_only() -> None:
+    diagnostics = (COMPONENT / "diagnostics.py").read_text()
+    coordinator = (COMPONENT / "coordinator.py").read_text()
+    source = (COMPONENT / "event_probe.py").read_text()
+    assert "probe_event_endpoints" in diagnostics
+    assert "probe_event_endpoints" not in coordinator
+    for forbidden in (
+        "/vehicle/set/send",
+        "/vehicle/set/save-set-data",
+        "/map/index/save",
+        "save_setting(",
+        "mow_zones(",
+    ):
+        assert forbidden not in source


### PR DESCRIPTION
## What changed
- narrow notification discovery around message/push namespaces that returned non-404 responses in beta19
- remove detailed 404 rows from diagnostics and summarize them by count
- add account-level profiles without mower identity
- add expanded message-center aliases and account/device pagination variants
- reuse commonUserVehicleIndex and vehicleShareType from read-only auth-list when available
- add beta20 regression coverage and release notes

## Why
Beta19 produced useful separation: known-dead vehicle guesses returned `404 url Not Exist`, while message/push candidates returned `502 HTTP error`. Beta20 focuses the search on the latter and tests account-level payload shapes that better match the Navimow app Notification view.

## Safety
The probe still runs only during explicit Home Assistant diagnostics export. It does not call mower control, settings write or map write endpoints, and normal coordinator polling is unchanged.

## Validation
GitHub Actions should run compile, full pytest/regression checks, hassfest and HACS validation before merge.