### PR TITLE
Navimower 0.4.1-beta21 action diagnostics routing

### DIFF
--- a/.github/release-notes/0.4.1-beta21.md
+++ b/.github/release-notes/0.4.1-beta21.md
@@ -1,0 +1,10 @@
+title: Navimower 0.4.1-beta21 diagnostics action routing
+
+Beta21 moves slow notification/event discovery out of Home Assistant's native Download diagnostics flow and into the explicit `navimower.export_diagnostics` action.
+
+- Download diagnostics is fast again and contains the normal sanitized mower diagnostics plus state-transition capture, but no `notification_event_probe`.
+- `navimower.export_diagnostics` now produces the extended diagnostics used for notification discovery, including the beta20 `notification_event_probe` results.
+- The action export also includes state-transition capture and the normal diagnostics payload.
+- Action exports are written under `/config/navimower_diagnostics/` and continue to update `navimower_diagnostics_latest.json` for convenient retrieval.
+- The action emits a Home Assistant persistent notification with the exact output path when the export completes.
+- Notification probing remains read-only and is not part of normal coordinator polling.

--- a/custom_components/navimower/action_diagnostics.py
+++ b/custom_components/navimower/action_diagnostics.py
@@ -1,0 +1,60 @@
+"""Extended diagnostics written by the navimower.export_diagnostics action.
+
+Beta21 deliberately keeps slow notification endpoint discovery out of Home
+Assistant's native Download diagnostics flow. The explicit action may take
+longer and writes its result to /config/navimower_diagnostics for retrieval.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+from .diagnostics_export import async_build_diagnostics, sanitize
+from .event_probe import probe_event_endpoints
+
+
+def _write_json(path: Path, document: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(document, ensure_ascii=False, indent=2, default=repr),
+        encoding="utf-8",
+    )
+
+
+async def async_export_action_diagnostics(
+    hass: HomeAssistant,
+    coordinator: Any,
+    *,
+    include_compressed_map: bool = True,
+) -> str:
+    """Write extended diagnostics including notification endpoint discovery."""
+    document = await async_build_diagnostics(
+        hass,
+        coordinator,
+        include_compressed_map=include_compressed_map,
+    )
+    if hasattr(coordinator, "state_transition_diagnostics"):
+        document["state_transition_capture"] = sanitize(
+            coordinator.state_transition_diagnostics()
+        )
+
+    document["notification_event_probe"] = await hass.async_add_executor_job(
+        probe_event_endpoints,
+        coordinator.client,
+        coordinator.sn,
+        coordinator.vehicle_type,
+    )
+    document["diagnostics_source"] = "navimower.export_diagnostics"
+
+    now = datetime.now(timezone.utc)
+    folder = Path(hass.config.path("navimower_diagnostics"))
+    stamp = now.strftime("%Y%m%d_%H%M%S")
+    path = folder / f"navimower_diagnostics_{stamp}.json"
+    latest = folder / "navimower_diagnostics_latest.json"
+    await hass.async_add_executor_job(_write_json, path, document)
+    await hass.async_add_executor_job(_write_json, latest, document)
+    return str(path)

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -8,7 +8,6 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .diagnostics_export import async_build_diagnostics, sanitize
-from .event_probe import probe_event_endpoints
 
 
 async def async_get_config_entry_diagnostics(
@@ -28,8 +27,9 @@ async def async_get_config_entry_diagnostics(
             },
         }
 
-    # Native HA diagnostics should remain reasonably sized. The uncompressed map
-    # endpoint is still included in full; the compressed copy is redundant here.
+    # Native HA diagnostics stays fast and predictable. Slow notification/event
+    # endpoint discovery is intentionally reserved for the explicit
+    # navimower.export_diagnostics action in beta21.
     document = await async_build_diagnostics(
         hass,
         coordinator,
@@ -39,15 +39,5 @@ async def async_get_config_entry_diagnostics(
         document["state_transition_capture"] = sanitize(
             coordinator.state_transition_diagnostics()
         )
-
-    # Beta19: the Navimow phone app exposes a Device notification timeline, but
-    # its runtime API endpoint is still unknown. Probe likely *read* endpoints
-    # only when diagnostics are explicitly downloaded. This is intentionally not
-    # part of normal polling and never calls a setting/control/map-write route.
-    document["notification_event_probe"] = await hass.async_add_executor_job(
-        probe_event_endpoints,
-        coordinator.client,
-        coordinator.sn,
-        coordinator.vehicle_type,
-    )
+    document["diagnostics_source"] = "home_assistant_download"
     return document

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta20"
+  "version": "0.4.1-beta21"
 }

--- a/custom_components/navimower/services.py
+++ b/custom_components/navimower/services.py
@@ -20,7 +20,7 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 
-from .diagnostics_export import async_export_diagnostics
+from .action_diagnostics import async_export_action_diagnostics
 
 from .const import (
     ACTIVITY_MOWING,
@@ -194,7 +194,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
     async def _export_diagnostics(call: ServiceCall) -> None:
         coordinator = _resolve_coordinator(call)
         try:
-            path = await async_export_diagnostics(
+            path = await async_export_action_diagnostics(
                 hass,
                 coordinator,
                 include_compressed_map=call.data["include_compressed_map"],
@@ -204,11 +204,12 @@ def async_setup_services(hass: HomeAssistant) -> None:
         persistent_notification.async_create(
             hass,
             (
-                "Read-only Navimower diagnostics export completed.\n\n"
+                "Extended read-only Navimower diagnostics export completed.\n\n"
                 f"File: `{path}`\n\n"
+                "This action export includes notification/event discovery and may take longer. "
                 "The export is sanitized, but review it before publishing."
             ),
-            title="Navimower diagnostics export",
+            title="Navimower extended diagnostics export",
             notification_id="navimower_diagnostics_export",
         )
 

--- a/tests/test_v041_beta19.py
+++ b/tests/test_v041_beta19.py
@@ -1,4 +1,4 @@
-"""Regression contracts for Navimower 0.4.1-beta19."""
+"""Regression contracts carried forward from Navimower 0.4.1-beta19."""
 from __future__ import annotations
 
 import ast
@@ -64,10 +64,12 @@ def test_event_probe_uses_broad_parameter_aliases() -> None:
     assert '"device_extended"' in source
 
 
-def test_native_diagnostics_executes_probe_only_on_export() -> None:
+def test_probe_runs_only_in_explicit_export_path() -> None:
     diagnostics = (COMPONENT / "diagnostics.py").read_text()
+    action_export = (COMPONENT / "action_diagnostics.py").read_text()
     coordinator = (COMPONENT / "coordinator.py").read_text()
-    assert "probe_event_endpoints" in diagnostics
-    assert 'document["notification_event_probe"]' in diagnostics
+    assert "probe_event_endpoints" not in diagnostics
+    assert "probe_event_endpoints" in action_export
+    assert 'document["notification_event_probe"]' in action_export
     assert "probe_event_endpoints" not in coordinator
-    assert "async_add_executor_job" in diagnostics
+    assert "async_add_executor_job" in action_export

--- a/tests/test_v041_beta20.py
+++ b/tests/test_v041_beta20.py
@@ -1,4 +1,4 @@
-"""Regression contracts for Navimower 0.4.1-beta20."""
+"""Regression contracts carried forward from Navimower 0.4.1-beta20."""
 from __future__ import annotations
 
 import ast
@@ -9,9 +9,11 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta20_manifest_and_release_notes() -> None:
+def test_beta20_release_notes_remain_present() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta20"
+    version = manifest["version"]
+    assert version.startswith("0.4.1-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 20
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta20.md").read_text()
     assert notes.startswith("title: Navimower 0.4.1-beta20")
     for phrase in (
@@ -63,11 +65,9 @@ def test_beta20_probe_has_account_and_device_profiles() -> None:
         assert key in source
 
 
-def test_beta20_probe_remains_diagnostics_only_and_read_only() -> None:
-    diagnostics = (COMPONENT / "diagnostics.py").read_text()
+def test_beta20_probe_remains_read_only_and_out_of_coordinator_polling() -> None:
     coordinator = (COMPONENT / "coordinator.py").read_text()
     source = (COMPONENT / "event_probe.py").read_text()
-    assert "probe_event_endpoints" in diagnostics
     assert "probe_event_endpoints" not in coordinator
     for forbidden in (
         "/vehicle/set/send",

--- a/tests/test_v041_beta21.py
+++ b/tests/test_v041_beta21.py
@@ -1,0 +1,62 @@
+"""Regression contracts for Navimower 0.4.1-beta21."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta21_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta21"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta21.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta21")
+    for phrase in (
+        "Download diagnostics",
+        "navimower.export_diagnostics",
+        "notification_event_probe",
+        "navimower_diagnostics_latest.json",
+    ):
+        assert phrase in notes
+
+
+def test_native_download_diagnostics_has_no_notification_probe() -> None:
+    source = (COMPONENT / "diagnostics.py").read_text()
+    ast.parse(source)
+    assert "probe_event_endpoints" not in source
+    assert '"notification_event_probe"' not in source
+    assert '"home_assistant_download"' in source
+    assert "state_transition_diagnostics" in source
+
+
+def test_action_export_contains_notification_probe_and_writes_latest() -> None:
+    source = (COMPONENT / "action_diagnostics.py").read_text()
+    ast.parse(source)
+    assert "probe_event_endpoints" in source
+    assert 'document["notification_event_probe"]' in source
+    assert '"navimower.export_diagnostics"' in source
+    assert '"navimower_diagnostics_latest.json"' in source
+    assert "state_transition_diagnostics" in source
+    assert "async_build_diagnostics" in source
+
+
+def test_export_service_uses_extended_action_export() -> None:
+    services = (COMPONENT / "services.py").read_text()
+    assert "async_export_action_diagnostics" in services
+    assert "async_export_diagnostics(" not in services
+    assert "includes notification/event discovery" in services
+
+
+def test_action_probe_remains_read_only() -> None:
+    source = (COMPONENT / "event_probe.py").read_text()
+    for forbidden in (
+        "/vehicle/set/send",
+        "/vehicle/set/save-set-data",
+        "/map/index/save",
+        "save_setting(",
+        "mow_zones(",
+    ):
+        assert forbidden not in source


### PR DESCRIPTION
## What changed
- remove notification endpoint probing from native Home Assistant Download diagnostics
- keep Download diagnostics fast while retaining normal sanitized diagnostics and state-transition capture
- route `navimower.export_diagnostics` through a new extended action export
- include beta20 `notification_event_probe` results in the action-generated file
- keep writing timestamped files plus `navimower_diagnostics_latest.json`
- add beta21 regression coverage and release notes

## Why
The beta20 notification probe can take long enough that mobile browser downloads appear stuck. The explicit action is a better place for slow discovery work because it writes directly to Home Assistant storage and can complete independently of a browser download.

## Safety
Notification probing remains read-only, runs only from the explicit export action, and is not part of normal coordinator polling.

## Validation
GitHub Actions should run compile, full pytest/regression checks, hassfest and HACS validation before merge.