### PR TITLE
Navimower 0.4.1-beta22 notification transport probe

### DIFF
--- a/.github/release-notes/0.4.1-beta22.md
+++ b/.github/release-notes/0.4.1-beta22.md
@@ -1,0 +1,9 @@
+title: Navimower 0.4.1-beta22
+
+Beta22 keeps Home Assistant's native Download diagnostics unchanged and moves the next notification discovery round entirely into the explicit `navimower.export_diagnostics` action.
+
+The action probe now pivots away from guessing more message parameters. It tests five focused `/message` and `/push` read paths across both the regional p:101 API host and the regional Navimow H5/Willand host, comparing POST vs GET and multiple request encodings.
+
+Authenticated variants retain the existing Navimow p:101 encryption, so uid/access token/device id remain inside the encrypted business payload. Additional plain variants are deliberately unauthenticated and contain only harmless language/page/pageSize fields; credentials are never placed in plaintext query parameters or request bodies.
+
+The generated `notification_event_probe` records HTTP status counts, host/method/encoding metadata, sanitized JSON/business-code structure, successful response inventory and small sanitized samples. 404 rows are summarized only. Normal coordinator polling and native Download diagnostics remain unchanged.

--- a/custom_components/navimower/action_diagnostics.py
+++ b/custom_components/navimower/action_diagnostics.py
@@ -16,7 +16,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 
 from .diagnostics_export import async_build_diagnostics, sanitize
-from .event_transport_probe import probe_event_transports
+from .event_transport_probe import probe_event_transports as probe_event_endpoints
 
 
 def _write_json(path: Path, document: dict[str, Any]) -> None:
@@ -45,7 +45,7 @@ async def async_export_action_diagnostics(
         )
 
     document["notification_event_probe"] = await hass.async_add_executor_job(
-        probe_event_transports,
+        probe_event_endpoints,
         coordinator.client,
         coordinator.sn,
         coordinator.vehicle_type,

--- a/custom_components/navimower/action_diagnostics.py
+++ b/custom_components/navimower/action_diagnostics.py
@@ -1,8 +1,10 @@
 """Extended diagnostics written by the navimower.export_diagnostics action.
 
-Beta21 deliberately keeps slow notification endpoint discovery out of Home
-Assistant's native Download diagnostics flow. The explicit action may take
-longer and writes its result to /config/navimower_diagnostics for retrieval.
+Beta21 moved slow notification discovery out of Home Assistant's native
+Download diagnostics flow. Beta22 keeps that separation and pivots the explicit
+action probe from parameter guessing to host/method/request-encoding discovery.
+The explicit action may take longer and writes its result to
+/config/navimower_diagnostics for retrieval.
 """
 from __future__ import annotations
 
@@ -14,7 +16,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 
 from .diagnostics_export import async_build_diagnostics, sanitize
-from .event_probe import probe_event_endpoints
+from .event_transport_probe import probe_event_transports
 
 
 def _write_json(path: Path, document: dict[str, Any]) -> None:
@@ -31,7 +33,7 @@ async def async_export_action_diagnostics(
     *,
     include_compressed_map: bool = True,
 ) -> str:
-    """Write extended diagnostics including notification endpoint discovery."""
+    """Write extended diagnostics including notification transport discovery."""
     document = await async_build_diagnostics(
         hass,
         coordinator,
@@ -43,7 +45,7 @@ async def async_export_action_diagnostics(
         )
 
     document["notification_event_probe"] = await hass.async_add_executor_job(
-        probe_event_endpoints,
+        probe_event_transports,
         coordinator.client,
         coordinator.sn,
         coordinator.vehicle_type,

--- a/custom_components/navimower/event_transport_probe.py
+++ b/custom_components/navimower/event_transport_probe.py
@@ -1,0 +1,256 @@
+"""Read-only notification transport discovery for explicit action diagnostics.
+
+Beta22 tests whether the missing Navimow notification timeline lives behind a
+separate host, HTTP method, or request encoding. It is intentionally separate
+from normal polling and Home Assistant's native Download diagnostics flow.
+
+Authenticated variants keep the existing p:101 business payload encrypted.
+Plain variants are deliberately unauthenticated and contain only harmless
+language/pagination fields; credentials are never placed in query parameters or
+plaintext request bodies.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+import hashlib
+import json
+from typing import Any
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from .api import crypto
+from .diagnostics_export import inventory, sanitize
+
+_PATHS: tuple[str, ...] = (
+    "/message/message/list",
+    "/message/notification/list",
+    "/message/center/list",
+    "/push/message/list",
+    "/push/notification/list",
+)
+
+
+def _hosts(client: Any) -> tuple[tuple[str, str], ...]:
+    region = str(getattr(client, "region", "fra") or "fra").lower()
+    return (
+        ("p101", f"https://navimow-{region}.ninebot.com"),
+        ("h5", f"https://navimow-h5-{region}.willand.com"),
+    )
+
+
+def _device_params(sn: str, vehicle_type: Any, language: str) -> dict[str, Any]:
+    return {
+        "vehicle_sn": sn,
+        "vehicle_type": vehicle_type,
+        "language": language,
+        "page": 1,
+        "pageSize": 20,
+    }
+
+
+def _plain_params(language: str) -> dict[str, Any]:
+    return {"language": language, "page": 1, "pageSize": 20}
+
+
+def _body_summary(raw: bytes, content_type: str) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "body_length": len(raw),
+        "body_sha256": hashlib.sha256(raw).hexdigest(),
+        "content_type": content_type,
+    }
+    if not raw:
+        return result
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError, TypeError):
+        result["body_kind"] = "non_json"
+        return result
+
+    result["body_kind"] = "json"
+    decoded = crypto.decode_response(parsed) if isinstance(parsed, dict) else parsed
+    clean = sanitize(decoded)
+    result["response_type"] = type(decoded).__name__
+    result["inventory"] = inventory(clean)
+    if isinstance(decoded, dict):
+        if "code" in decoded:
+            result["business_code"] = sanitize(decoded.get("code"))
+        if "desc" in decoded:
+            result["description"] = sanitize(decoded.get("desc"))
+        if decoded.get("code") == 1:
+            data = sanitize(decoded.get("data"))
+            result["business_ok"] = True
+            result["data_inventory"] = inventory(data)
+            if isinstance(data, list):
+                result["sample"] = data[:2]
+            elif isinstance(data, dict):
+                result["sample"] = {key: data[key] for key in list(data)[:12]}
+    return result
+
+
+def _request(
+    host: str,
+    path: str,
+    *,
+    method: str,
+    encoding: str,
+    envelope: dict[str, Any] | None = None,
+    plain: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    headers = {"ninebot-version": "1"}
+    url = host + path
+    data: bytes | None = None
+
+    if encoding == "p101_json_text_html":
+        headers["Content-Type"] = "text/html"
+        data = json.dumps(envelope or {}, separators=(",", ":")).encode()
+    elif encoding == "p101_json_application_json":
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(envelope or {}, separators=(",", ":")).encode()
+    elif encoding == "p101_form":
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+        data = urllib.parse.urlencode(envelope or {}).encode()
+    elif encoding == "p101_query":
+        url += "?" + urllib.parse.urlencode(envelope or {})
+    elif encoding == "plain_json":
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(plain or {}, separators=(",", ":")).encode()
+    elif encoding == "plain_query":
+        url += "?" + urllib.parse.urlencode(plain or {})
+    else:  # pragma: no cover - defensive contract
+        raise ValueError(f"unsupported probe encoding: {encoding}")
+
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=8) as resp:
+            raw = resp.read()
+            out = {
+                "http_status": getattr(resp, "status", 200),
+                "http_ok": True,
+            }
+            out.update(_body_summary(raw, str(resp.headers.get("Content-Type", ""))))
+            return out
+    except urllib.error.HTTPError as err:
+        raw = err.read()
+        out = {"http_status": err.code, "http_ok": False}
+        out.update(_body_summary(raw, str(err.headers.get("Content-Type", ""))))
+        return out
+    except urllib.error.URLError as err:
+        return {
+            "http_ok": False,
+            "transport_error": sanitize(str(err.reason)),
+        }
+    except Exception as err:  # noqa: BLE001 - bounded diagnostics discovery
+        return {
+            "http_ok": False,
+            "transport_error": sanitize(f"{type(err).__name__}: {err}"),
+        }
+
+
+def probe_event_transports(client: Any, sn: str, vehicle_type: Any) -> dict[str, Any]:
+    """Try bounded read-only host/method/encoding variants for notifications."""
+    language = str(getattr(client, "_language", "en") or "en")  # noqa: SLF001
+    business = client._auth_body(_device_params(sn, vehicle_type, language))  # noqa: SLF001
+    envelope = crypto.pack(deepcopy(business))
+    plain = _plain_params(language)
+
+    variants = (
+        ("POST", "p101_json_text_html", True),
+        ("POST", "p101_json_application_json", True),
+        ("POST", "p101_form", True),
+        ("GET", "p101_query", True),
+        ("POST", "plain_json", False),
+        ("GET", "plain_query", False),
+    )
+
+    attempts: list[dict[str, Any]] = []
+    matches: list[dict[str, Any]] = []
+    status_counts: dict[str, int] = {}
+    not_found_count = 0
+
+    for host_name, host in _hosts(client):
+        for path in _PATHS:
+            path_interesting = False
+            for method, encoding, authenticated in variants:
+                result = _request(
+                    host,
+                    path,
+                    method=method,
+                    encoding=encoding,
+                    envelope=envelope if authenticated else None,
+                    plain=plain if not authenticated else None,
+                )
+                status = result.get("http_status")
+                if status is not None:
+                    status_counts[str(status)] = status_counts.get(str(status), 0) + 1
+                if status == 404:
+                    not_found_count += 1
+                    continue
+
+                row = {
+                    "host": host_name,
+                    "host_url": host,
+                    "path": path,
+                    "method": method,
+                    "encoding": encoding,
+                    "authenticated_encrypted": authenticated,
+                    **result,
+                }
+                attempts.append(row)
+
+                interesting = (
+                    bool(result.get("business_ok"))
+                    or status not in (None, 404, 502)
+                    or result.get("body_kind") == "json"
+                    and result.get("business_code") not in (None, 502)
+                )
+                if interesting:
+                    path_interesting = True
+                    matches.append(
+                        {
+                            "host": host_name,
+                            "path": path,
+                            "method": method,
+                            "encoding": encoding,
+                            "http_status": status,
+                            "business_code": result.get("business_code"),
+                            "business_ok": result.get("business_ok", False),
+                            "inventory": result.get("data_inventory")
+                            or result.get("inventory"),
+                        }
+                    )
+
+                # A real successful business payload is enough for this path/host.
+                if result.get("business_ok"):
+                    break
+
+            # Keep probing other hosts even if one transport is interesting; host
+            # comparison is the purpose of beta22.
+            _ = path_interesting
+
+    return {
+        "read_only": True,
+        "normal_polling_unchanged": True,
+        "native_download_diagnostics_unchanged": True,
+        "candidate_path_count": len(_PATHS),
+        "host_count": len(_hosts(client)),
+        "hosts": [name for name, _host in _hosts(client)],
+        "transport_variants": [
+            f"{method}:{encoding}" for method, encoding, _auth in variants
+        ],
+        "credential_safety": (
+            "Authenticated variants keep uid/access_token/device_id inside the "
+            "encrypted p:101 business payload. Plain variants are unauthenticated "
+            "and contain only language/page/pageSize."
+        ),
+        "attempt_count": len(attempts) + not_found_count,
+        "retained_attempt_count": len(attempts),
+        "not_found_count": not_found_count,
+        "http_status_counts": status_counts,
+        "matches": matches,
+        "attempts": attempts,
+        "note": (
+            "Beta22 pivots from parameter guessing to host, HTTP method and "
+            "request-encoding discovery. 404 rows are summarized only."
+        ),
+    }

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta21"
+  "version": "0.4.1-beta22"
 }

--- a/tests/test_v041_beta21.py
+++ b/tests/test_v041_beta21.py
@@ -1,4 +1,4 @@
-"""Regression contracts for Navimower 0.4.1-beta21."""
+"""Regression contracts carried forward from Navimower 0.4.1-beta21."""
 from __future__ import annotations
 
 import ast
@@ -11,7 +11,9 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_beta21_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta21"
+    version = manifest["version"]
+    assert version.startswith("0.4.1-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 21
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta21.md").read_text()
     assert notes.startswith("title: Navimower 0.4.1-beta21")
     for phrase in (

--- a/tests/test_v041_beta22.py
+++ b/tests/test_v041_beta22.py
@@ -53,11 +53,10 @@ def test_beta22_transport_probe_covers_host_method_and_encoding() -> None:
         '"p101_query"',
         '"plain_json"',
         '"plain_query"',
-        'method="POST"',
     ):
         assert phrase in source
-    assert '"GET"' in source
-    assert '"POST"' in source
+    assert '("GET", "p101_query", True)' in source
+    assert '("POST", "p101_json_text_html", True)' in source
     assert source.count('"/message/') >= 3
     assert source.count('"/push/') >= 2
 

--- a/tests/test_v041_beta22.py
+++ b/tests/test_v041_beta22.py
@@ -1,0 +1,88 @@
+"""Regression contracts for Navimower 0.4.1-beta22."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta22_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta22"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta22.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta22")
+    for phrase in (
+        "Download diagnostics unchanged",
+        "navimower.export_diagnostics",
+        "H5/Willand",
+        "POST vs GET",
+        "credentials are never placed in plaintext",
+    ):
+        assert phrase in notes
+
+
+def test_beta22_native_download_remains_free_of_notification_probe() -> None:
+    source = (COMPONENT / "diagnostics.py").read_text()
+    ast.parse(source)
+    assert "probe_event" not in source
+    assert '"notification_event_probe"' not in source
+    assert '"home_assistant_download"' in source
+
+
+def test_beta22_action_uses_transport_probe() -> None:
+    source = (COMPONENT / "action_diagnostics.py").read_text()
+    ast.parse(source)
+    assert "event_transport_probe" in source
+    assert "probe_event_transports" in source
+    assert 'document["notification_event_probe"]' in source
+    assert '"navimower.export_diagnostics"' in source
+
+
+def test_beta22_transport_probe_covers_host_method_and_encoding() -> None:
+    source = (COMPONENT / "event_transport_probe.py").read_text()
+    ast.parse(source)
+    for phrase in (
+        "navimow-{region}.ninebot.com",
+        "navimow-h5-{region}.willand.com",
+        '"p101_json_text_html"',
+        '"p101_json_application_json"',
+        '"p101_form"',
+        '"p101_query"',
+        '"plain_json"',
+        '"plain_query"',
+        'method="POST"',
+    ):
+        assert phrase in source
+    assert '"GET"' in source
+    assert '"POST"' in source
+    assert source.count('"/message/') >= 3
+    assert source.count('"/push/') >= 2
+
+
+def test_beta22_plain_variants_do_not_include_credentials() -> None:
+    source = (COMPONENT / "event_transport_probe.py").read_text()
+    plain_fn = source[source.index("def _plain_params"):source.index("def _body_summary")]
+    assert "language" in plain_fn
+    assert "pageSize" in plain_fn
+    for forbidden in ("access_token", "uid", "device_id", "vehicle_sn"):
+        assert forbidden not in plain_fn
+
+
+def test_beta22_probe_remains_read_only_and_action_only() -> None:
+    source = (COMPONENT / "event_transport_probe.py").read_text()
+    coordinator = (COMPONENT / "coordinator.py").read_text()
+    for forbidden in (
+        "/vehicle/set/send",
+        "/vehicle/set/save-set-data",
+        "/map/index/save",
+        "save_setting(",
+        "mow_zones(",
+    ):
+        assert forbidden not in source
+    assert "event_transport_probe" not in coordinator
+    assert '"not_found_count"' in source
+    assert '"http_status_counts"' in source
+    assert '"native_download_diagnostics_unchanged": True' in source


### PR DESCRIPTION
## What changed
- keep native Home Assistant Download diagnostics unchanged and free of notification probing
- keep notification discovery only behind `navimower.export_diagnostics`
- pivot discovery from more parameter guessing to transport discovery
- probe five focused message/push read paths across the regional p:101 Ninebot host and Navimow H5/Willand host
- compare POST vs GET plus p:101 text/html JSON, application/json, form and query encodings
- add unauthenticated benign plain GET/POST probes containing only language/page/pageSize
- retain HTTP status counts, sanitized response structure, business codes and successful data samples
- summarize 404 attempts only
- add beta22 regression coverage and release notes

## Credential safety
Authenticated variants keep uid/access token/device id inside the existing encrypted p:101 business payload. Plain variants do not contain credentials or mower identity.

## Safety
All probed paths are read-only message/push candidates. The probe runs only during the explicit export action and is not part of coordinator polling or native Download diagnostics.
