### PR TITLE
Navimower 0.4.1-beta23 H5 frontend discovery

### DIFF
--- a/.github/release-notes/0.4.1-beta23.md
+++ b/.github/release-notes/0.4.1-beta23.md
@@ -1,0 +1,21 @@
+title: Navimower 0.4.1-beta23
+
+## H5 frontend discovery in Download diagnostics
+
+Beta23 stops brute-forcing guessed notification API paths. Home Assistant **Download diagnostics** now performs a bounded, public-only H5 frontend discovery pass:
+
+- fetches the Navimow H5 frontend shell from the regional `willand.com` host;
+- extracts referenced JavaScript bundle URLs;
+- fetches at most six script assets with strict timeout and byte limits;
+- records only structural clues such as discovered hosts, absolute URLs, base-URL candidates, and quoted strings related to `message`, `notification`, `notice`, `push`, `event`, API paths, `baseURL`, `graphql`, and `axios`;
+- stores SHA-256/body-length metadata but never stores the full HTML or JavaScript source bodies.
+
+The H5 requests are unauthenticated public GETs. They send no Navimow uid, access token, device id, vehicle serial, or p:101 business payload.
+
+## Diagnostics action
+
+`navimower.export_diagnostics` no longer runs notification/H5 discovery. It returns to being the extended on-disk diagnostic export, including the normal integration diagnostics and state-transition capture.
+
+## Safety
+
+Normal coordinator polling and mower control behavior are unchanged. The H5 discovery runs only when Home Assistant Download diagnostics is explicitly requested.

--- a/custom_components/navimower/action_diagnostics.py
+++ b/custom_components/navimower/action_diagnostics.py
@@ -1,10 +1,8 @@
 """Extended diagnostics written by the navimower.export_diagnostics action.
 
-Beta21 moved slow notification discovery out of Home Assistant's native
-Download diagnostics flow. Beta22 keeps that separation and pivots the explicit
-action probe from parameter guessing to host/method/request-encoding discovery.
-The explicit action may take longer and writes its result to
-/config/navimower_diagnostics for retrieval.
+Beta23 removes notification/H5 discovery from this action. The action returns to
+being a predictable extended on-disk export; H5 frontend discovery now runs only
+from Home Assistant's native Download diagnostics flow.
 """
 from __future__ import annotations
 
@@ -16,7 +14,6 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 
 from .diagnostics_export import async_build_diagnostics, sanitize
-from .event_transport_probe import probe_event_transports as probe_event_endpoints
 
 
 def _write_json(path: Path, document: dict[str, Any]) -> None:
@@ -33,7 +30,7 @@ async def async_export_action_diagnostics(
     *,
     include_compressed_map: bool = True,
 ) -> str:
-    """Write extended diagnostics including notification transport discovery."""
+    """Write extended diagnostics to /config without H5/notification probing."""
     document = await async_build_diagnostics(
         hass,
         coordinator,
@@ -43,13 +40,6 @@ async def async_export_action_diagnostics(
         document["state_transition_capture"] = sanitize(
             coordinator.state_transition_diagnostics()
         )
-
-    document["notification_event_probe"] = await hass.async_add_executor_job(
-        probe_event_endpoints,
-        coordinator.client,
-        coordinator.sn,
-        coordinator.vehicle_type,
-    )
     document["diagnostics_source"] = "navimower.export_diagnostics"
 
     now = datetime.now(timezone.utc)

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .diagnostics_export import async_build_diagnostics, sanitize
+from .h5_discovery import probe_h5_frontend
 
 
 async def async_get_config_entry_diagnostics(
@@ -27,9 +28,6 @@ async def async_get_config_entry_diagnostics(
             },
         }
 
-    # Native HA diagnostics stays fast and predictable. Slow notification/event
-    # endpoint discovery is intentionally reserved for the explicit
-    # navimower.export_diagnostics action in beta21.
     document = await async_build_diagnostics(
         hass,
         coordinator,
@@ -39,5 +37,13 @@ async def async_get_config_entry_diagnostics(
         document["state_transition_capture"] = sanitize(
             coordinator.state_transition_diagnostics()
         )
+
+    # Beta23 moves notification discovery back to the native Download diagnostics
+    # flow, but no longer brute-forces API paths. It follows only public H5 HTML
+    # and a bounded set of referenced JavaScript assets, storing structural clues.
+    document["h5_frontend_discovery"] = await hass.async_add_executor_job(
+        probe_h5_frontend,
+        coordinator.client,
+    )
     document["diagnostics_source"] = "home_assistant_download"
     return document

--- a/custom_components/navimower/h5_discovery.py
+++ b/custom_components/navimower/h5_discovery.py
@@ -1,0 +1,274 @@
+"""Read-only H5 frontend discovery for native Home Assistant diagnostics.
+
+Beta23 stops guessing notification API paths. Instead it fetches the public
+Navimow H5 frontend shell, follows a bounded number of referenced JavaScript
+bundles, and records only structural clues such as hosts, API-like paths and
+message/notification-related string literals.
+
+No Navimow credentials, mower identifiers or p:101 payloads are sent to H5.
+The fetched HTML/JavaScript bodies are never stored in diagnostics.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from .diagnostics_export import sanitize
+
+_ENTRY_PATHS: tuple[str, ...] = (
+    "/message/message/list",
+    "/old/",
+)
+_KEYWORDS: tuple[str, ...] = (
+    "message",
+    "notification",
+    "notice",
+    "push",
+    "event",
+    "baseurl",
+    "graphql",
+    "axios",
+)
+_MAX_HTML_BYTES = 256 * 1024
+_MAX_JS_BYTES = 2 * 1024 * 1024
+_MAX_SCRIPT_ASSETS = 6
+_MAX_FINDINGS = 80
+_TIMEOUT_SECONDS = 5
+
+_SCRIPT_SRC_RE = re.compile(
+    r"<script\b[^>]*\bsrc\s*=\s*[\"']([^\"']+)[\"'][^>]*>",
+    re.IGNORECASE,
+)
+_ABSOLUTE_URL_RE = re.compile(
+    r"https?://[A-Za-z0-9._:-]+(?:/[A-Za-z0-9_./?&=%+#@~,:;!$()*+\-]{0,300})?"
+)
+_QUOTED_STRING_RE = re.compile(r"[\"']([^\"'\r\n]{2,300})[\"']")
+_BASE_URL_RE = re.compile(
+    r"(?:baseURL|baseUrl|apiBase|apiBaseUrl|baseApi)\s*[:=]\s*[\"']([^\"']{1,300})[\"']"
+)
+
+
+def _h5_host(client: Any) -> str:
+    region = str(getattr(client, "region", "fra") or "fra").lower()
+    return f"https://navimow-h5-{region}.willand.com"
+
+
+def _safe_url(url: str) -> str:
+    """Drop query/fragment before persisting a discovered URL."""
+    parsed = urllib.parse.urlsplit(str(url))
+    return urllib.parse.urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, "", "")
+    )
+
+
+def _fetch(url: str, max_bytes: int) -> dict[str, Any]:
+    """Fetch one public GET resource with a hard byte/time bound."""
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "text/html,application/javascript,text/javascript,*/*;q=0.8",
+            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.1-beta23",
+        },
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_SECONDS) as resp:
+            raw = resp.read(max_bytes + 1)
+            status = int(getattr(resp, "status", 200))
+            content_type = str(resp.headers.get("Content-Type", ""))
+    except urllib.error.HTTPError as err:
+        raw = err.read(max_bytes + 1)
+        status = int(err.code)
+        content_type = str(err.headers.get("Content-Type", ""))
+    except urllib.error.URLError as err:
+        return {
+            "ok": False,
+            "url": _safe_url(url),
+            "transport_error": sanitize(str(err.reason)),
+        }
+    except Exception as err:  # noqa: BLE001 - bounded diagnostics discovery
+        return {
+            "ok": False,
+            "url": _safe_url(url),
+            "transport_error": sanitize(f"{type(err).__name__}: {err}"),
+        }
+
+    truncated = len(raw) > max_bytes
+    raw = raw[:max_bytes]
+    return {
+        "ok": 200 <= status < 400,
+        "url": _safe_url(url),
+        "http_status": status,
+        "content_type": content_type,
+        "body_length_read": len(raw),
+        "body_sha256": hashlib.sha256(raw).hexdigest(),
+        "truncated": truncated,
+        "_text": raw.decode("utf-8", errors="replace"),
+    }
+
+
+def _extract_script_urls(html: str, base_url: str) -> list[str]:
+    urls: list[str] = []
+    seen: set[str] = set()
+    for src in _SCRIPT_SRC_RE.findall(html):
+        url = urllib.parse.urljoin(base_url, src.strip())
+        parsed = urllib.parse.urlsplit(url)
+        if parsed.scheme != "https" or not parsed.netloc:
+            continue
+        if url in seen:
+            continue
+        seen.add(url)
+        urls.append(url)
+    return urls
+
+
+def _prioritize_scripts(urls: list[str]) -> list[str]:
+    def score(url: str) -> tuple[int, int]:
+        path = urllib.parse.urlsplit(url).path.lower()
+        preferred = any(token in path for token in ("app", "main", "index", "runtime"))
+        vendor = "vendor" in path
+        return (0 if preferred else 1 if not vendor else 2, len(path))
+
+    return sorted(urls, key=score)[:_MAX_SCRIPT_ASSETS]
+
+
+def _scan_text(text: str) -> dict[str, Any]:
+    """Return only compact static structure clues, never the source body."""
+    lower = text.lower()
+    keyword_counts = {
+        keyword: lower.count(keyword)
+        for keyword in _KEYWORDS
+        if keyword in lower
+    }
+
+    absolute_urls: set[str] = set()
+    hosts: set[str] = set()
+    for match in _ABSOLUTE_URL_RE.findall(text):
+        safe = _safe_url(match)
+        absolute_urls.add(safe)
+        host = urllib.parse.urlsplit(safe).netloc
+        if host:
+            hosts.add(host)
+
+    base_urls = {_safe_url(value) for value in _BASE_URL_RE.findall(text)}
+
+    api_like_strings: set[str] = set()
+    for value in _QUOTED_STRING_RE.findall(text):
+        candidate = value.strip()
+        low = candidate.lower()
+        if len(candidate) > 240:
+            continue
+        if (
+            any(keyword in low for keyword in _KEYWORDS)
+            or "/api/" in low
+            or low.startswith("api/")
+        ):
+            api_like_strings.add(candidate)
+
+    return {
+        "keyword_counts": keyword_counts,
+        "hosts": sorted(hosts)[:_MAX_FINDINGS],
+        "absolute_urls": sorted(absolute_urls)[:_MAX_FINDINGS],
+        "base_url_candidates": sorted(base_urls)[:_MAX_FINDINGS],
+        "api_like_strings": sorted(api_like_strings)[:_MAX_FINDINGS],
+    }
+
+
+def _public_result(result: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in result.items() if key != "_text"}
+
+
+def probe_h5_frontend(client: Any) -> dict[str, Any]:
+    """Inspect public H5 shells and bounded JS assets for API route clues."""
+    host = _h5_host(client)
+    pages: list[dict[str, Any]] = []
+    all_scripts: list[str] = []
+    seen_page_hashes: set[str] = set()
+    merged_hosts: set[str] = set()
+    merged_urls: set[str] = set()
+    merged_base_urls: set[str] = set()
+    merged_strings: set[str] = set()
+
+    for path in _ENTRY_PATHS:
+        url = urllib.parse.urljoin(host + "/", path.lstrip("/"))
+        result = _fetch(url, _MAX_HTML_BYTES)
+        text = str(result.get("_text") or "")
+        row = _public_result(result)
+        if text:
+            findings = _scan_text(text)
+            row["findings"] = findings
+            merged_hosts.update(findings["hosts"])
+            merged_urls.update(findings["absolute_urls"])
+            merged_base_urls.update(findings["base_url_candidates"])
+            merged_strings.update(findings["api_like_strings"])
+            scripts = _extract_script_urls(text, url)
+            row["script_count"] = len(scripts)
+            row["script_urls"] = [_safe_url(item) for item in scripts[:20]]
+            if result.get("body_sha256") not in seen_page_hashes:
+                all_scripts.extend(scripts)
+                seen_page_hashes.add(str(result.get("body_sha256")))
+        pages.append(row)
+
+    unique_scripts: list[str] = []
+    seen_scripts: set[str] = set()
+    for url in all_scripts:
+        if url in seen_scripts:
+            continue
+        seen_scripts.add(url)
+        unique_scripts.append(url)
+
+    selected_scripts = _prioritize_scripts(unique_scripts)
+    assets: list[dict[str, Any]] = []
+
+    for url in selected_scripts:
+        result = _fetch(url, _MAX_JS_BYTES)
+        text = str(result.get("_text") or "")
+        row = _public_result(result)
+        if text:
+            findings = _scan_text(text)
+            row["findings"] = findings
+            merged_hosts.update(findings["hosts"])
+            merged_urls.update(findings["absolute_urls"])
+            merged_base_urls.update(findings["base_url_candidates"])
+            merged_strings.update(findings["api_like_strings"])
+        assets.append(row)
+
+    return {
+        "read_only": True,
+        "public_unauthenticated_only": True,
+        "normal_polling_unchanged": True,
+        "source": "home_assistant_download",
+        "host": host,
+        "entry_paths": list(_ENTRY_PATHS),
+        "limits": {
+            "timeout_seconds_per_request": _TIMEOUT_SECONDS,
+            "max_html_bytes": _MAX_HTML_BYTES,
+            "max_js_bytes_per_asset": _MAX_JS_BYTES,
+            "max_script_assets": _MAX_SCRIPT_ASSETS,
+            "max_findings_per_category": _MAX_FINDINGS,
+        },
+        "credential_safety": (
+            "H5 discovery sends no uid, access token, device id, vehicle serial "
+            "or encrypted p:101 business payload. Source bodies are not stored."
+        ),
+        "page_count": len(pages),
+        "discovered_script_count": len(unique_scripts),
+        "inspected_script_count": len(assets),
+        "summary": {
+            "hosts": sorted(merged_hosts)[:_MAX_FINDINGS],
+            "absolute_urls": sorted(merged_urls)[:_MAX_FINDINGS],
+            "base_url_candidates": sorted(merged_base_urls)[:_MAX_FINDINGS],
+            "api_like_strings": sorted(merged_strings)[:_MAX_FINDINGS],
+        },
+        "pages": pages,
+        "assets": assets,
+        "note": (
+            "Beta23 follows public H5 HTML -> JavaScript references and records "
+            "only bounded structural clues that may reveal the notification API "
+            "host or route family."
+        ),
+    }

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta22"
+  "version": "0.4.1-beta23"
 }

--- a/custom_components/navimower/services.py
+++ b/custom_components/navimower/services.py
@@ -32,8 +32,6 @@ from .beta16_runtime import install_beta16_runtime
 from .model_support import supports_ordered_zone_mowing
 from .state_transition_capture import install_state_transition_capture
 
-# Keep beta15's diagnostic transition capture for further field testing, then
-# layer the beta16 public state/error semantics over the already-wrapped methods.
 install_state_transition_capture()
 install_beta16_runtime()
 
@@ -42,7 +40,6 @@ SERVICE_MOW = "mow"
 SERVICE_EXPORT_DIAGNOSTICS = "export_diagnostics"
 SERVICE_MARK_DISCOVERY_EVENT = "mark_discovery_event"
 
-# Navimow weekday numbering is 1=Sun .. 7=Sat.
 _WEEKDAY_TO_NUM = {
     "sunday": 1,
     "monday": 2,
@@ -206,7 +203,8 @@ def async_setup_services(hass: HomeAssistant) -> None:
             (
                 "Extended read-only Navimower diagnostics export completed.\n\n"
                 f"File: `{path}`\n\n"
-                "This action export includes notification/event discovery and may take longer. "
+                "Beta23 does not run notification/H5 discovery from this action. "
+                "Use Home Assistant Download diagnostics for the H5 discovery block. "
                 "The export is sanitized, but review it before publishing."
             ),
             title="Navimower extended diagnostics export",

--- a/tests/test_v041_beta19.py
+++ b/tests/test_v041_beta19.py
@@ -64,12 +64,6 @@ def test_event_probe_uses_broad_parameter_aliases() -> None:
     assert '"device_extended"' in source
 
 
-def test_probe_runs_only_in_explicit_export_path() -> None:
-    diagnostics = (COMPONENT / "diagnostics.py").read_text()
-    action_export = (COMPONENT / "action_diagnostics.py").read_text()
+def test_beta19_probe_code_remains_out_of_normal_polling() -> None:
     coordinator = (COMPONENT / "coordinator.py").read_text()
-    assert "probe_event_endpoints" not in diagnostics
-    assert "probe_event_endpoints" in action_export
-    assert 'document["notification_event_probe"]' in action_export
     assert "probe_event_endpoints" not in coordinator
-    assert "async_add_executor_job" in action_export

--- a/tests/test_v041_beta21.py
+++ b/tests/test_v041_beta21.py
@@ -25,34 +25,22 @@ def test_beta21_manifest_and_release_notes() -> None:
         assert phrase in notes
 
 
-def test_native_download_diagnostics_has_no_notification_probe() -> None:
-    source = (COMPONENT / "diagnostics.py").read_text()
-    ast.parse(source)
-    assert "probe_event_endpoints" not in source
-    assert '"notification_event_probe"' not in source
-    assert '"home_assistant_download"' in source
-    assert "state_transition_diagnostics" in source
-
-
-def test_action_export_contains_notification_probe_and_writes_latest() -> None:
+def test_action_export_still_writes_latest_and_state_capture() -> None:
     source = (COMPONENT / "action_diagnostics.py").read_text()
     ast.parse(source)
-    assert "probe_event_endpoints" in source
-    assert 'document["notification_event_probe"]' in source
     assert '"navimower.export_diagnostics"' in source
     assert '"navimower_diagnostics_latest.json"' in source
     assert "state_transition_diagnostics" in source
     assert "async_build_diagnostics" in source
 
 
-def test_export_service_uses_extended_action_export() -> None:
+def test_export_service_still_uses_action_export() -> None:
     services = (COMPONENT / "services.py").read_text()
     assert "async_export_action_diagnostics" in services
     assert "async_export_diagnostics(" not in services
-    assert "includes notification/event discovery" in services
 
 
-def test_action_probe_remains_read_only() -> None:
+def test_legacy_action_probe_code_remains_read_only() -> None:
     source = (COMPONENT / "event_probe.py").read_text()
     for forbidden in (
         "/vehicle/set/send",

--- a/tests/test_v041_beta22.py
+++ b/tests/test_v041_beta22.py
@@ -1,4 +1,4 @@
-"""Regression contracts for Navimower 0.4.1-beta22."""
+"""Regression contracts carried forward from Navimower 0.4.1-beta22."""
 from __future__ import annotations
 
 import ast
@@ -9,9 +9,11 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta22_manifest_and_release_notes() -> None:
+def test_beta22_release_notes_remain_present() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta22"
+    version = manifest["version"]
+    assert version.startswith("0.4.1-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 22
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta22.md").read_text()
     assert notes.startswith("title: Navimower 0.4.1-beta22")
     for phrase in (
@@ -24,24 +26,7 @@ def test_beta22_manifest_and_release_notes() -> None:
         assert phrase in notes
 
 
-def test_beta22_native_download_remains_free_of_notification_probe() -> None:
-    source = (COMPONENT / "diagnostics.py").read_text()
-    ast.parse(source)
-    assert "probe_event" not in source
-    assert '"notification_event_probe"' not in source
-    assert '"home_assistant_download"' in source
-
-
-def test_beta22_action_uses_transport_probe() -> None:
-    source = (COMPONENT / "action_diagnostics.py").read_text()
-    ast.parse(source)
-    assert "event_transport_probe" in source
-    assert "probe_event_transports" in source
-    assert 'document["notification_event_probe"]' in source
-    assert '"navimower.export_diagnostics"' in source
-
-
-def test_beta22_transport_probe_covers_host_method_and_encoding() -> None:
+def test_beta22_transport_probe_code_is_preserved_and_read_only() -> None:
     source = (COMPONENT / "event_transport_probe.py").read_text()
     ast.parse(source)
     for phrase in (
@@ -57,8 +42,14 @@ def test_beta22_transport_probe_covers_host_method_and_encoding() -> None:
         assert phrase in source
     assert '("GET", "p101_query", True)' in source
     assert '("POST", "p101_json_text_html", True)' in source
-    assert source.count('"/message/') >= 3
-    assert source.count('"/push/') >= 2
+    for forbidden in (
+        "/vehicle/set/send",
+        "/vehicle/set/save-set-data",
+        "/map/index/save",
+        "save_setting(",
+        "mow_zones(",
+    ):
+        assert forbidden not in source
 
 
 def test_beta22_plain_variants_do_not_include_credentials() -> None:
@@ -68,20 +59,3 @@ def test_beta22_plain_variants_do_not_include_credentials() -> None:
     assert "pageSize" in plain_fn
     for forbidden in ("access_token", "uid", "device_id", "vehicle_sn"):
         assert forbidden not in plain_fn
-
-
-def test_beta22_probe_remains_read_only_and_action_only() -> None:
-    source = (COMPONENT / "event_transport_probe.py").read_text()
-    coordinator = (COMPONENT / "coordinator.py").read_text()
-    for forbidden in (
-        "/vehicle/set/send",
-        "/vehicle/set/save-set-data",
-        "/map/index/save",
-        "save_setting(",
-        "mow_zones(",
-    ):
-        assert forbidden not in source
-    assert "event_transport_probe" not in coordinator
-    assert '"not_found_count"' in source
-    assert '"http_status_counts"' in source
-    assert '"native_download_diagnostics_unchanged": True' in source

--- a/tests/test_v041_beta23.py
+++ b/tests/test_v041_beta23.py
@@ -1,0 +1,84 @@
+"""Regression contracts for Navimower 0.4.1-beta23."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta23_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta23"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta23.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta23")
+    for phrase in (
+        "Download diagnostics",
+        "H5 frontend",
+        "JavaScript bundle",
+        "public GETs",
+        "navimower.export_diagnostics",
+    ):
+        assert phrase in notes
+
+
+def test_beta23_download_diagnostics_runs_h5_discovery() -> None:
+    source = (COMPONENT / "diagnostics.py").read_text()
+    ast.parse(source)
+    assert "probe_h5_frontend" in source
+    assert 'document["h5_frontend_discovery"]' in source
+    assert "async_add_executor_job" in source
+    assert '"home_assistant_download"' in source
+
+
+def test_beta23_action_has_no_notification_or_h5_probe() -> None:
+    source = (COMPONENT / "action_diagnostics.py").read_text()
+    ast.parse(source)
+    assert "probe_event" not in source
+    assert "probe_h5" not in source
+    assert '"notification_event_probe"' not in source
+    assert '"h5_frontend_discovery"' not in source
+    assert '"navimower_diagnostics_latest.json"' in source
+
+
+def test_beta23_h5_discovery_is_bounded_public_and_body_free() -> None:
+    source = (COMPONENT / "h5_discovery.py").read_text()
+    ast.parse(source)
+    for phrase in (
+        "_MAX_HTML_BYTES",
+        "_MAX_JS_BYTES",
+        "_MAX_SCRIPT_ASSETS = 6",
+        "_TIMEOUT_SECONDS = 5",
+        '"public_unauthenticated_only": True',
+        '"source": "home_assistant_download"',
+        "body_sha256",
+        "script_urls",
+        "base_url_candidates",
+        "api_like_strings",
+    ):
+        assert phrase in source
+    assert 'method="GET"' in source
+    assert '"_text"' in source
+    assert 'key != "_text"' in source
+
+
+def test_beta23_h5_requests_never_send_credentials_or_mower_identity() -> None:
+    source = (COMPONENT / "h5_discovery.py").read_text()
+    fetch_fn = source[source.index("def _fetch"):source.index("def _extract_script_urls")]
+    for forbidden in (
+        "access_token",
+        "refresh_token",
+        "vehicle_sn",
+        "device_id",
+        "crypto.pack",
+        "_auth_body",
+    ):
+        assert forbidden not in fetch_fn
+
+
+def test_beta23_h5_discovery_remains_out_of_polling() -> None:
+    coordinator = (COMPONENT / "coordinator.py").read_text()
+    assert "probe_h5_frontend" not in coordinator
+    assert "h5_frontend_discovery" not in coordinator


### PR DESCRIPTION
## What changed
- remove notification/H5 discovery from `navimower.export_diagnostics`
- move discovery back to native Home Assistant Download diagnostics
- stop brute-forcing guessed notification API endpoints
- add bounded public H5 frontend discovery: fetch H5 shell, extract script URLs, inspect at most six JavaScript assets
- record only structural clues: hosts, absolute URLs, base URL candidates, message/notification/notice/push/event/API-like strings, body length and SHA-256
- never store full HTML or JavaScript bodies
- H5 requests are unauthenticated public GETs and send no uid, access token, device id, mower serial, or p:101 business payload
- normal polling and mower control are unchanged

## Release
Version: `0.4.1-beta23`
