### PR TITLE
Navimower 0.4.1-beta24 native bridge discovery

### DIFF
--- a/.github/release-notes/0.4.1-beta24.md
+++ b/.github/release-notes/0.4.1-beta24.md
@@ -1,0 +1,11 @@
+title: Navimower 0.4.1-beta24
+
+Beta24 narrows notification discovery again. Instead of guessing more API endpoints, Download diagnostics now inspects the already discovered public H5 JavaScript bundles for native bridge and literal HTTP route clues.
+
+- Download diagnostics keeps the public H5 discovery introduced in beta23.
+- Adds native bridge method/callback extraction around `sendMessageToNative`, WebKit `messageHandlers`, and `AndroidAndJs` patterns.
+- Captures bounded context around bridge and notification terms such as `newMessages`, `notification`, and notice-title variants.
+- Extracts literal message/notification/notice/push/event/API paths and literal strings passed to fetch/axios/get/post patterns.
+- Context and finding counts are strictly bounded; full HTML/JavaScript bodies are never stored.
+- H5 discovery still uses public GET requests only and sends no credentials, mower identity, device id, or p:101 payload.
+- `navimower.export_diagnostics`, normal polling, mower control, history, map and state handling are unchanged.

--- a/custom_components/navimower/h5_discovery.py
+++ b/custom_components/navimower/h5_discovery.py
@@ -1,12 +1,12 @@
-"""Read-only H5 frontend discovery for native Home Assistant diagnostics.
+"""Read-only H5/native-bridge discovery for Home Assistant diagnostics.
 
-Beta23 stops guessing notification API paths. Instead it fetches the public
-Navimow H5 frontend shell, follows a bounded number of referenced JavaScript
-bundles, and records only structural clues such as hosts, API-like paths and
-message/notification-related string literals.
+Beta24 builds on beta23's public H5 asset discovery. It still fetches only public,
+unauthenticated HTML/JavaScript, but now extracts higher-value structural clues:
+native bridge method/callback literals, bounded context around bridge/notification
+keywords, and literal API-like strings passed to fetch/axios/get/post patterns.
 
 No Navimow credentials, mower identifiers or p:101 payloads are sent to H5.
-The fetched HTML/JavaScript bodies are never stored in diagnostics.
+Fetched source bodies are never stored in diagnostics.
 """
 from __future__ import annotations
 
@@ -32,11 +32,26 @@ _KEYWORDS: tuple[str, ...] = (
     "baseurl",
     "graphql",
     "axios",
+    "sendmessagetonative",
+    "messagehandlers",
+    "androidandjs",
+    "newmessages",
+)
+_CONTEXT_TERMS: tuple[str, ...] = (
+    "sendMessageToNative",
+    "messageHandlers",
+    "AndroidAndJs",
+    "newMessages",
+    "notification",
+    "notice_title",
+    "noticeTitle",
 )
 _MAX_HTML_BYTES = 256 * 1024
 _MAX_JS_BYTES = 2 * 1024 * 1024
 _MAX_SCRIPT_ASSETS = 6
 _MAX_FINDINGS = 80
+_MAX_CONTEXTS = 24
+_CONTEXT_RADIUS = 260
 _TIMEOUT_SECONDS = 5
 
 _SCRIPT_SRC_RE = re.compile(
@@ -50,6 +65,30 @@ _QUOTED_STRING_RE = re.compile(r"[\"']([^\"'\r\n]{2,300})[\"']")
 _BASE_URL_RE = re.compile(
     r"(?:baseURL|baseUrl|apiBase|apiBaseUrl|baseApi)\s*[:=]\s*[\"']([^\"']{1,300})[\"']"
 )
+_PATH_LITERAL_RE = re.compile(
+    r"[\"'](/[^\"'\r\n]{1,240})[\"']"
+)
+_CALL_LITERAL_RE = re.compile(
+    r"(?:fetch|axios(?:\.(?:get|post|put|delete|request))?|\.(?:get|post|put|delete))"
+    r"\s*\(\s*[\"']([^\"'\r\n]{1,240})[\"']",
+    re.IGNORECASE,
+)
+_BRIDGE_OBJECT_RE = re.compile(
+    r"(?:sendMessageToNative\s*\(|postMessage\s*\()(?P<body>.{0,800}?)(?:\)|;)",
+    re.IGNORECASE | re.DOTALL,
+)
+_METHOD_LITERAL_RE = re.compile(
+    r"(?:method|action|name)\s*:\s*[\"']([^\"']{1,120})[\"']",
+    re.IGNORECASE,
+)
+_CALLBACK_LITERAL_RE = re.compile(
+    r"callback\s*:\s*[\"']([^\"']{1,160})[\"']",
+    re.IGNORECASE,
+)
+_DIRECT_BRIDGE_RE = re.compile(
+    r"sendMessageToNative\s*\(\s*[\"']([^\"']{1,120})[\"']",
+    re.IGNORECASE,
+)
 
 
 def _h5_host(client: Any) -> str:
@@ -58,20 +97,16 @@ def _h5_host(client: Any) -> str:
 
 
 def _safe_url(url: str) -> str:
-    """Drop query/fragment before persisting a discovered URL."""
     parsed = urllib.parse.urlsplit(str(url))
-    return urllib.parse.urlunsplit(
-        (parsed.scheme, parsed.netloc, parsed.path, "", "")
-    )
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
 
 
 def _fetch(url: str, max_bytes: int) -> dict[str, Any]:
-    """Fetch one public GET resource with a hard byte/time bound."""
     req = urllib.request.Request(
         url,
         headers={
             "Accept": "text/html,application/javascript,text/javascript,*/*;q=0.8",
-            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.1-beta23",
+            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.1-beta24",
         },
         method="GET",
     )
@@ -85,11 +120,7 @@ def _fetch(url: str, max_bytes: int) -> dict[str, Any]:
         status = int(err.code)
         content_type = str(err.headers.get("Content-Type", ""))
     except urllib.error.URLError as err:
-        return {
-            "ok": False,
-            "url": _safe_url(url),
-            "transport_error": sanitize(str(err.reason)),
-        }
+        return {"ok": False, "url": _safe_url(url), "transport_error": sanitize(str(err.reason))}
     except Exception as err:  # noqa: BLE001 - bounded diagnostics discovery
         return {
             "ok": False,
@@ -117,9 +148,7 @@ def _extract_script_urls(html: str, base_url: str) -> list[str]:
     for src in _SCRIPT_SRC_RE.findall(html):
         url = urllib.parse.urljoin(base_url, src.strip())
         parsed = urllib.parse.urlsplit(url)
-        if parsed.scheme != "https" or not parsed.netloc:
-            continue
-        if url in seen:
+        if parsed.scheme != "https" or not parsed.netloc or url in seen:
             continue
         seen.add(url)
         urls.append(url)
@@ -129,21 +158,89 @@ def _extract_script_urls(html: str, base_url: str) -> list[str]:
 def _prioritize_scripts(urls: list[str]) -> list[str]:
     def score(url: str) -> tuple[int, int]:
         path = urllib.parse.urlsplit(url).path.lower()
-        preferred = any(token in path for token in ("app", "main", "index", "runtime"))
+        preferred = any(token in path for token in ("app", "main", "index", "runtime", "entry"))
         vendor = "vendor" in path
         return (0 if preferred else 1 if not vendor else 2, len(path))
 
     return sorted(urls, key=score)[:_MAX_SCRIPT_ASSETS]
 
 
-def _scan_text(text: str) -> dict[str, Any]:
-    """Return only compact static structure clues, never the source body."""
-    lower = text.lower()
-    keyword_counts = {
-        keyword: lower.count(keyword)
-        for keyword in _KEYWORDS
-        if keyword in lower
+def _interesting_path(value: str) -> bool:
+    low = value.lower()
+    return (
+        any(token in low for token in ("message", "notification", "notice", "push", "event"))
+        or "/api/" in low
+        or low.startswith("/api")
+        or low.startswith("api/")
+    )
+
+
+def _bridge_findings(text: str) -> dict[str, Any]:
+    methods: set[str] = set(_DIRECT_BRIDGE_RE.findall(text))
+    callbacks: set[str] = set()
+    bridge_objects: list[dict[str, Any]] = []
+
+    for match in _BRIDGE_OBJECT_RE.finditer(text):
+        body = match.group("body")
+        obj_methods = _METHOD_LITERAL_RE.findall(body)
+        obj_callbacks = _CALLBACK_LITERAL_RE.findall(body)
+        methods.update(obj_methods)
+        callbacks.update(obj_callbacks)
+        if obj_methods or obj_callbacks:
+            bridge_objects.append(
+                {
+                    "methods": obj_methods[:8],
+                    "callbacks": obj_callbacks[:8],
+                }
+            )
+        if len(bridge_objects) >= _MAX_FINDINGS:
+            break
+
+    return {
+        "methods": sorted(methods)[:_MAX_FINDINGS],
+        "callbacks": sorted(callbacks)[:_MAX_FINDINGS],
+        "objects": bridge_objects[:_MAX_FINDINGS],
     }
+
+
+def _call_literals(text: str) -> list[str]:
+    values = {value.strip() for value in _CALL_LITERAL_RE.findall(text) if _interesting_path(value)}
+    return sorted(values)[:_MAX_FINDINGS]
+
+
+def _path_literals(text: str) -> list[str]:
+    values = {value.strip() for value in _PATH_LITERAL_RE.findall(text) if _interesting_path(value)}
+    return sorted(values)[:_MAX_FINDINGS]
+
+
+def _contexts(text: str) -> list[dict[str, str]]:
+    lower = text.lower()
+    rows: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for term in _CONTEXT_TERMS:
+        needle = term.lower()
+        start = 0
+        while len(rows) < _MAX_CONTEXTS:
+            idx = lower.find(needle, start)
+            if idx < 0:
+                break
+            lo = max(0, idx - _CONTEXT_RADIUS)
+            hi = min(len(text), idx + len(term) + _CONTEXT_RADIUS)
+            snippet = text[lo:hi]
+            snippet = re.sub(r"\s+", " ", snippet).strip()
+            key = (term.lower(), snippet)
+            if key not in seen:
+                seen.add(key)
+                rows.append({"term": term, "context": snippet})
+            start = idx + len(term)
+        if len(rows) >= _MAX_CONTEXTS:
+            break
+    return rows
+
+
+def _scan_text(text: str) -> dict[str, Any]:
+    lower = text.lower()
+    keyword_counts = {keyword: lower.count(keyword) for keyword in _KEYWORDS if keyword in lower}
 
     absolute_urls: set[str] = set()
     hosts: set[str] = set()
@@ -159,14 +256,7 @@ def _scan_text(text: str) -> dict[str, Any]:
     api_like_strings: set[str] = set()
     for value in _QUOTED_STRING_RE.findall(text):
         candidate = value.strip()
-        low = candidate.lower()
-        if len(candidate) > 240:
-            continue
-        if (
-            any(keyword in low for keyword in _KEYWORDS)
-            or "/api/" in low
-            or low.startswith("api/")
-        ):
+        if len(candidate) <= 240 and _interesting_path(candidate):
             api_like_strings.add(candidate)
 
     return {
@@ -175,6 +265,10 @@ def _scan_text(text: str) -> dict[str, Any]:
         "absolute_urls": sorted(absolute_urls)[:_MAX_FINDINGS],
         "base_url_candidates": sorted(base_urls)[:_MAX_FINDINGS],
         "api_like_strings": sorted(api_like_strings)[:_MAX_FINDINGS],
+        "path_literals": _path_literals(text),
+        "http_call_literals": _call_literals(text),
+        "native_bridge": _bridge_findings(text),
+        "contexts": _contexts(text),
     }
 
 
@@ -183,7 +277,6 @@ def _public_result(result: dict[str, Any]) -> dict[str, Any]:
 
 
 def probe_h5_frontend(client: Any) -> dict[str, Any]:
-    """Inspect public H5 shells and bounded JS assets for API route clues."""
     host = _h5_host(client)
     pages: list[dict[str, Any]] = []
     all_scripts: list[str] = []
@@ -192,6 +285,24 @@ def probe_h5_frontend(client: Any) -> dict[str, Any]:
     merged_urls: set[str] = set()
     merged_base_urls: set[str] = set()
     merged_strings: set[str] = set()
+    merged_paths: set[str] = set()
+    merged_calls: set[str] = set()
+    merged_methods: set[str] = set()
+    merged_callbacks: set[str] = set()
+    merged_contexts: list[dict[str, str]] = []
+
+    def merge(findings: dict[str, Any]) -> None:
+        merged_hosts.update(findings["hosts"])
+        merged_urls.update(findings["absolute_urls"])
+        merged_base_urls.update(findings["base_url_candidates"])
+        merged_strings.update(findings["api_like_strings"])
+        merged_paths.update(findings["path_literals"])
+        merged_calls.update(findings["http_call_literals"])
+        merged_methods.update(findings["native_bridge"]["methods"])
+        merged_callbacks.update(findings["native_bridge"]["callbacks"])
+        for row in findings["contexts"]:
+            if row not in merged_contexts and len(merged_contexts) < _MAX_CONTEXTS:
+                merged_contexts.append(row)
 
     for path in _ENTRY_PATHS:
         url = urllib.parse.urljoin(host + "/", path.lstrip("/"))
@@ -201,10 +312,7 @@ def probe_h5_frontend(client: Any) -> dict[str, Any]:
         if text:
             findings = _scan_text(text)
             row["findings"] = findings
-            merged_hosts.update(findings["hosts"])
-            merged_urls.update(findings["absolute_urls"])
-            merged_base_urls.update(findings["base_url_candidates"])
-            merged_strings.update(findings["api_like_strings"])
+            merge(findings)
             scripts = _extract_script_urls(text, url)
             row["script_count"] = len(scripts)
             row["script_urls"] = [_safe_url(item) for item in scripts[:20]]
@@ -221,20 +329,15 @@ def probe_h5_frontend(client: Any) -> dict[str, Any]:
         seen_scripts.add(url)
         unique_scripts.append(url)
 
-    selected_scripts = _prioritize_scripts(unique_scripts)
     assets: list[dict[str, Any]] = []
-
-    for url in selected_scripts:
+    for url in _prioritize_scripts(unique_scripts):
         result = _fetch(url, _MAX_JS_BYTES)
         text = str(result.get("_text") or "")
         row = _public_result(result)
         if text:
             findings = _scan_text(text)
             row["findings"] = findings
-            merged_hosts.update(findings["hosts"])
-            merged_urls.update(findings["absolute_urls"])
-            merged_base_urls.update(findings["base_url_candidates"])
-            merged_strings.update(findings["api_like_strings"])
+            merge(findings)
         assets.append(row)
 
     return {
@@ -250,6 +353,8 @@ def probe_h5_frontend(client: Any) -> dict[str, Any]:
             "max_js_bytes_per_asset": _MAX_JS_BYTES,
             "max_script_assets": _MAX_SCRIPT_ASSETS,
             "max_findings_per_category": _MAX_FINDINGS,
+            "max_contexts": _MAX_CONTEXTS,
+            "context_radius_chars": _CONTEXT_RADIUS,
         },
         "credential_safety": (
             "H5 discovery sends no uid, access token, device id, vehicle serial "
@@ -263,12 +368,16 @@ def probe_h5_frontend(client: Any) -> dict[str, Any]:
             "absolute_urls": sorted(merged_urls)[:_MAX_FINDINGS],
             "base_url_candidates": sorted(merged_base_urls)[:_MAX_FINDINGS],
             "api_like_strings": sorted(merged_strings)[:_MAX_FINDINGS],
+            "path_literals": sorted(merged_paths)[:_MAX_FINDINGS],
+            "http_call_literals": sorted(merged_calls)[:_MAX_FINDINGS],
+            "native_bridge_methods": sorted(merged_methods)[:_MAX_FINDINGS],
+            "native_bridge_callbacks": sorted(merged_callbacks)[:_MAX_FINDINGS],
+            "contexts": merged_contexts[:_MAX_CONTEXTS],
         },
         "pages": pages,
         "assets": assets,
         "note": (
-            "Beta23 follows public H5 HTML -> JavaScript references and records "
-            "only bounded structural clues that may reveal the notification API "
-            "host or route family."
+            "Beta24 focuses on native WebView bridge and literal HTTP-route discovery "
+            "inside the already-discovered public Navimow H5 bundles."
         ),
     }

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta23"
+  "version": "0.4.1-beta24"
 }

--- a/tests/test_v041_beta23.py
+++ b/tests/test_v041_beta23.py
@@ -1,4 +1,4 @@
-"""Regression contracts for Navimower 0.4.1-beta23."""
+"""Regression contracts carried forward from Navimower 0.4.1-beta23."""
 from __future__ import annotations
 
 import ast
@@ -11,7 +11,9 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_beta23_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta23"
+    version = manifest["version"]
+    assert version.startswith("0.4.1-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 23
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta23.md").read_text()
     assert notes.startswith("title: Navimower 0.4.1-beta23")
     for phrase in (

--- a/tests/test_v041_beta24.py
+++ b/tests/test_v041_beta24.py
@@ -1,0 +1,65 @@
+"""Regression contracts for Navimower 0.4.1-beta24."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta24_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta24"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta24.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta24")
+    for phrase in (
+        "native bridge",
+        "sendMessageToNative",
+        "Download diagnostics",
+        "public H5",
+        "no credentials",
+    ):
+        assert phrase in notes
+
+
+def test_beta24_h5_scanner_extracts_bridge_and_literal_routes() -> None:
+    source = (COMPONENT / "h5_discovery.py").read_text()
+    ast.parse(source)
+    for phrase in (
+        "_BRIDGE_OBJECT_RE",
+        "_DIRECT_BRIDGE_RE",
+        "_CALL_LITERAL_RE",
+        "_PATH_LITERAL_RE",
+        "native_bridge_methods",
+        "native_bridge_callbacks",
+        "http_call_literals",
+        "path_literals",
+        "contexts",
+        "sendMessageToNative",
+        "messageHandlers",
+        "AndroidAndJs",
+        "newMessages",
+    ):
+        assert phrase in source
+
+
+def test_beta24_context_capture_is_bounded() -> None:
+    source = (COMPONENT / "h5_discovery.py").read_text()
+    assert "_MAX_CONTEXTS = 24" in source
+    assert "_CONTEXT_RADIUS = 260" in source
+    assert '"max_contexts": _MAX_CONTEXTS' in source
+    assert '"context_radius_chars": _CONTEXT_RADIUS' in source
+
+
+def test_beta24_remains_public_read_only_and_action_free() -> None:
+    h5 = (COMPONENT / "h5_discovery.py").read_text()
+    action = (COMPONENT / "action_diagnostics.py").read_text()
+    coordinator = (COMPONENT / "coordinator.py").read_text()
+    assert '"public_unauthenticated_only": True' in h5
+    assert 'method="GET"' in h5
+    for forbidden in ("access_token", "refresh_token", "crypto.pack", "_auth_body"):
+        assert forbidden not in h5[h5.index("def _fetch"):h5.index("def _extract_script_urls")]
+    assert "probe_h5_frontend" not in action
+    assert "probe_h5_frontend" not in coordinator


### PR DESCRIPTION
## What changed
- keep beta23 H5 discovery in native Download diagnostics
- stop expanding guessed notification endpoints
- extract native WebView bridge method/callback literals from public H5 JavaScript
- capture bounded context around `sendMessageToNative`, `messageHandlers`, `AndroidAndJs`, `newMessages`, and notification/notice terms
- extract literal message/notification/notice/push/event/API paths and literal fetch/axios/get/post arguments
- keep full HTML/JS bodies out of diagnostics
- no credentials or mower identity are sent to H5
- action diagnostics, normal polling and mower control remain unchanged

## Release
Version: `0.4.1-beta24`