### PR TITLE
Navimower 0.4.1-beta25 bridge alias and lazy chunk discovery

### DIFF
--- a/.github/release-notes/0.4.1-beta25.md
+++ b/.github/release-notes/0.4.1-beta25.md
@@ -1,0 +1,13 @@
+title: Navimower 0.4.1-beta25
+
+Beta25 sharpens the public H5 discovery used by Home Assistant Download diagnostics.
+
+- recognize minified/native bridge aliases such as `*.callNative(...)` and `*.sendEncryptionData(...)`
+- record literal bridge method names, callbacks and callee/method pairs
+- add bounded context around bridge, message, notification and history terms
+- discover JavaScript chunk literals referenced by already-inspected public H5 bundles
+- follow at most four lazy chunks only when their URL or nearby source context is message/notification/notice/push/history themed
+- merge useful bridge/API clues from those lazy chunks into the diagnostics summary
+- keep full HTML/JavaScript source bodies out of diagnostics
+- keep H5 requests public, unauthenticated and read-only; no credentials or mower identity are sent
+- leave `navimower.export_diagnostics`, normal polling and mower controls unchanged

--- a/custom_components/navimower/h5_discovery.py
+++ b/custom_components/navimower/h5_discovery.py
@@ -1,9 +1,10 @@
 """Read-only H5/native-bridge discovery for Home Assistant diagnostics.
 
-Beta24 builds on beta23's public H5 asset discovery. It still fetches only public,
-unauthenticated HTML/JavaScript, but now extracts higher-value structural clues:
-native bridge method/callback literals, bounded context around bridge/notification
-keywords, and literal API-like strings passed to fetch/axios/get/post patterns.
+Beta25 keeps beta24's bounded public H5 inspection, but follows the evidence from
+real Navimow bundles more closely: minified helper aliases such as ``Rd.callNative``
+and ``je.sendEncryptionData`` are parsed generically, and message/notification/
+history-related lazy JavaScript chunks referenced by inspected bundles can be
+followed with strict request and size limits.
 
 No Navimow credentials, mower identifiers or p:101 payloads are sent to H5.
 Fetched source bodies are never stored in diagnostics.
@@ -29,29 +30,46 @@ _KEYWORDS: tuple[str, ...] = (
     "notice",
     "push",
     "event",
+    "history",
+    "newmessages",
     "baseurl",
     "graphql",
     "axios",
     "sendmessagetonative",
     "messagehandlers",
     "androidandjs",
-    "newmessages",
+    "callnative",
+    "sendencryptiondata",
 )
 _CONTEXT_TERMS: tuple[str, ...] = (
     "sendMessageToNative",
     "messageHandlers",
     "AndroidAndJs",
+    "callNative",
+    "sendEncryptionData",
     "newMessages",
     "notification",
     "notice_title",
     "noticeTitle",
+    "messageHistory",
+    "history",
+)
+_CHUNK_THEME_TERMS: tuple[str, ...] = (
+    "message",
+    "notification",
+    "notice",
+    "push",
+    "history",
+    "newmessages",
 )
 _MAX_HTML_BYTES = 256 * 1024
 _MAX_JS_BYTES = 2 * 1024 * 1024
 _MAX_SCRIPT_ASSETS = 6
+_MAX_DYNAMIC_CHUNKS = 4
 _MAX_FINDINGS = 80
-_MAX_CONTEXTS = 24
-_CONTEXT_RADIUS = 260
+_MAX_CONTEXTS = 32
+_CONTEXT_RADIUS = 320
+_CHUNK_CONTEXT_RADIUS = 700
 _TIMEOUT_SECONDS = 5
 
 _SCRIPT_SRC_RE = re.compile(
@@ -65,16 +83,15 @@ _QUOTED_STRING_RE = re.compile(r"[\"']([^\"'\r\n]{2,300})[\"']")
 _BASE_URL_RE = re.compile(
     r"(?:baseURL|baseUrl|apiBase|apiBaseUrl|baseApi)\s*[:=]\s*[\"']([^\"']{1,300})[\"']"
 )
-_PATH_LITERAL_RE = re.compile(
-    r"[\"'](/[^\"'\r\n]{1,240})[\"']"
-)
+_PATH_LITERAL_RE = re.compile(r"[\"'](/[^\"'\r\n]{1,240})[\"']")
 _CALL_LITERAL_RE = re.compile(
     r"(?:fetch|axios(?:\.(?:get|post|put|delete|request))?|\.(?:get|post|put|delete))"
     r"\s*\(\s*[\"']([^\"'\r\n]{1,240})[\"']",
     re.IGNORECASE,
 )
 _BRIDGE_OBJECT_RE = re.compile(
-    r"(?:sendMessageToNative\s*\(|postMessage\s*\()(?P<body>.{0,800}?)(?:\)|;)",
+    r"(?:sendMessageToNative|postMessage|callNative|sendEncryptionData)\s*\("
+    r"(?P<body>.{0,1200}?)(?:\)|;)",
     re.IGNORECASE | re.DOTALL,
 )
 _METHOD_LITERAL_RE = re.compile(
@@ -86,7 +103,19 @@ _CALLBACK_LITERAL_RE = re.compile(
     re.IGNORECASE,
 )
 _DIRECT_BRIDGE_RE = re.compile(
-    r"sendMessageToNative\s*\(\s*[\"']([^\"']{1,120})[\"']",
+    r"(?:[A-Za-z_$][\w$]*\s*\.\s*)*"
+    r"(?:sendMessageToNative|callNative|sendEncryptionData)\s*\(\s*"
+    r"[\"']([^\"']{1,120})[\"']",
+    re.IGNORECASE,
+)
+_GENERIC_BRIDGE_CALL_RE = re.compile(
+    r"(?P<callee>(?:[A-Za-z_$][\w$]*\s*\.\s*)*"
+    r"(?:callNative|sendEncryptionData|sendMessageToNative))\s*\("
+    r"\s*[\"'](?P<method>[^\"']{1,120})[\"']",
+    re.IGNORECASE,
+)
+_JS_LITERAL_RE = re.compile(
+    r"[\"']([^\"'\r\n]{1,360}\.js(?:\?[^\"'\r\n]{0,120})?)[\"']",
     re.IGNORECASE,
 )
 
@@ -106,7 +135,7 @@ def _fetch(url: str, max_bytes: int) -> dict[str, Any]:
         url,
         headers={
             "Accept": "text/html,application/javascript,text/javascript,*/*;q=0.8",
-            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.1-beta24",
+            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.1-beta25",
         },
         method="GET",
     )
@@ -168,7 +197,7 @@ def _prioritize_scripts(urls: list[str]) -> list[str]:
 def _interesting_path(value: str) -> bool:
     low = value.lower()
     return (
-        any(token in low for token in ("message", "notification", "notice", "push", "event"))
+        any(token in low for token in ("message", "notification", "notice", "push", "event", "history"))
         or "/api/" in low
         or low.startswith("/api")
         or low.startswith("api/")
@@ -179,6 +208,17 @@ def _bridge_findings(text: str) -> dict[str, Any]:
     methods: set[str] = set(_DIRECT_BRIDGE_RE.findall(text))
     callbacks: set[str] = set()
     bridge_objects: list[dict[str, Any]] = []
+    calls: list[dict[str, str]] = []
+
+    for match in _GENERIC_BRIDGE_CALL_RE.finditer(text):
+        method = match.group("method")
+        callee = re.sub(r"\s+", "", match.group("callee"))
+        methods.add(method)
+        row = {"callee": callee, "method": method}
+        if row not in calls:
+            calls.append(row)
+        if len(calls) >= _MAX_FINDINGS:
+            break
 
     for match in _BRIDGE_OBJECT_RE.finditer(text):
         body = match.group("body")
@@ -187,18 +227,19 @@ def _bridge_findings(text: str) -> dict[str, Any]:
         methods.update(obj_methods)
         callbacks.update(obj_callbacks)
         if obj_methods or obj_callbacks:
-            bridge_objects.append(
-                {
-                    "methods": obj_methods[:8],
-                    "callbacks": obj_callbacks[:8],
-                }
-            )
+            bridge_objects.append({"methods": obj_methods[:8], "callbacks": obj_callbacks[:8]})
         if len(bridge_objects) >= _MAX_FINDINGS:
             break
+
+    for method in list(methods):
+        callback = f"{method}Callback"
+        if callback in text:
+            callbacks.add(callback)
 
     return {
         "methods": sorted(methods)[:_MAX_FINDINGS],
         "callbacks": sorted(callbacks)[:_MAX_FINDINGS],
+        "calls": calls[:_MAX_FINDINGS],
         "objects": bridge_objects[:_MAX_FINDINGS],
     }
 
@@ -226,8 +267,7 @@ def _contexts(text: str) -> list[dict[str, str]]:
                 break
             lo = max(0, idx - _CONTEXT_RADIUS)
             hi = min(len(text), idx + len(term) + _CONTEXT_RADIUS)
-            snippet = text[lo:hi]
-            snippet = re.sub(r"\s+", " ", snippet).strip()
+            snippet = re.sub(r"\s+", " ", text[lo:hi]).strip()
             key = (term.lower(), snippet)
             if key not in seen:
                 seen.add(key)
@@ -236,6 +276,45 @@ def _contexts(text: str) -> list[dict[str, str]]:
         if len(rows) >= _MAX_CONTEXTS:
             break
     return rows
+
+
+def _dynamic_chunk_candidates(text: str, base_url: str) -> list[dict[str, Any]]:
+    """Find JS literals whose URL or nearby source context is notification-themed."""
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    lower = text.lower()
+    for match in _JS_LITERAL_RE.finditer(text):
+        raw = match.group(1).strip()
+        url = urllib.parse.urljoin(base_url, raw)
+        parsed = urllib.parse.urlsplit(url)
+        if parsed.scheme != "https" or not parsed.netloc:
+            continue
+        safe = _safe_url(url)
+        if safe in seen:
+            continue
+        lo = max(0, match.start() - _CHUNK_CONTEXT_RADIUS)
+        hi = min(len(text), match.end() + _CHUNK_CONTEXT_RADIUS)
+        nearby = lower[lo:hi]
+        url_low = safe.lower()
+        terms = sorted(
+            {
+                term
+                for term in _CHUNK_THEME_TERMS
+                if term in url_low or term in nearby
+            }
+        )
+        if not terms:
+            continue
+        seen.add(safe)
+        rows.append(
+            {
+                "url": safe,
+                "theme_terms": terms,
+                "score": sum(3 if term in url_low else 1 for term in terms),
+            }
+        )
+    rows.sort(key=lambda row: (-int(row["score"]), str(row["url"])))
+    return rows[:_MAX_FINDINGS]
 
 
 def _scan_text(text: str) -> dict[str, Any]:
@@ -289,7 +368,9 @@ def probe_h5_frontend(client: Any) -> dict[str, Any]:
     merged_calls: set[str] = set()
     merged_methods: set[str] = set()
     merged_callbacks: set[str] = set()
+    merged_bridge_calls: list[dict[str, str]] = []
     merged_contexts: list[dict[str, str]] = []
+    chunk_candidates: dict[str, dict[str, Any]] = {}
 
     def merge(findings: dict[str, Any]) -> None:
         merged_hosts.update(findings["hosts"])
@@ -300,6 +381,9 @@ def probe_h5_frontend(client: Any) -> dict[str, Any]:
         merged_calls.update(findings["http_call_literals"])
         merged_methods.update(findings["native_bridge"]["methods"])
         merged_callbacks.update(findings["native_bridge"]["callbacks"])
+        for row in findings["native_bridge"]["calls"]:
+            if row not in merged_bridge_calls and len(merged_bridge_calls) < _MAX_FINDINGS:
+                merged_bridge_calls.append(row)
         for row in findings["contexts"]:
             if row not in merged_contexts and len(merged_contexts) < _MAX_CONTEXTS:
                 merged_contexts.append(row)
@@ -330,7 +414,8 @@ def probe_h5_frontend(client: Any) -> dict[str, Any]:
         unique_scripts.append(url)
 
     assets: list[dict[str, Any]] = []
-    for url in _prioritize_scripts(unique_scripts):
+    selected_scripts = _prioritize_scripts(unique_scripts)
+    for url in selected_scripts:
         result = _fetch(url, _MAX_JS_BYTES)
         text = str(result.get("_text") or "")
         row = _public_result(result)
@@ -338,7 +423,37 @@ def probe_h5_frontend(client: Any) -> dict[str, Any]:
             findings = _scan_text(text)
             row["findings"] = findings
             merge(findings)
+            candidates = _dynamic_chunk_candidates(text, url)
+            row["dynamic_chunk_candidate_count"] = len(candidates)
+            row["dynamic_chunk_candidates"] = candidates[:20]
+            for candidate in candidates:
+                current = chunk_candidates.get(str(candidate["url"]))
+                if current is None or int(candidate["score"]) > int(current["score"]):
+                    chunk_candidates[str(candidate["url"])] = candidate
         assets.append(row)
+
+    ranked_chunks = sorted(
+        chunk_candidates.values(),
+        key=lambda row: (-int(row["score"]), str(row["url"])),
+    )
+    dynamic_assets: list[dict[str, Any]] = []
+    selected_set = set(selected_scripts)
+    for candidate in ranked_chunks:
+        if len(dynamic_assets) >= _MAX_DYNAMIC_CHUNKS:
+            break
+        url = str(candidate["url"])
+        if url in selected_set:
+            continue
+        result = _fetch(url, _MAX_JS_BYTES)
+        text = str(result.get("_text") or "")
+        row = _public_result(result)
+        row["theme_terms"] = candidate["theme_terms"]
+        row["score"] = candidate["score"]
+        if text:
+            findings = _scan_text(text)
+            row["findings"] = findings
+            merge(findings)
+        dynamic_assets.append(row)
 
     return {
         "read_only": True,
@@ -352,9 +467,11 @@ def probe_h5_frontend(client: Any) -> dict[str, Any]:
             "max_html_bytes": _MAX_HTML_BYTES,
             "max_js_bytes_per_asset": _MAX_JS_BYTES,
             "max_script_assets": _MAX_SCRIPT_ASSETS,
+            "max_dynamic_chunks": _MAX_DYNAMIC_CHUNKS,
             "max_findings_per_category": _MAX_FINDINGS,
             "max_contexts": _MAX_CONTEXTS,
             "context_radius_chars": _CONTEXT_RADIUS,
+            "chunk_context_radius_chars": _CHUNK_CONTEXT_RADIUS,
         },
         "credential_safety": (
             "H5 discovery sends no uid, access token, device id, vehicle serial "
@@ -363,6 +480,8 @@ def probe_h5_frontend(client: Any) -> dict[str, Any]:
         "page_count": len(pages),
         "discovered_script_count": len(unique_scripts),
         "inspected_script_count": len(assets),
+        "dynamic_chunk_candidate_count": len(ranked_chunks),
+        "inspected_dynamic_chunk_count": len(dynamic_assets),
         "summary": {
             "hosts": sorted(merged_hosts)[:_MAX_FINDINGS],
             "absolute_urls": sorted(merged_urls)[:_MAX_FINDINGS],
@@ -372,12 +491,15 @@ def probe_h5_frontend(client: Any) -> dict[str, Any]:
             "http_call_literals": sorted(merged_calls)[:_MAX_FINDINGS],
             "native_bridge_methods": sorted(merged_methods)[:_MAX_FINDINGS],
             "native_bridge_callbacks": sorted(merged_callbacks)[:_MAX_FINDINGS],
+            "native_bridge_calls": merged_bridge_calls[:_MAX_FINDINGS],
+            "dynamic_chunk_candidates": ranked_chunks[:20],
             "contexts": merged_contexts[:_MAX_CONTEXTS],
         },
         "pages": pages,
         "assets": assets,
+        "dynamic_assets": dynamic_assets,
         "note": (
-            "Beta24 focuses on native WebView bridge and literal HTTP-route discovery "
-            "inside the already-discovered public Navimow H5 bundles."
+            "Beta25 recognizes aliased callNative/sendEncryptionData bridge calls and "
+            "follows only bounded message/notification/history-themed lazy JS chunks."
         ),
     }

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta24"
+  "version": "0.4.1-beta25"
 }

--- a/tests/test_v041_beta24.py
+++ b/tests/test_v041_beta24.py
@@ -1,17 +1,14 @@
-"""Regression contracts for Navimower 0.4.1-beta24."""
+"""Regression contracts introduced with Navimower 0.4.1-beta24."""
 from __future__ import annotations
 
 import ast
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta24_manifest_and_release_notes() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta24"
+def test_beta24_release_notes_remain_available() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta24.md").read_text()
     assert notes.startswith("title: Navimower 0.4.1-beta24")
     for phrase in (
@@ -45,10 +42,10 @@ def test_beta24_h5_scanner_extracts_bridge_and_literal_routes() -> None:
         assert phrase in source
 
 
-def test_beta24_context_capture_is_bounded() -> None:
+def test_beta24_context_capture_remains_bounded() -> None:
     source = (COMPONENT / "h5_discovery.py").read_text()
-    assert "_MAX_CONTEXTS = 24" in source
-    assert "_CONTEXT_RADIUS = 260" in source
+    assert "_MAX_CONTEXTS" in source
+    assert "_CONTEXT_RADIUS" in source
     assert '"max_contexts": _MAX_CONTEXTS' in source
     assert '"context_radius_chars": _CONTEXT_RADIUS' in source
 

--- a/tests/test_v041_beta25.py
+++ b/tests/test_v041_beta25.py
@@ -1,0 +1,79 @@
+"""Regression contracts for Navimower 0.4.1-beta25."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta25_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta25"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta25.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta25")
+    for phrase in (
+        "callNative",
+        "sendEncryptionData",
+        "lazy chunks",
+        "Download diagnostics",
+        "no credentials",
+    ):
+        assert phrase in notes
+
+
+def test_beta25_generic_bridge_alias_extractor() -> None:
+    source = (COMPONENT / "h5_discovery.py").read_text()
+    ast.parse(source)
+    for phrase in (
+        "_GENERIC_BRIDGE_CALL_RE",
+        "callNative",
+        "sendEncryptionData",
+        '"native_bridge_calls"',
+        '"callee"',
+        '"method"',
+    ):
+        assert phrase in source
+
+
+def test_beta25_dynamic_chunk_discovery_is_thematic_and_bounded() -> None:
+    source = (COMPONENT / "h5_discovery.py").read_text()
+    ast.parse(source)
+    for phrase in (
+        "_JS_LITERAL_RE",
+        "_dynamic_chunk_candidates",
+        "_MAX_DYNAMIC_CHUNKS = 4",
+        "_CHUNK_THEME_TERMS",
+        "message",
+        "notification",
+        "history",
+        '"dynamic_assets"',
+        '"dynamic_chunk_candidates"',
+        '"max_dynamic_chunks": _MAX_DYNAMIC_CHUNKS',
+    ):
+        assert phrase in source
+
+
+def test_beta25_stays_download_only_public_and_read_only() -> None:
+    h5 = (COMPONENT / "h5_discovery.py").read_text()
+    diagnostics = (COMPONENT / "diagnostics.py").read_text()
+    action = (COMPONENT / "action_diagnostics.py").read_text()
+    coordinator = (COMPONENT / "coordinator.py").read_text()
+    assert '"source": "home_assistant_download"' in h5
+    assert '"public_unauthenticated_only": True' in h5
+    assert 'method="GET"' in h5
+    assert "probe_h5_frontend" in diagnostics
+    assert "probe_h5_frontend" not in action
+    assert "probe_h5_frontend" not in coordinator
+    fetch_fn = h5[h5.index("def _fetch"):h5.index("def _extract_script_urls")]
+    for forbidden in (
+        "access_token",
+        "refresh_token",
+        "vehicle_sn",
+        "device_id",
+        "crypto.pack",
+        "_auth_body",
+    ):
+        assert forbidden not in fetch_fn


### PR DESCRIPTION
## What changed
- keep H5 discovery in Home Assistant Download diagnostics only
- recognize minified bridge aliases such as `*.callNative(...)` and `*.sendEncryptionData(...)`
- record bridge callee/method pairs and callback clues
- discover JavaScript chunk literals referenced by inspected public H5 bundles
- follow at most four message/notification/notice/push/history-themed lazy chunks
- merge structural API/bridge clues from those chunks into the diagnostics summary
- keep full source bodies out of diagnostics
- send no credentials or mower identity to H5
- leave action diagnostics, normal polling and mower control unchanged

## Release
Version: `0.4.1-beta25`