### PR TITLE
Navimower 0.4.1-beta26 notification history sensor

### DIFF
--- a/.github/release-notes/0.4.1-beta26.md
+++ b/.github/release-notes/0.4.1-beta26.md
@@ -1,0 +1,13 @@
+title: Navimower 0.4.1-beta26 notification history sensor
+prerelease: true
+
+## Highlights
+
+- Uses the exact read-only vendor message-history endpoint recovered from the public Navimow H5 application in beta25: `/mowerbot/user/message/get-vehicle-history-message`.
+- Sends `vehicle_sn`, `page` and `size` through the existing authenticated encrypted p:101 private-cloud transport.
+- Adds a **Notification** sensor whose state is the newest vendor notification title.
+- Notification attributes expose bounded details for the newest item (`message_id`, content, timestamp, read flag and level) plus up to five recent messages.
+- Polls message history at most once per 60 seconds and retains the last successful result across transient endpoint failures.
+- Home Assistant **Download diagnostics** no longer scans public H5 JavaScript. It performs one fresh read-only request to the exact notification-history endpoint and records the sanitized response plus structure inventory.
+- `navimower.export_diagnostics` remains on the normal diagnostics path and does not run the fresh notification-history probe.
+- The integration does **not** mark notifications read, request message details, change mower settings, or send mower commands as part of notification handling.

--- a/custom_components/navimower/beta26_runtime.py
+++ b/custom_components/navimower/beta26_runtime.py
@@ -1,0 +1,242 @@
+"""Beta26 live vendor notification history support.
+
+The exact message-history route and payload were recovered from Navimow's public
+H5 bundle in beta25.  This runtime keeps the integration-side implementation
+small and conservative:
+
+* use the existing authenticated p:101 private-cloud transport,
+* poll the read-only history endpoint at most once per minute,
+* retain the last successful response across transient failures,
+* expose only the newest message plus a bounded recent list to Home Assistant,
+* never mark messages read and never call the message-detail endpoint.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import replace
+from datetime import UTC, datetime
+import time
+from typing import Any
+
+from . import coordinator as _coordinator
+from .api.client import NavimowCloudClient
+
+_NOTIFICATION_PATH = "/mowerbot/user/message/get-vehicle-history-message"
+_NOTIFICATION_TTL_SECONDS = 60
+_NOTIFICATION_PAGE_SIZE = 20
+_NOTIFICATION_ATTR_HISTORY_LIMIT = 5
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _bounded_text(value: Any, limit: int) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text[:limit]
+
+
+def _created_at(value: Any) -> str | None:
+    try:
+        stamp = float(value)
+    except (TypeError, ValueError):
+        return None
+    if stamp > 10_000_000_000:
+        stamp /= 1000.0
+    try:
+        return datetime.fromtimestamp(stamp, UTC).isoformat()
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _normalize_item(item: Any) -> dict[str, Any] | None:
+    if not isinstance(item, dict):
+        return None
+    addtime = item.get("addtime")
+    return {
+        "id": item.get("id"),
+        "message_id": item.get("message_id"),
+        "title": _bounded_text(item.get("title"), 255),
+        "content": _bounded_text(item.get("content"), 1200),
+        "addtime": addtime,
+        "created_at": _created_at(addtime),
+        "read": _as_int(item.get("read")),
+        "level": _as_int(item.get("level")),
+    }
+
+
+def _normalize_response(value: Any) -> dict[str, Any]:
+    response = value if isinstance(value, dict) else {}
+    messages: list[dict[str, Any]] = []
+    for item in response.get("list") or []:
+        normalized = _normalize_item(item)
+        if normalized is not None:
+            messages.append(normalized)
+    return {
+        "list": messages,
+        "total": _as_int(response.get("total")),
+        "page": _as_int(response.get("page")),
+    }
+
+
+def _decorate_snapshot(coordinator: Any, snapshot: dict[str, Any]) -> dict[str, Any]:
+    result = dict(snapshot)
+    cache = getattr(coordinator, "_beta26_notification_cache", None)
+    normalized = _normalize_response(cache)
+    messages = normalized["list"]
+    latest = messages[0] if messages else {}
+    last_success = getattr(coordinator, "_beta26_notification_last_success_mono", None)
+    source_age = (
+        max(0.0, time.monotonic() - float(last_success))
+        if last_success is not None
+        else None
+    )
+    result.update(
+        {
+            "notification_title": latest.get("title"),
+            "notification_content": latest.get("content"),
+            "notification_message_id": latest.get("message_id"),
+            "notification_addtime": latest.get("addtime"),
+            "notification_created_at": latest.get("created_at"),
+            "notification_read": latest.get("read"),
+            "notification_level": latest.get("level"),
+            "notification_history": deepcopy(
+                messages[:_NOTIFICATION_ATTR_HISTORY_LIMIT]
+            ),
+            "notification_total": normalized.get("total"),
+            "notification_page": normalized.get("page"),
+            "notification_source": (
+                "private_cloud_message_history" if cache is not None else None
+            ),
+            "notification_source_age": source_age,
+            "notification_error": getattr(
+                coordinator, "_beta26_notification_error", None
+            ),
+        }
+    )
+    return result
+
+
+def _refresh_notification_cache(coordinator: Any) -> None:
+    now = time.monotonic()
+    last_attempt = getattr(
+        coordinator, "_beta26_notification_last_attempt_mono", None
+    )
+    if (
+        last_attempt is not None
+        and now - float(last_attempt) < _NOTIFICATION_TTL_SECONDS
+    ):
+        return
+
+    coordinator._beta26_notification_last_attempt_mono = now  # noqa: SLF001
+    try:
+        response = coordinator.client.notification_history(  # type: ignore[attr-defined]
+            coordinator.sn,
+            page=1,
+            size=_NOTIFICATION_PAGE_SIZE,
+        )
+    except Exception as err:  # noqa: BLE001 - optional feed must not break core poll.
+        coordinator._beta26_notification_error = (  # noqa: SLF001
+            f"{type(err).__name__}: {err}"
+        )
+        return
+
+    coordinator._beta26_notification_cache = response  # noqa: SLF001
+    coordinator._beta26_notification_last_success_mono = now  # noqa: SLF001
+    coordinator._beta26_notification_error = None  # noqa: SLF001
+
+
+def _install_notification_sensor() -> None:
+    from . import sensor as platform
+
+    if any(description.key == "notification" for description in platform.SENSORS):
+        return
+
+    def value(data: dict[str, Any]) -> str | None:
+        title = data.get("notification_title")
+        if title:
+            return str(title)[:255]
+        if data.get("notification_total") == 0:
+            return "No notifications"
+        return None
+
+    def attrs(data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "message_id": data.get("notification_message_id"),
+            "content": data.get("notification_content"),
+            "created_at": data.get("notification_created_at"),
+            "addtime": data.get("notification_addtime"),
+            "read": data.get("notification_read"),
+            "level": data.get("notification_level"),
+            "total": data.get("notification_total"),
+            "page": data.get("notification_page"),
+            "source": data.get("notification_source"),
+            "source_age": data.get("notification_source_age"),
+            "last_error": data.get("notification_error"),
+            "recent": deepcopy(
+                (data.get("notification_history") or [])[
+                    :_NOTIFICATION_ATTR_HISTORY_LIMIT
+                ]
+            ),
+        }
+
+    platform.SENSORS = (
+        *platform.SENSORS,
+        platform.NavimowSensorDescription(
+            key="notification",
+            name="Notification",
+            icon="mdi:bell-outline",
+            value_fn=value,
+            attrs_fn=attrs,
+        ),
+    )
+
+
+def install_beta26_runtime() -> None:
+    """Install notification-history transport, polling and sensor once."""
+    cls = _coordinator.NavimowCoordinator
+    if getattr(cls, "_beta26_runtime_installed", False):
+        _install_notification_sensor()
+        return
+
+    if not hasattr(NavimowCloudClient, "notification_history"):
+        def notification_history(
+            self: NavimowCloudClient,
+            sn: str,
+            page: int = 1,
+            size: int = _NOTIFICATION_PAGE_SIZE,
+        ) -> dict[str, Any]:
+            data = self.call(
+                _NOTIFICATION_PATH,
+                {
+                    "vehicle_sn": str(sn),
+                    "page": int(page),
+                    "size": int(size),
+                },
+            )
+            return data if isinstance(data, dict) else {}
+
+        NavimowCloudClient.notification_history = notification_history  # type: ignore[attr-defined]
+
+    original_fetch = cls._fetch_blocking
+    original_bootstrap = cls._bootstrap_snapshot
+
+    def fetch_blocking(self: Any) -> dict[str, Any]:
+        snapshot = original_fetch(self)
+        _refresh_notification_cache(self)
+        return _decorate_snapshot(self, snapshot)
+
+    def bootstrap_snapshot(self: Any) -> dict[str, Any]:
+        return _decorate_snapshot(self, original_bootstrap(self))
+
+    cls._fetch_blocking = fetch_blocking
+    cls._bootstrap_snapshot = bootstrap_snapshot
+    cls._beta26_runtime_installed = True
+    _install_notification_sensor()

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -7,8 +7,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
-from .diagnostics_export import async_build_diagnostics, sanitize
-from .h5_discovery import probe_h5_frontend
+from .diagnostics_export import async_build_diagnostics, inventory, sanitize
+
+_NOTIFICATION_PATH = "/mowerbot/user/message/get-vehicle-history-message"
 
 
 async def async_get_config_entry_diagnostics(
@@ -38,12 +39,43 @@ async def async_get_config_entry_diagnostics(
             coordinator.state_transition_diagnostics()
         )
 
-    # Beta23 moves notification discovery back to the native Download diagnostics
-    # flow, but no longer brute-forces API paths. It follows only public H5 HTML
-    # and a bounded set of referenced JavaScript assets, storing structural clues.
-    document["h5_frontend_discovery"] = await hass.async_add_executor_job(
-        probe_h5_frontend,
-        coordinator.client,
-    )
+    # Beta26 replaces public-H5 source scanning with the exact read-only vendor
+    # endpoint recovered in beta25. The private-cloud client still owns auth,
+    # p:101 encryption and session refresh; diagnostics receives only decoded data.
+    try:
+        response = await hass.async_add_executor_job(
+            coordinator.client.notification_history,
+            coordinator.sn,
+            1,
+            20,
+        )
+    except Exception as err:  # noqa: BLE001 - diagnostics records probe failure.
+        document["notification_history_probe"] = {
+            "ok": False,
+            "read_only": True,
+            "endpoint": _NOTIFICATION_PATH,
+            "request": {
+                "vehicle_sn": "<redacted>",
+                "page": 1,
+                "size": 20,
+            },
+            "error_type": type(err).__name__,
+            "error": str(err),
+        }
+    else:
+        clean = sanitize(response)
+        document["notification_history_probe"] = {
+            "ok": True,
+            "read_only": True,
+            "endpoint": _NOTIFICATION_PATH,
+            "request": {
+                "vehicle_sn": "<redacted>",
+                "page": 1,
+                "size": 20,
+            },
+            "response": clean,
+            "inventory": inventory(clean),
+        }
+
     document["diagnostics_source"] = "home_assistant_download"
     return document

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta25"
+  "version": "0.4.1-beta26"
 }

--- a/custom_components/navimower/services.py
+++ b/custom_components/navimower/services.py
@@ -29,11 +29,13 @@ from .const import (
     mow_setup,
 )
 from .beta16_runtime import install_beta16_runtime
+from .beta26_runtime import install_beta26_runtime
 from .model_support import supports_ordered_zone_mowing
 from .state_transition_capture import install_state_transition_capture
 
 install_state_transition_capture()
 install_beta16_runtime()
+install_beta26_runtime()
 
 SERVICE_SET_SCHEDULE = "set_schedule"
 SERVICE_MOW = "mow"
@@ -203,9 +205,10 @@ def async_setup_services(hass: HomeAssistant) -> None:
             (
                 "Extended read-only Navimower diagnostics export completed.\n\n"
                 f"File: `{path}`\n\n"
-                "Beta23 does not run notification/H5 discovery from this action. "
-                "Use Home Assistant Download diagnostics for the H5 discovery block. "
-                "The export is sanitized, but review it before publishing."
+                "The action export stays on the normal diagnostics path. "
+                "Use Home Assistant Download diagnostics for the fresh vendor "
+                "notification-history probe. The export is sanitized, but review "
+                "it before publishing."
             ),
             title="Navimower extended diagnostics export",
             notification_id="navimower_diagnostics_export",

--- a/tests/test_v041_beta23.py
+++ b/tests/test_v041_beta23.py
@@ -26,12 +26,10 @@ def test_beta23_manifest_and_release_notes() -> None:
         assert phrase in notes
 
 
-def test_beta23_download_diagnostics_runs_h5_discovery() -> None:
-    source = (COMPONENT / "diagnostics.py").read_text()
+def test_beta23_h5_discovery_implementation_remains_parseable() -> None:
+    source = (COMPONENT / "h5_discovery.py").read_text()
     ast.parse(source)
     assert "probe_h5_frontend" in source
-    assert 'document["h5_frontend_discovery"]' in source
-    assert "async_add_executor_job" in source
     assert '"home_assistant_download"' in source
 
 

--- a/tests/test_v041_beta25.py
+++ b/tests/test_v041_beta25.py
@@ -11,7 +11,7 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_beta25_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta25"
+    assert manifest["version"].startswith("0.4.1-beta")
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta25.md").read_text()
     assert notes.startswith("title: Navimower 0.4.1-beta25")
     for phrase in (
@@ -56,15 +56,13 @@ def test_beta25_dynamic_chunk_discovery_is_thematic_and_bounded() -> None:
         assert phrase in source
 
 
-def test_beta25_stays_download_only_public_and_read_only() -> None:
+def test_beta25_h5_scanner_remains_public_and_read_only_if_reused() -> None:
     h5 = (COMPONENT / "h5_discovery.py").read_text()
-    diagnostics = (COMPONENT / "diagnostics.py").read_text()
     action = (COMPONENT / "action_diagnostics.py").read_text()
     coordinator = (COMPONENT / "coordinator.py").read_text()
     assert '"source": "home_assistant_download"' in h5
     assert '"public_unauthenticated_only": True' in h5
     assert 'method="GET"' in h5
-    assert "probe_h5_frontend" in diagnostics
     assert "probe_h5_frontend" not in action
     assert "probe_h5_frontend" not in coordinator
     fetch_fn = h5[h5.index("def _fetch"):h5.index("def _extract_script_urls")]

--- a/tests/test_v041_beta26.py
+++ b/tests/test_v041_beta26.py
@@ -19,7 +19,7 @@ def test_beta26_manifest_and_release_notes() -> None:
         "get-vehicle-history-message",
         "60 seconds",
         "Download diagnostics",
-        "does not mark notifications read",
+        "does **not** mark notifications read",
     ):
         assert phrase in notes
 
@@ -54,7 +54,6 @@ def test_beta26_notification_sensor_is_bounded_and_last_good() -> None:
         "_beta26_notification_cache",
     ):
         assert phrase in source
-    # Failure path records an error and returns without clearing the cache.
     failure = source[source.index("except Exception as err"):source.index("def _install_notification_sensor")]
     assert "_beta26_notification_error" in failure
     assert "_beta26_notification_cache = None" not in failure

--- a/tests/test_v041_beta26.py
+++ b/tests/test_v041_beta26.py
@@ -1,0 +1,78 @@
+"""Regression contracts for Navimower 0.4.1-beta26."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta26_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta26"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta26.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta26")
+    for phrase in (
+        "Notification",
+        "get-vehicle-history-message",
+        "60 seconds",
+        "Download diagnostics",
+        "does not mark notifications read",
+    ):
+        assert phrase in notes
+
+
+def test_beta26_runtime_uses_exact_encrypted_history_contract() -> None:
+    source = (COMPONENT / "beta26_runtime.py").read_text()
+    ast.parse(source)
+    for phrase in (
+        '"/mowerbot/user/message/get-vehicle-history-message"',
+        '"vehicle_sn": str(sn)',
+        '"page": int(page)',
+        '"size": int(size)',
+        "self.call(",
+        "_NOTIFICATION_TTL_SECONDS = 60",
+        "_NOTIFICATION_PAGE_SIZE = 20",
+    ):
+        assert phrase in source
+    assert "getmessageDetailResp" not in source
+    assert "mark-read" not in source.lower()
+
+
+def test_beta26_notification_sensor_is_bounded_and_last_good() -> None:
+    source = (COMPONENT / "beta26_runtime.py").read_text()
+    assert "_NOTIFICATION_ATTR_HISTORY_LIMIT = 5" in source
+    for phrase in (
+        'key="notification"',
+        'name="Notification"',
+        'icon="mdi:bell-outline"',
+        '"notification_history"',
+        '"notification_error"',
+        '"private_cloud_message_history"',
+        "_beta26_notification_cache",
+    ):
+        assert phrase in source
+    # Failure path records an error and returns without clearing the cache.
+    failure = source[source.index("except Exception as err"):source.index("def _install_notification_sensor")]
+    assert "_beta26_notification_error" in failure
+    assert "_beta26_notification_cache = None" not in failure
+
+
+def test_beta26_download_diagnostics_probes_exact_endpoint_not_h5_assets() -> None:
+    diagnostics = (COMPONENT / "diagnostics.py").read_text()
+    action = (COMPONENT / "action_diagnostics.py").read_text()
+    assert "notification_history_probe" in diagnostics
+    assert "coordinator.client.notification_history" in diagnostics
+    assert '"vehicle_sn": "<redacted>"' in diagnostics
+    assert "inventory(clean)" in diagnostics
+    assert "probe_h5_frontend" not in diagnostics
+    assert "h5_frontend_discovery" not in diagnostics
+    assert "notification_history_probe" not in action
+
+
+def test_beta26_runtime_installs_before_sensor_platform_setup() -> None:
+    services = (COMPONENT / "services.py").read_text()
+    assert "from .beta26_runtime import install_beta26_runtime" in services
+    assert "install_beta16_runtime()\ninstall_beta26_runtime()" in services


### PR DESCRIPTION
## What changed
- use the exact H5-discovered encrypted vendor endpoint `/mowerbot/user/message/get-vehicle-history-message`
- poll vendor notification history at most once per 60 seconds with last-good retention
- add a normal `Notification` sensor showing the latest vendor title
- expose bounded latest-message attributes and up to five recent messages
- replace Download diagnostics H5 bundle scanning with one fresh sanitized notification-history request
- keep `navimower.export_diagnostics` on the normal diagnostics path
- never mark messages read, fetch message details, or perform notification-related writes

## Release
Version: `0.4.1-beta26`