### PR TITLE
Navimower 0.4.1-beta28 translation-key notification discovery

### DIFF
--- a/.github/release-notes/0.4.1-beta28.md
+++ b/.github/release-notes/0.4.1-beta28.md
@@ -1,0 +1,13 @@
+title: Navimower 0.4.1-beta28
+
+Beta28 fixes the beta27 H5 discovery bias and follows translation keys toward the real main Notification -> Device feed.
+
+- Keeps the beta26 Notification sensor and exact read-only `get-vehicle-history-message` probe unchanged while the main feed is still being identified.
+- Keeps `navimower.export_diagnostics`, normal polling, mower controls, and notification read state unchanged.
+- Runs the new discovery only from Home Assistant **Download diagnostics**.
+- Maps exact visible strings such as `Important`, `Work status`, `newMessages`, `No more messages`, and `Failed to load new messages` to nearby JavaScript translation keys before ranking lazy chunks.
+- Keeps `All`, `System`, and `Device` hit counts as evidence, but excludes their discovered keys from chunk ranking so generic words cannot consume the search budget.
+- Uses a separate bounded context quota per anchor/translation key rather than one shared list.
+- In selected high-signal chunks, inventories literal `/mowerbot/...` requests together with HTTP method hints, `skipEncryption`, nearby object/payload keys, and `sendEncryptionData` / `callNative` / `sendMessageToNative` bridge calls.
+- Follows at most 6 root assets and 6 dynamic assets, with strict request time and body-size bounds.
+- Public H5 discovery sends no uid, access token, mower serial, device id, account id, or p:101 business payload and never stores full HTML/JavaScript source bodies.

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -40,7 +40,7 @@ async def async_get_config_entry_diagnostics(
             coordinator.state_transition_diagnostics()
         )
 
-    # Keep the exact beta26 vehicle-history contract visible while beta27
+    # Keep the exact beta26 vehicle-history contract visible while beta28
     # investigates whether the main Notification -> Device feed is a different
     # request path. The vendor call is read-only and uses the existing p:101
     # client; no message is marked read.
@@ -79,9 +79,10 @@ async def async_get_config_entry_diagnostics(
             "inventory": inventory(clean),
         }
 
-    # Beta27 re-enters public H5 discovery, but only around exact strings from
-    # the main Notification UI. This scanner never receives credentials or the
-    # mower serial and persists only bounded structural context.
+    # Beta28 maps exact Notification UI translations to translation keys first,
+    # then uses only high-signal phrases/keys to select lazy H5 chunks. The
+    # scanner never receives credentials or mower identity and persists only
+    # bounded request structure and source context.
     try:
         discovery = await hass.async_add_executor_job(
             probe_main_notification_feed,

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta27"
+  "version": "0.4.1-beta28"
 }

--- a/custom_components/navimower/notification_feed_discovery.py
+++ b/custom_components/navimower/notification_feed_discovery.py
@@ -1,20 +1,14 @@
-"""Targeted public-H5 discovery for the main Navimow Notification feed.
+"""Read-only H5 discovery for the main Navimow Notification feed.
 
-Beta28 fixes the main weakness observed in beta27: generic UI words such as
-``All`` can occur hundreds of times and must not decide which lazy chunks are
-inspected.  Discovery now works in two stages:
+Beta28 first maps exact visible Notification translations to their JavaScript
+translation keys, then uses only high-signal phrases/keys to rank lazy chunks.
+Generic words such as All/System/Device remain visible as evidence but cannot
+dominate chunk selection. Selected chunks are inspected for literal mowerbot
+requests, HTTP method hints, skipEncryption, payload/object keys and native or
+encryption bridge calls.
 
-1. map exact Notification UI translations to their nearby translation keys;
-2. use those keys plus high-signal Notification phrases to find the owning
-   JavaScript chunks, then inventory request structure inside those chunks.
-
-The scanner records bounded source context, literal ``/mowerbot/...`` routes,
-HTTP method hints, ``skipEncryption`` values, object/payload keys and native or
-encryption bridge calls.  Generic ``All`` / ``System`` / ``Device`` hits remain
-visible for evidence but cannot dominate chunk ranking.
-
-No credentials, mower serials, account ids or p:101 payloads are sent. Source
-HTML/JavaScript bodies are never persisted in diagnostics.
+No credentials, mower serials, account ids, device ids or p:101 payloads are
+sent to H5. Full HTML/JavaScript bodies are never persisted in diagnostics.
 """
 from __future__ import annotations
 
@@ -27,7 +21,7 @@ import urllib.request
 
 from .diagnostics_export import sanitize
 
-_ANCHORS: tuple[str, ...] = (
+_ANCHORS = (
     "All",
     "Important",
     "Work status",
@@ -37,51 +31,44 @@ _ANCHORS: tuple[str, ...] = (
     "No more messages",
     "Failed to load new messages",
 )
-_STRONG_ANCHORS: tuple[str, ...] = (
+_STRONG_ANCHORS = (
     "Important",
     "Work status",
     "newMessages",
     "No more messages",
     "Failed to load new messages",
 )
-_WEAK_ANCHORS: tuple[str, ...] = ("System", "Device")
-_GENERIC_ANCHORS: tuple[str, ...] = ("All",)
-_SEED_KEYS: tuple[str, ...] = ("newMessages", "messageCenter")
-_ENTRY_PATHS: tuple[str, ...] = ("/message/message/list", "/old/")
+_WEAK_ANCHORS = ("System", "Device")
+_GENERIC_ANCHORS = ("All",)
+_SEED_KEYS = ("newMessages", "messageCenter")
+_ENTRY_PATHS = ("/message/message/list", "/old/")
 _MAX_HTML_BYTES = 256 * 1024
 _MAX_JS_BYTES = 2 * 1024 * 1024
 _MAX_ROOT_ASSETS = 6
 _MAX_DYNAMIC_ASSETS = 6
 _MAX_CONTEXTS_PER_TERM = 4
 _MAX_REQUEST_CONTEXTS = 48
-_MAX_TRANSLATION_ROWS = 80
-_MAX_REQUEST_ROWS = 60
 _CONTEXT_RADIUS = 2200
 _REQUEST_RADIUS = 3200
 _DYNAMIC_RADIUS = 2600
 _TIMEOUT_SECONDS = 5
 
 _SCRIPT_RE = re.compile(r"<script\b[^>]*\bsrc\s*=\s*[\"']([^\"']+)[\"']", re.I)
-_JS_LITERAL_RE = re.compile(r"[\"']([^\"'\r\n]{1,360}\.js(?:\?[^\"'\r\n]{0,120})?)[\"']", re.I)
+_JS_RE = re.compile(r"[\"']([^\"'\r\n]{1,360}\.js(?:\?[^\"'\r\n]{0,120})?)[\"']", re.I)
 _MOWERBOT_RE = re.compile(r"[\"'](/mowerbot/[^\"'\r\n]{1,240})[\"']", re.I)
-_HTTP_METHOD_RE = re.compile(
-    r"(?:method\s*:\s*[\"']?|\.(?:request|ajax)\([^)]{0,300}?method\s*:\s*[\"']?)"
-    r"(GET|POST|PUT|DELETE|PATCH)[\"']?",
-    re.I,
-)
-_SKIP_ENCRYPTION_RE = re.compile(r"skipEncryption\s*:\s*(true|false)", re.I)
-_SEND_ENCRYPT_RE = re.compile(
+_HTTP_RE = re.compile(r"method\s*:\s*[\"']?(GET|POST|PUT|DELETE|PATCH)[\"']?", re.I)
+_SKIP_RE = re.compile(r"skipEncryption\s*:\s*(true|false)", re.I)
+_BRIDGE_RE = re.compile(
     r"(?P<callee>(?:[A-Za-z_$][\w$]*\.)*(?:sendEncryptionData|callNative|sendMessageToNative))"
     r"\s*\(\s*[\"'](?P<method>[^\"']{1,140})[\"']",
     re.I,
 )
+_OBJECT_KEY_RE = re.compile(r"(?:^|[,{])\s*[\"']?([A-Za-z_$][\w$]{1,80})[\"']?\s*:")
 _REQUEST_HINT_RE = re.compile(
-    r"(?:skipEncryption|sendEncryptionData|callNative|sendMessageToNative|axios|fetch|"
-    r"\.post\(|\.get\(|\.request\(|method\s*:|/mowerbot/)",
+    r"(?:/mowerbot/|skipEncryption|sendEncryptionData|callNative|sendMessageToNative|"
+    r"axios|fetch|\.post\(|\.get\(|\.request\(|method\s*:)",
     re.I,
 )
-_OBJECT_KEY_RE = re.compile(r"(?:^|[,{])\s*[\"']?([A-Za-z_$][\w$]{1,80})[\"']?\s*:")
-_PARENT_OBJECT_RE = re.compile(r"([A-Za-z_$][\w$]{0,80})\s*:\s*\{[^{}]{0,220}$")
 
 
 def _host(client: Any) -> str:
@@ -113,18 +100,13 @@ def _fetch(url: str, limit: int) -> dict[str, Any]:
         status = int(err.code)
         content_type = str(err.headers.get("Content-Type", ""))
     except urllib.error.URLError as err:
-        return {
-            "ok": False,
-            "url": _safe_url(url),
-            "transport_error": sanitize(str(err.reason)),
-        }
+        return {"ok": False, "url": _safe_url(url), "transport_error": sanitize(str(err.reason))}
     except Exception as err:  # noqa: BLE001 - bounded diagnostics-only discovery
         return {
             "ok": False,
             "url": _safe_url(url),
             "transport_error": sanitize(f"{type(err).__name__}: {err}"),
         }
-
     truncated = len(raw) > limit
     raw = raw[:limit]
     return {
@@ -144,100 +126,72 @@ def _public(result: dict[str, Any]) -> dict[str, Any]:
 
 
 def _root_scripts(html: str, base_url: str) -> list[str]:
-    out: list[str] = []
-    seen: set[str] = set()
+    found: list[str] = []
     for src in _SCRIPT_RE.findall(html):
         url = urllib.parse.urljoin(base_url, src.strip())
         parsed = urllib.parse.urlsplit(url)
-        if parsed.scheme != "https" or not parsed.netloc or url in seen:
-            continue
-        seen.add(url)
-        out.append(url)
-    out.sort(
-        key=lambda url: (
-            0
-            if any(token in url.lower() for token in ("app", "main", "entry", "index"))
-            else 1,
-            len(url),
+        if parsed.scheme == "https" and parsed.netloc and url not in found:
+            found.append(url)
+    found.sort(
+        key=lambda value: (
+            0 if any(word in value.lower() for word in ("app", "main", "entry", "index")) else 1,
+            len(value),
         )
     )
-    return out[:_MAX_ROOT_ASSETS]
+    return found[:_MAX_ROOT_ASSETS]
 
 
 def _anchor_counts(text: str) -> dict[str, int]:
     lower = text.lower()
-    return {
-        anchor: lower.count(anchor.lower())
-        for anchor in _ANCHORS
-        if anchor.lower() in lower
-    }
+    return {anchor: lower.count(anchor.lower()) for anchor in _ANCHORS if anchor.lower() in lower}
 
 
-def _qualified_key(text: str, start: int, key: str) -> str:
-    prefix = text[max(0, start - 240):start]
-    parents = list(_PARENT_OBJECT_RE.finditer(prefix))
-    if parents:
-        parent = parents[-1].group(1)
-        if parent and parent != key:
-            return f"{parent}.{key}"
-    return key
-
-
-def _translation_keys(text: str, source_url: str) -> list[dict[str, str]]:
-    """Map exact visible English strings to nearby translation object keys."""
+def _translation_rows(text: str, source: str) -> list[dict[str, str]]:
     rows: list[dict[str, str]] = []
     seen: set[tuple[str, str]] = set()
     for anchor in _ANCHORS:
         escaped = re.escape(anchor)
         patterns = (
-            re.compile(
-                rf"(?P<key>[A-Za-z_$][\w$.-]{{0,100}})\s*:\s*[\"']{escaped}[\"']",
-                re.I,
-            ),
-            re.compile(
-                rf"[\"'](?P<key>[^\"'\r\n]{{1,120}})[\"']\s*:\s*[\"']{escaped}[\"']",
-                re.I,
-            ),
+            re.compile(rf"(?P<key>[A-Za-z_$][\w$.-]{{0,100}})\s*:\s*[\"']{escaped}[\"']", re.I),
+            re.compile(rf"[\"'](?P<key>[^\"'\r\n]{{1,120}})[\"']\s*:\s*[\"']{escaped}[\"']", re.I),
         )
         for pattern in patterns:
             for match in pattern.finditer(text):
                 key = str(match.group("key")).strip()
-                if not key or len(key) > 120:
+                marker = (anchor.lower(), key.lower())
+                if not key or marker in seen:
                     continue
-                qualified = _qualified_key(text, match.start("key"), key)
-                dedupe = (anchor.lower(), qualified.lower())
-                if dedupe in seen:
-                    continue
-                seen.add(dedupe)
-                lo = max(0, match.start() - 260)
-                hi = min(len(text), match.end() + 260)
+                seen.add(marker)
+                lo = max(0, match.start() - 280)
+                hi = min(len(text), match.end() + 280)
                 rows.append(
                     {
                         "anchor": anchor,
                         "key": key,
-                        "qualified_key": qualified,
-                        "source": _safe_url(source_url),
+                        "source": _safe_url(source),
                         "context": re.sub(r"\s+", " ", text[lo:hi]).strip(),
                     }
                 )
-                if len(rows) >= _MAX_TRANSLATION_ROWS:
+                if len(rows) >= 80:
                     return rows
     return rows
 
 
-def _key_terms(translation_rows: list[dict[str, str]]) -> list[str]:
-    values: set[str] = set(_SEED_KEYS)
-    for row in translation_rows:
-        for field in ("key", "qualified_key"):
-            value = str(row.get(field) or "").strip()
-            if len(value) >= 3:
-                values.add(value)
+def _ranking_keys(rows: list[dict[str, str]]) -> list[str]:
+    """Only strong anchors may contribute discovered keys to chunk scoring."""
+    values = set(_SEED_KEYS)
+    for row in rows:
+        if row.get("anchor") not in _STRONG_ANCHORS:
+            continue
+        key = str(row.get("key") or "").strip()
+        if len(key) >= 3:
+            values.add(key)
     return sorted(values, key=lambda value: (-len(value), value.lower()))
 
 
-def _bridge_calls(snippet: str) -> list[dict[str, str]]:
+def _bridge_calls(text: str) -> list[dict[str, str]]:
     rows: list[dict[str, str]] = []
-    for match in _SEND_ENCRYPT_RE.finditer(snippet):
+    for match in _BRIDGE_RE.finditer(text):
         row = {"callee": match.group("callee"), "method": match.group("method")}
         if row not in rows:
             rows.append(row)
@@ -246,205 +200,152 @@ def _bridge_calls(snippet: str) -> list[dict[str, str]]:
     return rows
 
 
-def _object_keys(snippet: str) -> list[str]:
-    ignored = {
-        "class",
-        "style",
-        "children",
-        "props",
-        "key",
-        "ref",
-        "type",
-        "name",
-        "component",
-        "render",
-    }
-    out: list[str] = []
-    for value in _OBJECT_KEY_RE.findall(snippet):
-        if value.lower() in ignored or value in out:
+def _object_keys(text: str) -> list[str]:
+    ignored = {"class", "style", "children", "props", "key", "ref", "type", "name", "render"}
+    values: list[str] = []
+    for key in _OBJECT_KEY_RE.findall(text):
+        if key.lower() in ignored or key in values:
             continue
-        out.append(value)
-        if len(out) >= 40:
+        values.append(key)
+        if len(values) >= 40:
             break
-    return out
+    return values
 
 
-def _context_row(
-    text: str,
-    idx: int,
-    term: str,
-    kind: str,
-    source_url: str,
-) -> dict[str, Any]:
+def _matched(text: str, keys: list[str]) -> tuple[list[str], list[str], list[str], int]:
+    lower = text.lower()
+    strong = [value for value in _STRONG_ANCHORS if value.lower() in lower]
+    weak = [value for value in _WEAK_ANCHORS if value.lower() in lower]
+    key_hits = [value for value in keys if value.lower() in lower]
+    themes = [
+        value
+        for value in ("messagecenter", "notification", "newmessages", "messagehistory")
+        if value in lower
+    ]
+    score = len(strong) * 8 + len(key_hits) * 10 + len(themes) * 3 + len(weak)
+    return strong + weak, key_hits, themes, score
+
+
+def _dynamic_candidates(text: str, base_url: str, keys: list[str]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for match in _JS_RE.finditer(text):
+        url = _safe_url(urllib.parse.urljoin(base_url, match.group(1).strip()))
+        parsed = urllib.parse.urlsplit(url)
+        if parsed.scheme != "https" or not parsed.netloc or url in seen:
+            continue
+        lo = max(0, match.start() - _DYNAMIC_RADIUS)
+        hi = min(len(text), match.end() + _DYNAMIC_RADIUS)
+        anchors, key_hits, themes, score = _matched(text[lo:hi], keys)
+        # All has no score and cannot select a chunk; weak anchors alone are insufficient.
+        if score < 3:
+            continue
+        seen.add(url)
+        rows.append(
+            {
+                "url": url,
+                "anchors": anchors,
+                "translation_keys": key_hits[:20],
+                "theme_terms": themes,
+                "score": score,
+            }
+        )
+    return sorted(rows, key=lambda row: (-int(row["score"]), str(row["url"])))
+
+
+def _context(text: str, idx: int, term: str, kind: str, source: str) -> dict[str, Any]:
     lo = max(0, idx - _CONTEXT_RADIUS)
     hi = min(len(text), idx + len(term) + _CONTEXT_RADIUS)
-    snippet = re.sub(r"\s+", " ", text[lo:hi]).strip()
+    raw = text[lo:hi]
     return {
         "term": term,
         "kind": kind,
-        "source": _safe_url(source_url),
-        "mowerbot_paths": sorted(set(_MOWERBOT_RE.findall(snippet)))[:20],
-        "http_methods": sorted({value.upper() for value in _HTTP_METHOD_RE.findall(snippet)}),
-        "skip_encryption": sorted({value.lower() for value in _SKIP_ENCRYPTION_RE.findall(snippet)}),
-        "bridge_calls": _bridge_calls(snippet),
-        "object_keys": _object_keys(snippet),
-        "has_request_hint": bool(_REQUEST_HINT_RE.search(snippet)),
-        "context": snippet,
+        "source": _safe_url(source),
+        "mowerbot_paths": sorted(set(_MOWERBOT_RE.findall(raw)))[:20],
+        "http_methods": sorted({value.upper() for value in _HTTP_RE.findall(raw)}),
+        "skip_encryption": sorted({value.lower() for value in _SKIP_RE.findall(raw)}),
+        "bridge_calls": _bridge_calls(raw),
+        "object_keys": _object_keys(raw),
+        "has_request_hint": bool(_REQUEST_HINT_RE.search(raw)),
+        "context": re.sub(r"\s+", " ", raw).strip(),
     }
 
 
-def _target_contexts(
-    text: str,
-    source_url: str,
-    key_terms: list[str],
-) -> list[dict[str, Any]]:
-    """Keep a separate bounded quota for every useful anchor/key term."""
+def _target_contexts(text: str, source: str, keys: list[str]) -> list[dict[str, Any]]:
+    """Use a separate quota per anchor/key, so one common term cannot fill the list."""
     lower = text.lower()
     rows: list[dict[str, Any]] = []
     terms: list[tuple[str, str, int]] = []
-    terms.extend((anchor, "anchor", _MAX_CONTEXTS_PER_TERM) for anchor in _STRONG_ANCHORS)
-    terms.extend((anchor, "anchor", 2) for anchor in _WEAK_ANCHORS)
-    # ``All`` is counted elsewhere but intentionally omitted from request context.
-    terms.extend((key, "translation_key", _MAX_CONTEXTS_PER_TERM) for key in key_terms)
-
-    seen: set[tuple[str, str, int]] = set()
+    terms += [(value, "anchor", _MAX_CONTEXTS_PER_TERM) for value in _STRONG_ANCHORS]
+    terms += [(value, "anchor", 2) for value in _WEAK_ANCHORS]
+    terms += [(value, "translation_key", _MAX_CONTEXTS_PER_TERM) for value in keys]
+    # All is deliberately not a request-context term.
     for term, kind, limit in terms:
-        needle = term.lower()
-        if not needle:
-            continue
         start = 0
         kept = 0
+        needle = term.lower()
         while kept < limit and len(rows) < _MAX_REQUEST_CONTEXTS:
             idx = lower.find(needle, start)
             if idx < 0:
                 break
             start = idx + max(1, len(needle))
-            bucket = idx // 500
-            marker = (kind, needle, bucket)
-            if marker in seen:
-                continue
-            seen.add(marker)
-            rows.append(_context_row(text, idx, term, kind, source_url))
+            rows.append(_context(text, idx, term, kind, source))
             kept += 1
-        if len(rows) >= _MAX_REQUEST_CONTEXTS:
-            break
     return rows
 
 
-def _matched_terms(nearby: str, key_terms: list[str]) -> tuple[list[str], list[str], list[str], int]:
-    low = nearby.lower()
-    strong = [anchor for anchor in _STRONG_ANCHORS if anchor.lower() in low]
-    weak = [anchor for anchor in _WEAK_ANCHORS if anchor.lower() in low]
-    keys = [key for key in key_terms if key.lower() in low]
-    theme_terms = [
-        term
-        for term in ("messagecenter", "notification", "newmessages", "messagehistory")
-        if term in low
-    ]
-    score = len(strong) * 8 + len(keys) * 10 + len(theme_terms) * 3 + len(weak)
-    return strong + weak, keys, theme_terms, score
-
-
-def _dynamic_candidates(
-    text: str,
-    base_url: str,
-    key_terms: list[str],
-) -> list[dict[str, Any]]:
-    """Rank chunks by strong phrases/translation keys; generic All scores zero."""
+def _request_rows(text: str, source: str, keys: list[str]) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     seen: set[str] = set()
-    for match in _JS_LITERAL_RE.finditer(text):
-        url = urllib.parse.urljoin(base_url, match.group(1).strip())
-        parsed = urllib.parse.urlsplit(url)
-        if parsed.scheme != "https" or not parsed.netloc:
-            continue
-        safe = _safe_url(url)
-        if safe in seen:
-            continue
-        lo = max(0, match.start() - _DYNAMIC_RADIUS)
-        hi = min(len(text), match.end() + _DYNAMIC_RADIUS)
-        nearby = text[lo:hi]
-        anchors, keys, themes, score = _matched_terms(nearby, key_terms)
-        if score < 3:
-            continue
-        seen.add(safe)
-        rows.append(
-            {
-                "url": safe,
-                "anchors": anchors,
-                "translation_keys": keys[:20],
-                "theme_terms": themes,
-                "score": score,
-            }
-        )
-    rows.sort(key=lambda row: (-int(row["score"]), str(row["url"])))
-    return rows
-
-
-def _request_rows(
-    text: str,
-    source_url: str,
-    key_terms: list[str],
-) -> list[dict[str, Any]]:
-    """Inventory literal mowerbot requests in a selected target chunk."""
-    rows: list[dict[str, Any]] = []
-    seen: set[tuple[str, int]] = set()
     for match in _MOWERBOT_RE.finditer(text):
-        route = match.group(1)
-        bucket = match.start() // 1000
-        marker = (route, bucket)
-        if marker in seen:
+        path = match.group(1)
+        if path in seen:
             continue
-        seen.add(marker)
+        seen.add(path)
         lo = max(0, match.start() - _REQUEST_RADIUS)
         hi = min(len(text), match.end() + _REQUEST_RADIUS)
         raw = text[lo:hi]
-        snippet = re.sub(r"\s+", " ", raw).strip()
-        anchors, keys, themes, score = _matched_terms(raw, key_terms)
+        anchors, key_hits, themes, score = _matched(raw, keys)
         rows.append(
             {
-                "path": route,
-                "source": _safe_url(source_url),
+                "path": path,
+                "source": _safe_url(source),
                 "target_score": score,
                 "matched_anchors": anchors,
-                "matched_translation_keys": keys[:20],
+                "matched_translation_keys": key_hits[:20],
                 "theme_terms": themes,
-                "http_methods": sorted({value.upper() for value in _HTTP_METHOD_RE.findall(raw)}),
-                "skip_encryption": sorted({value.lower() for value in _SKIP_ENCRYPTION_RE.findall(raw)}),
+                "http_methods": sorted({value.upper() for value in _HTTP_RE.findall(raw)}),
+                "skip_encryption": sorted({value.lower() for value in _SKIP_RE.findall(raw)}),
                 "bridge_calls": _bridge_calls(raw),
                 "object_keys": _object_keys(raw),
-                "context": snippet,
+                "context": re.sub(r"\s+", " ", raw).strip(),
             }
         )
-        if len(rows) >= _MAX_REQUEST_ROWS:
+        if len(rows) >= 60:
             break
-    rows.sort(key=lambda row: (-int(row["target_score"]), str(row["path"])))
-    return rows
+    return sorted(rows, key=lambda row: (-int(row["target_score"]), str(row["path"])))
 
 
 def probe_main_notification_feed(client: Any) -> dict[str, Any]:
-    """Discover the real main Notification feed request from public H5 source."""
+    """Discover request clues for Notification -> Device from public H5 source."""
     host = _host(client)
     pages: list[dict[str, Any]] = []
     scripts: list[str] = []
     page_hashes: set[str] = set()
-    translation_rows: list[dict[str, str]] = []
-    anchor_hit_counts: dict[str, int] = {}
+    translations: list[dict[str, str]] = []
+    anchor_counts: dict[str, int] = {}
 
-    def merge_anchor_counts(counts: dict[str, int]) -> None:
-        for key, value in counts.items():
-            anchor_hit_counts[key] = anchor_hit_counts.get(key, 0) + int(value)
+    def add_counts(values: dict[str, int]) -> None:
+        for key, value in values.items():
+            anchor_counts[key] = anchor_counts.get(key, 0) + int(value)
 
-    def merge_translation(rows: list[dict[str, str]]) -> None:
-        existing = {
-            (str(row.get("anchor") or "").lower(), str(row.get("qualified_key") or "").lower())
-            for row in translation_rows
-        }
-        for row in rows:
-            marker = (row["anchor"].lower(), row["qualified_key"].lower())
-            if marker not in existing and len(translation_rows) < _MAX_TRANSLATION_ROWS:
-                translation_rows.append(row)
-                existing.add(marker)
+    def add_translations(values: list[dict[str, str]]) -> None:
+        known = {(row["anchor"].lower(), row["key"].lower()) for row in translations}
+        for row in values:
+            marker = (row["anchor"].lower(), row["key"].lower())
+            if marker not in known and len(translations) < 80:
+                translations.append(row)
+                known.add(marker)
 
     for path in _ENTRY_PATHS:
         url = urllib.parse.urljoin(host + "/", path.lstrip("/"))
@@ -453,138 +354,114 @@ def probe_main_notification_feed(client: Any) -> dict[str, Any]:
         row = _public(result)
         if text:
             found = _root_scripts(text, url)
-            row["script_urls"] = [_safe_url(item) for item in found]
+            row["script_urls"] = [_safe_url(value) for value in found]
             row["anchor_hit_counts"] = _anchor_counts(text)
-            merge_anchor_counts(row["anchor_hit_counts"])
-            found_keys = _translation_keys(text, url)
-            row["translation_keys"] = found_keys
-            merge_translation(found_keys)
-            body_hash = str(result.get("body_sha256") or "")
-            if body_hash not in page_hashes:
-                scripts.extend(found)
-                page_hashes.add(body_hash)
+            add_counts(row["anchor_hit_counts"])
+            found_translations = _translation_rows(text, url)
+            row["translation_keys"] = found_translations
+            add_translations(found_translations)
+            digest = str(result.get("body_sha256") or "")
+            if digest not in page_hashes:
+                scripts += found
+                page_hashes.add(digest)
         pages.append(row)
 
-    unique_scripts: list[str] = []
-    seen_scripts: set[str] = set()
-    for url in scripts:
-        if url not in seen_scripts:
-            seen_scripts.add(url)
-            unique_scripts.append(url)
-
-    # Fetch roots first so translation discovery is complete before chunk ranking.
     root_sources: list[tuple[str, str]] = []
     root_assets: list[dict[str, Any]] = []
-    for url in unique_scripts[:_MAX_ROOT_ASSETS]:
+    for url in list(dict.fromkeys(scripts))[:_MAX_ROOT_ASSETS]:
         result = _fetch(url, _MAX_JS_BYTES)
         text = str(result.get("_text") or "")
         row = _public(result)
         if text:
             root_sources.append((url, text))
             row["anchor_hit_counts"] = _anchor_counts(text)
-            merge_anchor_counts(row["anchor_hit_counts"])
-            found_keys = _translation_keys(text, url)
-            row["translation_keys"] = found_keys
-            merge_translation(found_keys)
+            add_counts(row["anchor_hit_counts"])
+            found_translations = _translation_rows(text, url)
+            row["translation_keys"] = found_translations
+            add_translations(found_translations)
         root_assets.append(row)
 
-    key_terms = _key_terms(translation_rows)
+    ranking_keys = _ranking_keys(translations)
     candidates: dict[str, dict[str, Any]] = {}
-    all_contexts: list[dict[str, Any]] = []
-    request_rows: list[dict[str, Any]] = []
+    contexts: list[dict[str, Any]] = []
+    requests: list[dict[str, Any]] = []
 
-    def merge_candidate(candidate: dict[str, Any]) -> None:
-        url = str(candidate["url"])
-        current = candidates.get(url)
-        if current is None or int(candidate["score"]) > int(current["score"]):
-            candidates[url] = candidate
+    def add_candidates(text: str, url: str) -> None:
+        for candidate in _dynamic_candidates(text, url, ranking_keys):
+            old = candidates.get(candidate["url"])
+            if old is None or int(candidate["score"]) > int(old["score"]):
+                candidates[candidate["url"]] = candidate
 
-    # Revisit roots with the complete translation key set.
     for url, text in root_sources:
-        contexts = _target_contexts(text, url, key_terms)
-        all_contexts.extend(contexts)
-        for candidate in _dynamic_candidates(text, url, key_terms):
-            merge_candidate(candidate)
+        contexts += _target_contexts(text, url, ranking_keys)
+        requests += _request_rows(text, url, ranking_keys)
+        add_candidates(text, url)
 
     dynamic_assets: list[dict[str, Any]] = []
-    fetched_dynamic: set[str] = set()
+    fetched: set[str] = set()
     while len(dynamic_assets) < _MAX_DYNAMIC_ASSETS:
         ranked = sorted(
-            (row for row in candidates.values() if str(row["url"]) not in fetched_dynamic),
+            (row for row in candidates.values() if row["url"] not in fetched),
             key=lambda row: (-int(row["score"]), str(row["url"])),
         )
         if not ranked:
             break
         candidate = ranked[0]
         url = str(candidate["url"])
-        fetched_dynamic.add(url)
+        fetched.add(url)
         result = _fetch(url, _MAX_JS_BYTES)
         text = str(result.get("_text") or "")
         row = _public(result)
         row["candidate"] = candidate
         if text:
             row["anchor_hit_counts"] = _anchor_counts(text)
-            merge_anchor_counts(row["anchor_hit_counts"])
-            found_keys = _translation_keys(text, url)
-            row["translation_keys"] = found_keys
-            merge_translation(found_keys)
-            # New exact keys can improve subsequent child-chunk ranking.
-            key_terms = _key_terms(translation_rows)
-            contexts = _target_contexts(text, url, key_terms)
-            row["target_contexts"] = contexts
-            all_contexts.extend(contexts)
-            requests = _request_rows(text, url, key_terms)
-            row["mowerbot_requests"] = requests
-            request_rows.extend(requests)
-            for child in _dynamic_candidates(text, url, key_terms):
-                merge_candidate(child)
+            add_counts(row["anchor_hit_counts"])
+            found_translations = _translation_rows(text, url)
+            row["translation_keys"] = found_translations
+            add_translations(found_translations)
+            ranking_keys = _ranking_keys(translations)
+            row["target_contexts"] = _target_contexts(text, url, ranking_keys)
+            contexts += row["target_contexts"]
+            row["mowerbot_requests"] = _request_rows(text, url, ranking_keys)
+            requests += row["mowerbot_requests"]
+            add_candidates(text, url)
         dynamic_assets.append(row)
 
-    # Root requests are also useful if the Notification request lives in app-entry.
-    for url, text in root_sources:
-        request_rows.extend(_request_rows(text, url, key_terms))
-
-    # Keep best evidence per source/path pair.
-    unique_requests: dict[tuple[str, str], dict[str, Any]] = {}
-    for row in request_rows:
-        marker = (str(row.get("source") or ""), str(row.get("path") or ""))
-        current = unique_requests.get(marker)
-        if current is None or int(row.get("target_score") or 0) > int(current.get("target_score") or 0):
-            unique_requests[marker] = row
-    ranked_requests = sorted(
-        unique_requests.values(),
-        key=lambda row: (-int(row.get("target_score") or 0), str(row.get("path") or "")),
-    )[:_MAX_REQUEST_ROWS]
-
     translation_map: dict[str, list[str]] = {}
-    for row in translation_rows:
+    for row in translations:
         translation_map.setdefault(row["anchor"], [])
-        qualified = row["qualified_key"]
-        if qualified not in translation_map[row["anchor"]]:
-            translation_map[row["anchor"]].append(qualified)
+        if row["key"] not in translation_map[row["anchor"]]:
+            translation_map[row["anchor"]].append(row["key"])
 
-    bridge_hits: list[dict[str, str]] = []
-    for context in all_contexts:
-        for bridge in context.get("bridge_calls") or []:
-            if bridge not in bridge_hits:
-                bridge_hits.append(bridge)
-    for request in ranked_requests:
-        for bridge in request.get("bridge_calls") or []:
-            if bridge not in bridge_hits:
-                bridge_hits.append(bridge)
+    request_best: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in requests:
+        marker = (str(row["source"]), str(row["path"]))
+        old = request_best.get(marker)
+        if old is None or int(row["target_score"]) > int(old["target_score"]):
+            request_best[marker] = row
+    ranked_requests = sorted(
+        request_best.values(),
+        key=lambda row: (-int(row["target_score"]), str(row["path"])),
+    )[:60]
 
-    ranked_candidates = sorted(
-        candidates.values(),
-        key=lambda row: (-int(row["score"]), str(row["url"])),
-    )
+    bridge_calls: list[dict[str, str]] = []
+    for row in [*contexts, *ranked_requests]:
+        for bridge in row.get("bridge_calls") or []:
+            if bridge not in bridge_calls:
+                bridge_calls.append(bridge)
+
     useful_contexts = [
         row
-        for row in all_contexts
+        for row in contexts
         if row.get("has_request_hint")
         or row.get("mowerbot_paths")
         or row.get("bridge_calls")
         or row.get("skip_encryption")
     ][:_MAX_REQUEST_CONTEXTS]
+    ranked_candidates = sorted(
+        candidates.values(),
+        key=lambda row: (-int(row["score"]), str(row["url"])),
+    )
 
     return {
         "read_only": True,
@@ -598,7 +475,7 @@ def probe_main_notification_feed(client: Any) -> dict[str, Any]:
             "weak_anchors": list(_WEAK_ANCHORS),
             "generic_zero_score_anchors": list(_GENERIC_ANCHORS),
             "seed_keys": list(_SEED_KEYS),
-            "note": "All is evidence-only and cannot select a dynamic chunk.",
+            "note": "All is evidence-only; discovered keys from All/System/Device are excluded from chunk scoring.",
         },
         "limits": {
             "timeout_seconds_per_request": _TIMEOUT_SECONDS,
@@ -613,19 +490,19 @@ def probe_main_notification_feed(client: Any) -> dict[str, Any]:
             "Public H5 discovery sends no uid, token, mower serial, device id or p:101 payload; source bodies are not stored."
         ),
         "summary": {
-            "anchor_hit_counts": anchor_hit_counts,
+            "anchor_hit_counts": anchor_counts,
             "translation_key_map": translation_map,
-            "translation_keys": translation_rows,
-            "search_key_terms": key_terms,
+            "translation_keys": translations,
+            "ranking_translation_keys": ranking_keys,
             "dynamic_candidates": ranked_candidates[:30],
             "mowerbot_requests": ranked_requests,
-            "bridge_calls": bridge_hits[:80],
+            "bridge_calls": bridge_calls[:80],
             "request_contexts": useful_contexts,
         },
         "pages": pages,
         "root_assets": root_assets,
         "dynamic_assets": dynamic_assets,
         "note": (
-            "Beta28 maps exact Notification translations to keys, ranks lazy chunks by high-signal phrases/keys, and inventories mowerbot request structure in the owning chunks."
+            "Beta28 discovers translation keys first, excludes generic labels from ranking, and inventories request structure in high-signal Notification chunks."
         ),
     }

--- a/custom_components/navimower/notification_feed_discovery.py
+++ b/custom_components/navimower/notification_feed_discovery.py
@@ -1,11 +1,17 @@
 """Targeted public-H5 discovery for the main Navimow Notification feed.
 
-Beta27 follows the evidence captured from the real app UI. Instead of broad
-message endpoint guessing, it searches public H5 JavaScript specifically around
-strings rendered by the main Notification screen (All / Important / Work
-status / System / Device / newMessages / No more messages / Failed to load new
-messages). It then records only nearby request structure: mowerbot paths, HTTP
-method literals and native/encryption bridge calls.
+Beta28 fixes the main weakness observed in beta27: generic UI words such as
+``All`` can occur hundreds of times and must not decide which lazy chunks are
+inspected.  Discovery now works in two stages:
+
+1. map exact Notification UI translations to their nearby translation keys;
+2. use those keys plus high-signal Notification phrases to find the owning
+   JavaScript chunks, then inventory request structure inside those chunks.
+
+The scanner records bounded source context, literal ``/mowerbot/...`` routes,
+HTTP method hints, ``skipEncryption`` values, object/payload keys and native or
+encryption bridge calls.  Generic ``All`` / ``System`` / ``Device`` hits remain
+visible for evidence but cannot dominate chunk ranking.
 
 No credentials, mower serials, account ids or p:101 payloads are sent. Source
 HTML/JavaScript bodies are never persisted in diagnostics.
@@ -31,29 +37,51 @@ _ANCHORS: tuple[str, ...] = (
     "No more messages",
     "Failed to load new messages",
 )
+_STRONG_ANCHORS: tuple[str, ...] = (
+    "Important",
+    "Work status",
+    "newMessages",
+    "No more messages",
+    "Failed to load new messages",
+)
+_WEAK_ANCHORS: tuple[str, ...] = ("System", "Device")
+_GENERIC_ANCHORS: tuple[str, ...] = ("All",)
+_SEED_KEYS: tuple[str, ...] = ("newMessages", "messageCenter")
 _ENTRY_PATHS: tuple[str, ...] = ("/message/message/list", "/old/")
 _MAX_HTML_BYTES = 256 * 1024
 _MAX_JS_BYTES = 2 * 1024 * 1024
 _MAX_ROOT_ASSETS = 6
 _MAX_DYNAMIC_ASSETS = 6
-_MAX_CONTEXTS = 40
-_CONTEXT_RADIUS = 1800
-_DYNAMIC_RADIUS = 2200
+_MAX_CONTEXTS_PER_TERM = 4
+_MAX_REQUEST_CONTEXTS = 48
+_MAX_TRANSLATION_ROWS = 80
+_MAX_REQUEST_ROWS = 60
+_CONTEXT_RADIUS = 2200
+_REQUEST_RADIUS = 3200
+_DYNAMIC_RADIUS = 2600
 _TIMEOUT_SECONDS = 5
 
 _SCRIPT_RE = re.compile(r"<script\b[^>]*\bsrc\s*=\s*[\"']([^\"']+)[\"']", re.I)
 _JS_LITERAL_RE = re.compile(r"[\"']([^\"'\r\n]{1,360}\.js(?:\?[^\"'\r\n]{0,120})?)[\"']", re.I)
 _MOWERBOT_RE = re.compile(r"[\"'](/mowerbot/[^\"'\r\n]{1,240})[\"']", re.I)
-_HTTP_METHOD_RE = re.compile(r"(?:method\s*:\s*|\.)[\"']?(GET|POST|PUT|DELETE|PATCH)[\"']?", re.I)
+_HTTP_METHOD_RE = re.compile(
+    r"(?:method\s*:\s*[\"']?|\.(?:request|ajax)\([^)]{0,300}?method\s*:\s*[\"']?)"
+    r"(GET|POST|PUT|DELETE|PATCH)[\"']?",
+    re.I,
+)
+_SKIP_ENCRYPTION_RE = re.compile(r"skipEncryption\s*:\s*(true|false)", re.I)
 _SEND_ENCRYPT_RE = re.compile(
     r"(?P<callee>(?:[A-Za-z_$][\w$]*\.)*(?:sendEncryptionData|callNative|sendMessageToNative))"
     r"\s*\(\s*[\"'](?P<method>[^\"']{1,140})[\"']",
     re.I,
 )
 _REQUEST_HINT_RE = re.compile(
-    r"(?:skipEncryption|sendEncryptionData|callNative|axios|fetch|\.post\(|\.get\(|method\s*:)",
+    r"(?:skipEncryption|sendEncryptionData|callNative|sendMessageToNative|axios|fetch|"
+    r"\.post\(|\.get\(|\.request\(|method\s*:|/mowerbot/)",
     re.I,
 )
+_OBJECT_KEY_RE = re.compile(r"(?:^|[,{])\s*[\"']?([A-Za-z_$][\w$]{1,80})[\"']?\s*:")
+_PARENT_OBJECT_RE = re.compile(r"([A-Za-z_$][\w$]{0,80})\s*:\s*\{[^{}]{0,220}$")
 
 
 def _host(client: Any) -> str:
@@ -71,7 +99,7 @@ def _fetch(url: str, limit: int) -> dict[str, Any]:
         url,
         headers={
             "Accept": "text/html,application/javascript,text/javascript,*/*;q=0.8",
-            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.1-beta27",
+            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.1-beta28",
         },
         method="GET",
     )
@@ -85,7 +113,11 @@ def _fetch(url: str, limit: int) -> dict[str, Any]:
         status = int(err.code)
         content_type = str(err.headers.get("Content-Type", ""))
     except urllib.error.URLError as err:
-        return {"ok": False, "url": _safe_url(url), "transport_error": sanitize(str(err.reason))}
+        return {
+            "ok": False,
+            "url": _safe_url(url),
+            "transport_error": sanitize(str(err.reason)),
+        }
     except Exception as err:  # noqa: BLE001 - bounded diagnostics-only discovery
         return {
             "ok": False,
@@ -121,58 +153,204 @@ def _root_scripts(html: str, base_url: str) -> list[str]:
             continue
         seen.add(url)
         out.append(url)
-    out.sort(key=lambda url: (0 if any(t in url.lower() for t in ("app", "main", "entry", "index")) else 1, len(url)))
+    out.sort(
+        key=lambda url: (
+            0
+            if any(token in url.lower() for token in ("app", "main", "entry", "index"))
+            else 1,
+            len(url),
+        )
+    )
     return out[:_MAX_ROOT_ASSETS]
 
 
-def _anchor_contexts(text: str, source_url: str) -> list[dict[str, Any]]:
+def _anchor_counts(text: str) -> dict[str, int]:
     lower = text.lower()
-    rows: list[dict[str, Any]] = []
-    seen: set[tuple[str, int]] = set()
+    return {
+        anchor: lower.count(anchor.lower())
+        for anchor in _ANCHORS
+        if anchor.lower() in lower
+    }
+
+
+def _qualified_key(text: str, start: int, key: str) -> str:
+    prefix = text[max(0, start - 240):start]
+    parents = list(_PARENT_OBJECT_RE.finditer(prefix))
+    if parents:
+        parent = parents[-1].group(1)
+        if parent and parent != key:
+            return f"{parent}.{key}"
+    return key
+
+
+def _translation_keys(text: str, source_url: str) -> list[dict[str, str]]:
+    """Map exact visible English strings to nearby translation object keys."""
+    rows: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
     for anchor in _ANCHORS:
-        needle = anchor.lower()
-        start = 0
-        while len(rows) < _MAX_CONTEXTS:
-            idx = lower.find(needle, start)
-            if idx < 0:
-                break
-            bucket = idx // 500
-            key = (needle, bucket)
-            start = idx + max(1, len(needle))
-            if key in seen:
-                continue
-            seen.add(key)
-            lo = max(0, idx - _CONTEXT_RADIUS)
-            hi = min(len(text), idx + len(anchor) + _CONTEXT_RADIUS)
-            snippet = re.sub(r"\s+", " ", text[lo:hi]).strip()
-            routes = sorted(set(_MOWERBOT_RE.findall(snippet)))
-            methods = sorted({value.upper() for value in _HTTP_METHOD_RE.findall(snippet)})
-            bridges = []
-            for match in _SEND_ENCRYPT_RE.finditer(snippet):
-                row = {
-                    "callee": match.group("callee"),
-                    "method": match.group("method"),
-                }
-                if row not in bridges:
-                    bridges.append(row)
-            rows.append(
-                {
-                    "anchor": anchor,
-                    "source": _safe_url(source_url),
-                    "mowerbot_paths": routes[:20],
-                    "http_methods": methods,
-                    "bridge_calls": bridges[:20],
-                    "has_request_hint": bool(_REQUEST_HINT_RE.search(snippet)),
-                    "context": snippet,
-                }
-            )
-        if len(rows) >= _MAX_CONTEXTS:
+        escaped = re.escape(anchor)
+        patterns = (
+            re.compile(
+                rf"(?P<key>[A-Za-z_$][\w$.-]{{0,100}})\s*:\s*[\"']{escaped}[\"']",
+                re.I,
+            ),
+            re.compile(
+                rf"[\"'](?P<key>[^\"'\r\n]{{1,120}})[\"']\s*:\s*[\"']{escaped}[\"']",
+                re.I,
+            ),
+        )
+        for pattern in patterns:
+            for match in pattern.finditer(text):
+                key = str(match.group("key")).strip()
+                if not key or len(key) > 120:
+                    continue
+                qualified = _qualified_key(text, match.start("key"), key)
+                dedupe = (anchor.lower(), qualified.lower())
+                if dedupe in seen:
+                    continue
+                seen.add(dedupe)
+                lo = max(0, match.start() - 260)
+                hi = min(len(text), match.end() + 260)
+                rows.append(
+                    {
+                        "anchor": anchor,
+                        "key": key,
+                        "qualified_key": qualified,
+                        "source": _safe_url(source_url),
+                        "context": re.sub(r"\s+", " ", text[lo:hi]).strip(),
+                    }
+                )
+                if len(rows) >= _MAX_TRANSLATION_ROWS:
+                    return rows
+    return rows
+
+
+def _key_terms(translation_rows: list[dict[str, str]]) -> list[str]:
+    values: set[str] = set(_SEED_KEYS)
+    for row in translation_rows:
+        for field in ("key", "qualified_key"):
+            value = str(row.get(field) or "").strip()
+            if len(value) >= 3:
+                values.add(value)
+    return sorted(values, key=lambda value: (-len(value), value.lower()))
+
+
+def _bridge_calls(snippet: str) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for match in _SEND_ENCRYPT_RE.finditer(snippet):
+        row = {"callee": match.group("callee"), "method": match.group("method")}
+        if row not in rows:
+            rows.append(row)
+        if len(rows) >= 20:
             break
     return rows
 
 
-def _dynamic_candidates(text: str, base_url: str) -> list[dict[str, Any]]:
+def _object_keys(snippet: str) -> list[str]:
+    ignored = {
+        "class",
+        "style",
+        "children",
+        "props",
+        "key",
+        "ref",
+        "type",
+        "name",
+        "component",
+        "render",
+    }
+    out: list[str] = []
+    for value in _OBJECT_KEY_RE.findall(snippet):
+        if value.lower() in ignored or value in out:
+            continue
+        out.append(value)
+        if len(out) >= 40:
+            break
+    return out
+
+
+def _context_row(
+    text: str,
+    idx: int,
+    term: str,
+    kind: str,
+    source_url: str,
+) -> dict[str, Any]:
+    lo = max(0, idx - _CONTEXT_RADIUS)
+    hi = min(len(text), idx + len(term) + _CONTEXT_RADIUS)
+    snippet = re.sub(r"\s+", " ", text[lo:hi]).strip()
+    return {
+        "term": term,
+        "kind": kind,
+        "source": _safe_url(source_url),
+        "mowerbot_paths": sorted(set(_MOWERBOT_RE.findall(snippet)))[:20],
+        "http_methods": sorted({value.upper() for value in _HTTP_METHOD_RE.findall(snippet)}),
+        "skip_encryption": sorted({value.lower() for value in _SKIP_ENCRYPTION_RE.findall(snippet)}),
+        "bridge_calls": _bridge_calls(snippet),
+        "object_keys": _object_keys(snippet),
+        "has_request_hint": bool(_REQUEST_HINT_RE.search(snippet)),
+        "context": snippet,
+    }
+
+
+def _target_contexts(
+    text: str,
+    source_url: str,
+    key_terms: list[str],
+) -> list[dict[str, Any]]:
+    """Keep a separate bounded quota for every useful anchor/key term."""
     lower = text.lower()
+    rows: list[dict[str, Any]] = []
+    terms: list[tuple[str, str, int]] = []
+    terms.extend((anchor, "anchor", _MAX_CONTEXTS_PER_TERM) for anchor in _STRONG_ANCHORS)
+    terms.extend((anchor, "anchor", 2) for anchor in _WEAK_ANCHORS)
+    # ``All`` is counted elsewhere but intentionally omitted from request context.
+    terms.extend((key, "translation_key", _MAX_CONTEXTS_PER_TERM) for key in key_terms)
+
+    seen: set[tuple[str, str, int]] = set()
+    for term, kind, limit in terms:
+        needle = term.lower()
+        if not needle:
+            continue
+        start = 0
+        kept = 0
+        while kept < limit and len(rows) < _MAX_REQUEST_CONTEXTS:
+            idx = lower.find(needle, start)
+            if idx < 0:
+                break
+            start = idx + max(1, len(needle))
+            bucket = idx // 500
+            marker = (kind, needle, bucket)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            rows.append(_context_row(text, idx, term, kind, source_url))
+            kept += 1
+        if len(rows) >= _MAX_REQUEST_CONTEXTS:
+            break
+    return rows
+
+
+def _matched_terms(nearby: str, key_terms: list[str]) -> tuple[list[str], list[str], list[str], int]:
+    low = nearby.lower()
+    strong = [anchor for anchor in _STRONG_ANCHORS if anchor.lower() in low]
+    weak = [anchor for anchor in _WEAK_ANCHORS if anchor.lower() in low]
+    keys = [key for key in key_terms if key.lower() in low]
+    theme_terms = [
+        term
+        for term in ("messagecenter", "notification", "newmessages", "messagehistory")
+        if term in low
+    ]
+    score = len(strong) * 8 + len(keys) * 10 + len(theme_terms) * 3 + len(weak)
+    return strong + weak, keys, theme_terms, score
+
+
+def _dynamic_candidates(
+    text: str,
+    base_url: str,
+    key_terms: list[str],
+) -> list[dict[str, Any]]:
+    """Rank chunks by strong phrases/translation keys; generic All scores zero."""
     rows: list[dict[str, Any]] = []
     seen: set[str] = set()
     for match in _JS_LITERAL_RE.finditer(text):
@@ -185,22 +363,88 @@ def _dynamic_candidates(text: str, base_url: str) -> list[dict[str, Any]]:
             continue
         lo = max(0, match.start() - _DYNAMIC_RADIUS)
         hi = min(len(text), match.end() + _DYNAMIC_RADIUS)
-        nearby = lower[lo:hi]
-        matched = [anchor for anchor in _ANCHORS if anchor.lower() in nearby]
-        if not matched:
+        nearby = text[lo:hi]
+        anchors, keys, themes, score = _matched_terms(nearby, key_terms)
+        if score < 3:
             continue
         seen.add(safe)
-        rows.append({"url": safe, "anchors": matched, "score": len(matched)})
+        rows.append(
+            {
+                "url": safe,
+                "anchors": anchors,
+                "translation_keys": keys[:20],
+                "theme_terms": themes,
+                "score": score,
+            }
+        )
     rows.sort(key=lambda row: (-int(row["score"]), str(row["url"])))
     return rows
 
 
+def _request_rows(
+    text: str,
+    source_url: str,
+    key_terms: list[str],
+) -> list[dict[str, Any]]:
+    """Inventory literal mowerbot requests in a selected target chunk."""
+    rows: list[dict[str, Any]] = []
+    seen: set[tuple[str, int]] = set()
+    for match in _MOWERBOT_RE.finditer(text):
+        route = match.group(1)
+        bucket = match.start() // 1000
+        marker = (route, bucket)
+        if marker in seen:
+            continue
+        seen.add(marker)
+        lo = max(0, match.start() - _REQUEST_RADIUS)
+        hi = min(len(text), match.end() + _REQUEST_RADIUS)
+        raw = text[lo:hi]
+        snippet = re.sub(r"\s+", " ", raw).strip()
+        anchors, keys, themes, score = _matched_terms(raw, key_terms)
+        rows.append(
+            {
+                "path": route,
+                "source": _safe_url(source_url),
+                "target_score": score,
+                "matched_anchors": anchors,
+                "matched_translation_keys": keys[:20],
+                "theme_terms": themes,
+                "http_methods": sorted({value.upper() for value in _HTTP_METHOD_RE.findall(raw)}),
+                "skip_encryption": sorted({value.lower() for value in _SKIP_ENCRYPTION_RE.findall(raw)}),
+                "bridge_calls": _bridge_calls(raw),
+                "object_keys": _object_keys(raw),
+                "context": snippet,
+            }
+        )
+        if len(rows) >= _MAX_REQUEST_ROWS:
+            break
+    rows.sort(key=lambda row: (-int(row["target_score"]), str(row["path"])))
+    return rows
+
+
 def probe_main_notification_feed(client: Any) -> dict[str, Any]:
-    """Discover request clues specifically around the main Notification UI."""
+    """Discover the real main Notification feed request from public H5 source."""
     host = _host(client)
     pages: list[dict[str, Any]] = []
     scripts: list[str] = []
     page_hashes: set[str] = set()
+    translation_rows: list[dict[str, str]] = []
+    anchor_hit_counts: dict[str, int] = {}
+
+    def merge_anchor_counts(counts: dict[str, int]) -> None:
+        for key, value in counts.items():
+            anchor_hit_counts[key] = anchor_hit_counts.get(key, 0) + int(value)
+
+    def merge_translation(rows: list[dict[str, str]]) -> None:
+        existing = {
+            (str(row.get("anchor") or "").lower(), str(row.get("qualified_key") or "").lower())
+            for row in translation_rows
+        }
+        for row in rows:
+            marker = (row["anchor"].lower(), row["qualified_key"].lower())
+            if marker not in existing and len(translation_rows) < _MAX_TRANSLATION_ROWS:
+                translation_rows.append(row)
+                existing.add(marker)
 
     for path in _ENTRY_PATHS:
         url = urllib.parse.urljoin(host + "/", path.lstrip("/"))
@@ -210,7 +454,11 @@ def probe_main_notification_feed(client: Any) -> dict[str, Any]:
         if text:
             found = _root_scripts(text, url)
             row["script_urls"] = [_safe_url(item) for item in found]
-            row["anchor_contexts"] = _anchor_contexts(text, url)
+            row["anchor_hit_counts"] = _anchor_counts(text)
+            merge_anchor_counts(row["anchor_hit_counts"])
+            found_keys = _translation_keys(text, url)
+            row["translation_keys"] = found_keys
+            merge_translation(found_keys)
             body_hash = str(result.get("body_sha256") or "")
             if body_hash not in page_hashes:
                 scripts.extend(found)
@@ -224,54 +472,119 @@ def probe_main_notification_feed(client: Any) -> dict[str, Any]:
             seen_scripts.add(url)
             unique_scripts.append(url)
 
+    # Fetch roots first so translation discovery is complete before chunk ranking.
+    root_sources: list[tuple[str, str]] = []
     root_assets: list[dict[str, Any]] = []
-    candidates: dict[str, dict[str, Any]] = {}
-    all_contexts: list[dict[str, Any]] = []
     for url in unique_scripts[:_MAX_ROOT_ASSETS]:
         result = _fetch(url, _MAX_JS_BYTES)
         text = str(result.get("_text") or "")
         row = _public(result)
         if text:
-            contexts = _anchor_contexts(text, url)
-            row["anchor_contexts"] = contexts
-            all_contexts.extend(contexts)
-            dynamic = _dynamic_candidates(text, url)
-            row["dynamic_candidates"] = dynamic[:20]
-            for candidate in dynamic:
-                current = candidates.get(str(candidate["url"]))
-                if current is None or int(candidate["score"]) > int(current["score"]):
-                    candidates[str(candidate["url"])] = candidate
+            root_sources.append((url, text))
+            row["anchor_hit_counts"] = _anchor_counts(text)
+            merge_anchor_counts(row["anchor_hit_counts"])
+            found_keys = _translation_keys(text, url)
+            row["translation_keys"] = found_keys
+            merge_translation(found_keys)
         root_assets.append(row)
 
-    ranked = sorted(candidates.values(), key=lambda row: (-int(row["score"]), str(row["url"])))
-    dynamic_assets: list[dict[str, Any]] = []
-    for candidate in ranked[:_MAX_DYNAMIC_ASSETS]:
+    key_terms = _key_terms(translation_rows)
+    candidates: dict[str, dict[str, Any]] = {}
+    all_contexts: list[dict[str, Any]] = []
+    request_rows: list[dict[str, Any]] = []
+
+    def merge_candidate(candidate: dict[str, Any]) -> None:
         url = str(candidate["url"])
+        current = candidates.get(url)
+        if current is None or int(candidate["score"]) > int(current["score"]):
+            candidates[url] = candidate
+
+    # Revisit roots with the complete translation key set.
+    for url, text in root_sources:
+        contexts = _target_contexts(text, url, key_terms)
+        all_contexts.extend(contexts)
+        for candidate in _dynamic_candidates(text, url, key_terms):
+            merge_candidate(candidate)
+
+    dynamic_assets: list[dict[str, Any]] = []
+    fetched_dynamic: set[str] = set()
+    while len(dynamic_assets) < _MAX_DYNAMIC_ASSETS:
+        ranked = sorted(
+            (row for row in candidates.values() if str(row["url"]) not in fetched_dynamic),
+            key=lambda row: (-int(row["score"]), str(row["url"])),
+        )
+        if not ranked:
+            break
+        candidate = ranked[0]
+        url = str(candidate["url"])
+        fetched_dynamic.add(url)
         result = _fetch(url, _MAX_JS_BYTES)
         text = str(result.get("_text") or "")
         row = _public(result)
-        row["candidate_anchors"] = candidate["anchors"]
+        row["candidate"] = candidate
         if text:
-            contexts = _anchor_contexts(text, url)
-            row["anchor_contexts"] = contexts
+            row["anchor_hit_counts"] = _anchor_counts(text)
+            merge_anchor_counts(row["anchor_hit_counts"])
+            found_keys = _translation_keys(text, url)
+            row["translation_keys"] = found_keys
+            merge_translation(found_keys)
+            # New exact keys can improve subsequent child-chunk ranking.
+            key_terms = _key_terms(translation_rows)
+            contexts = _target_contexts(text, url, key_terms)
+            row["target_contexts"] = contexts
             all_contexts.extend(contexts)
+            requests = _request_rows(text, url, key_terms)
+            row["mowerbot_requests"] = requests
+            request_rows.extend(requests)
+            for child in _dynamic_candidates(text, url, key_terms):
+                merge_candidate(child)
         dynamic_assets.append(row)
 
-    route_hits: set[str] = set()
-    method_hits: set[str] = set()
+    # Root requests are also useful if the Notification request lives in app-entry.
+    for url, text in root_sources:
+        request_rows.extend(_request_rows(text, url, key_terms))
+
+    # Keep best evidence per source/path pair.
+    unique_requests: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in request_rows:
+        marker = (str(row.get("source") or ""), str(row.get("path") or ""))
+        current = unique_requests.get(marker)
+        if current is None or int(row.get("target_score") or 0) > int(current.get("target_score") or 0):
+            unique_requests[marker] = row
+    ranked_requests = sorted(
+        unique_requests.values(),
+        key=lambda row: (-int(row.get("target_score") or 0), str(row.get("path") or "")),
+    )[:_MAX_REQUEST_ROWS]
+
+    translation_map: dict[str, list[str]] = {}
+    for row in translation_rows:
+        translation_map.setdefault(row["anchor"], [])
+        qualified = row["qualified_key"]
+        if qualified not in translation_map[row["anchor"]]:
+            translation_map[row["anchor"]].append(qualified)
+
     bridge_hits: list[dict[str, str]] = []
-    anchor_hit_counts: dict[str, int] = {}
-    request_contexts: list[dict[str, Any]] = []
-    for row in all_contexts:
-        anchor = str(row.get("anchor") or "")
-        anchor_hit_counts[anchor] = anchor_hit_counts.get(anchor, 0) + 1
-        route_hits.update(row.get("mowerbot_paths") or [])
-        method_hits.update(row.get("http_methods") or [])
-        for bridge in row.get("bridge_calls") or []:
+    for context in all_contexts:
+        for bridge in context.get("bridge_calls") or []:
             if bridge not in bridge_hits:
                 bridge_hits.append(bridge)
-        if row.get("has_request_hint") or row.get("mowerbot_paths") or row.get("bridge_calls"):
-            request_contexts.append(row)
+    for request in ranked_requests:
+        for bridge in request.get("bridge_calls") or []:
+            if bridge not in bridge_hits:
+                bridge_hits.append(bridge)
+
+    ranked_candidates = sorted(
+        candidates.values(),
+        key=lambda row: (-int(row["score"]), str(row["url"])),
+    )
+    useful_contexts = [
+        row
+        for row in all_contexts
+        if row.get("has_request_hint")
+        or row.get("mowerbot_paths")
+        or row.get("bridge_calls")
+        or row.get("skip_encryption")
+    ][:_MAX_REQUEST_CONTEXTS]
 
     return {
         "read_only": True,
@@ -280,28 +593,39 @@ def probe_main_notification_feed(client: Any) -> dict[str, Any]:
         "source": "home_assistant_download",
         "host": host,
         "anchors": list(_ANCHORS),
+        "ranking_policy": {
+            "strong_anchors": list(_STRONG_ANCHORS),
+            "weak_anchors": list(_WEAK_ANCHORS),
+            "generic_zero_score_anchors": list(_GENERIC_ANCHORS),
+            "seed_keys": list(_SEED_KEYS),
+            "note": "All is evidence-only and cannot select a dynamic chunk.",
+        },
         "limits": {
             "timeout_seconds_per_request": _TIMEOUT_SECONDS,
             "max_root_assets": _MAX_ROOT_ASSETS,
             "max_dynamic_assets": _MAX_DYNAMIC_ASSETS,
-            "max_contexts": _MAX_CONTEXTS,
+            "max_contexts_per_term": _MAX_CONTEXTS_PER_TERM,
+            "max_request_contexts": _MAX_REQUEST_CONTEXTS,
             "context_radius_chars": _CONTEXT_RADIUS,
+            "request_radius_chars": _REQUEST_RADIUS,
         },
         "credential_safety": (
             "Public H5 discovery sends no uid, token, mower serial, device id or p:101 payload; source bodies are not stored."
         ),
         "summary": {
             "anchor_hit_counts": anchor_hit_counts,
-            "mowerbot_paths": sorted(route_hits)[:80],
-            "http_methods": sorted(method_hits),
+            "translation_key_map": translation_map,
+            "translation_keys": translation_rows,
+            "search_key_terms": key_terms,
+            "dynamic_candidates": ranked_candidates[:30],
+            "mowerbot_requests": ranked_requests,
             "bridge_calls": bridge_hits[:80],
-            "dynamic_candidates": ranked[:30],
-            "request_contexts": request_contexts[:_MAX_CONTEXTS],
+            "request_contexts": useful_contexts,
         },
         "pages": pages,
         "root_assets": root_assets,
         "dynamic_assets": dynamic_assets,
         "note": (
-            "Beta27 targets the main Notification UI strings and captures only nearby request structure instead of guessing endpoints."
+            "Beta28 maps exact Notification translations to keys, ranks lazy chunks by high-signal phrases/keys, and inventories mowerbot request structure in the owning chunks."
         ),
     }

--- a/tests/test_v041_beta27.py
+++ b/tests/test_v041_beta27.py
@@ -1,4 +1,4 @@
-"""Regression contracts for Navimower 0.4.1-beta27."""
+"""Regression contracts for Navimower 0.4.1-beta27 and later betas."""
 from __future__ import annotations
 
 import ast
@@ -11,7 +11,9 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_beta27_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta27"
+    version = manifest["version"]
+    assert version.startswith("0.4.1-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 27
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta27.md").read_text()
     assert notes.startswith("title: Navimower 0.4.1-beta27")
     for phrase in (

--- a/tests/test_v041_beta28.py
+++ b/tests/test_v041_beta28.py
@@ -1,0 +1,80 @@
+"""Regression contracts for Navimower 0.4.1-beta28."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta28_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    version = manifest["version"]
+    assert version.startswith("0.4.1-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 28
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta28.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta28")
+    for phrase in (
+        "translation keys",
+        "Work status",
+        "No more messages",
+        "Failed to load new messages",
+        "skipEncryption",
+        "/mowerbot/",
+        "Download diagnostics",
+    ):
+        assert phrase in notes
+
+
+def test_beta28_translation_key_ranking_contract() -> None:
+    source = (COMPONENT / "notification_feed_discovery.py").read_text()
+    ast.parse(source)
+    for phrase in (
+        "_STRONG_ANCHORS",
+        "_WEAK_ANCHORS",
+        "_GENERIC_ANCHORS",
+        "_translation_rows",
+        "_ranking_keys",
+        'if row.get("anchor") not in _STRONG_ANCHORS:',
+        "_MAX_CONTEXTS_PER_TERM = 4",
+        "_MAX_DYNAMIC_ASSETS = 6",
+        '"generic_zero_score_anchors"',
+        '"translation_key_map"',
+        '"ranking_translation_keys"',
+    ):
+        assert phrase in source
+    assert "All is deliberately not a request-context term" in source
+    assert "All has no score and cannot select a chunk" in source
+
+
+def test_beta28_extracts_request_structure_from_target_chunks() -> None:
+    source = (COMPONENT / "notification_feed_discovery.py").read_text()
+    for phrase in (
+        'r"[\\\"\'](/mowerbot/',
+        "skipEncryption",
+        "sendEncryptionData",
+        "callNative",
+        "sendMessageToNative",
+        '"mowerbot_requests"',
+        '"http_methods"',
+        '"skip_encryption"',
+        '"object_keys"',
+        '"target_score"',
+    ):
+        assert phrase in source
+    assert "access_token" not in source
+    assert "vehicle_sn" not in source
+    assert "device_id" not in source
+
+
+def test_beta28_download_only_discovery_and_beta26_probe_remain() -> None:
+    diagnostics = (COMPONENT / "diagnostics.py").read_text()
+    action = (COMPONENT / "action_diagnostics.py").read_text()
+    assert "notification_history_probe" in diagnostics
+    assert "notification_feed_discovery" in diagnostics
+    assert "probe_main_notification_feed" in diagnostics
+    assert "coordinator.client.notification_history" in diagnostics
+    assert "probe_main_notification_feed" not in action
+    assert "notification_feed_discovery" not in action


### PR DESCRIPTION
## Summary
- keep beta26 Notification sensor and exact vehicle-history probe unchanged
- refine Download diagnostics H5 discovery with translation-key mapping before lazy-chunk ranking
- prevent generic All/System/Device labels from dominating discovery
- use a per-anchor/per-key context quota
- inventory target `/mowerbot/...` request paths, HTTP method hints, `skipEncryption`, object/payload keys, and native/encryption bridge calls
- keep action export, normal polling, mower controls, and notification read state unchanged

## Safety
Public H5 discovery remains read-only and unauthenticated. It sends no uid, access token, mower serial, device id, account id, or p:101 business payload, and it does not store full HTML/JavaScript source bodies.