### PR TITLE
Navimower 0.4.1-beta29 main Device notification feed

### DIFF
--- a/.github/release-notes/0.4.1-beta29.md
+++ b/.github/release-notes/0.4.1-beta29.md
@@ -1,0 +1,13 @@
+title: Navimower 0.4.1-beta29
+
+Beta29 switches Notification handling from the separate vehicle-history view to the main Navimow app **Notification -> Device** feed recovered by beta28.
+
+- Uses the exact read-only encrypted p:101 endpoint `/mowerbot/user/message/vehicleMessageListField`.
+- First-page payload is `message_id: ""`, `vehicle_sn`, and `filter_state: "all"`, matching the public H5 MessageCenter implementation.
+- Normal polling now reads `vehicle_message_list` and `has_history_message` at most once every 60 seconds and retains the last successful response across transient failures.
+- The **Notification** sensor now uses the main Device feed, keeps at most 5 recent normalized items in attributes, and exposes feed metadata such as `has_history_message`, `next_message_id`, `filter_state`, source, and source age.
+- Field normalization accepts common vendor aliases without inventing values while **Download diagnostics** keeps the full sanitized response/inventory so the real production schema can be confirmed.
+- Removes the large public-H5 scanner from **Download diagnostics** and replaces it with one exact `notification_feed_probe` against `vehicleMessageListField`.
+- The older `get-vehicle-history-message` helper remains inert for compatibility/debugging but is no longer used by normal notification polling or Download diagnostics.
+- This release does not mark messages read and does not call `clearBatchMessageRead` or any other notification read-state mutation endpoint.
+- `navimower.export_diagnostics`, mower controls, normal map/state polling, and the action diagnostics path are otherwise unchanged.

--- a/custom_components/navimower/beta26_runtime.py
+++ b/custom_components/navimower/beta26_runtime.py
@@ -1,19 +1,25 @@
-"""Beta26 live vendor notification history support.
+"""Vendor notification support introduced in beta26 and refined in beta29.
 
-The exact message-history route and payload were recovered from Navimow's public
-H5 bundle in beta25.  This runtime keeps the integration-side implementation
-small and conservative:
+Beta26 initially used Navimow's separate vehicle message-history route. Beta28
+then recovered the actual main app Notification -> Device feed contract from the
+public H5 MessageCenter component. Beta29 switches the live sensor to that
+read-only encrypted feed while keeping the old history method available only as
+an inert compatibility/debug helper.
 
-* use the existing authenticated p:101 private-cloud transport,
-* poll the read-only history endpoint at most once per minute,
-* retain the last successful response across transient failures,
-* expose only the newest message plus a bounded recent list to Home Assistant,
-* never mark messages read and never call the message-detail endpoint.
+Main Device feed contract recovered from H5:
+
+* POST ``/mowerbot/user/message/vehicleMessageListField`` through p:101,
+* payload ``message_id`` + ``vehicle_sn`` + ``filter_state``,
+* first page uses an empty ``message_id`` and ``filter_state=all``,
+* response exposes ``vehicle_message_list`` and ``has_history_message``.
+
+The integration polls at most once per minute, retains the last successful
+response across transient failures, exposes a bounded recent list, and never
+marks messages read or calls any read-state mutation endpoint.
 """
 from __future__ import annotations
 
 from copy import deepcopy
-from dataclasses import replace
 from datetime import UTC, datetime
 import time
 from typing import Any
@@ -21,10 +27,16 @@ from typing import Any
 from . import coordinator as _coordinator
 from .api.client import NavimowCloudClient
 
-_NOTIFICATION_PATH = "/mowerbot/user/message/get-vehicle-history-message"
+# Main Notification -> Device feed used from beta29 onward.
+_NOTIFICATION_PATH = "/mowerbot/user/message/vehicleMessageListField"
+_NOTIFICATION_FILTER = "all"
 _NOTIFICATION_TTL_SECONDS = 60
-_NOTIFICATION_PAGE_SIZE = 20
 _NOTIFICATION_ATTR_HISTORY_LIMIT = 5
+
+# Historical beta26 route kept as a callable compatibility/debug helper only.
+# It is no longer used by normal polling or Download diagnostics from beta29.
+_LEGACY_NOTIFICATION_PATH = "/mowerbot/user/message/get-vehicle-history-message"
+_NOTIFICATION_PAGE_SIZE = 20
 
 
 def _as_int(value: Any) -> int | None:
@@ -43,6 +55,13 @@ def _bounded_text(value: Any, limit: int) -> str | None:
     return text[:limit]
 
 
+def _first_present(item: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in item and item.get(key) is not None:
+            return item.get(key)
+    return None
+
+
 def _created_at(value: Any) -> str | None:
     try:
         stamp = float(value)
@@ -57,32 +76,70 @@ def _created_at(value: Any) -> str | None:
 
 
 def _normalize_item(item: Any) -> dict[str, Any] | None:
+    """Normalize known/likely vendor field aliases without inventing values."""
     if not isinstance(item, dict):
         return None
-    addtime = item.get("addtime")
+
+    addtime = _first_present(
+        item,
+        "addtime",
+        "add_time",
+        "create_time",
+        "createTime",
+        "timestamp",
+        "time",
+    )
     return {
-        "id": item.get("id"),
-        "message_id": item.get("message_id"),
-        "title": _bounded_text(item.get("title"), 255),
-        "content": _bounded_text(item.get("content"), 1200),
+        "id": _first_present(item, "id", "message_record_id"),
+        "message_id": _first_present(item, "message_id", "messageId"),
+        "title": _bounded_text(
+            _first_present(item, "title", "message_title", "messageTitle"),
+            255,
+        ),
+        "content": _bounded_text(
+            _first_present(item, "content", "message_content", "messageContent"),
+            1200,
+        ),
         "addtime": addtime,
         "created_at": _created_at(addtime),
-        "read": _as_int(item.get("read")),
-        "level": _as_int(item.get("level")),
+        "read": _as_int(_first_present(item, "read", "is_read", "isRead")),
+        "level": _as_int(_first_present(item, "level", "message_level")),
+        "type": _first_present(item, "type", "message_type", "messageType"),
+        "event_code": _first_present(
+            item,
+            "event_code",
+            "eventCode",
+            "message_code",
+            "messageCode",
+        ),
     }
 
 
 def _normalize_response(value: Any) -> dict[str, Any]:
     response = value if isinstance(value, dict) else {}
+    raw_messages = response.get("vehicle_message_list")
+    source_key = "vehicle_message_list"
+    if not isinstance(raw_messages, list):
+        # Legacy fallback keeps persisted/cache data from older betas readable.
+        raw_messages = response.get("list")
+        source_key = "list"
+    if not isinstance(raw_messages, list):
+        raw_messages = []
+
     messages: list[dict[str, Any]] = []
-    for item in response.get("list") or []:
+    for item in raw_messages:
         normalized = _normalize_item(item)
         if normalized is not None:
             messages.append(normalized)
+
     return {
         "list": messages,
-        "total": _as_int(response.get("total")),
-        "page": _as_int(response.get("page")),
+        "count": len(messages),
+        "has_history_message": response.get("has_history_message"),
+        "source_key": source_key,
+        "next_message_id": (
+            messages[-1].get("message_id") if messages else None
+        ),
     }
 
 
@@ -107,13 +164,21 @@ def _decorate_snapshot(coordinator: Any, snapshot: dict[str, Any]) -> dict[str, 
             "notification_created_at": latest.get("created_at"),
             "notification_read": latest.get("read"),
             "notification_level": latest.get("level"),
+            "notification_type": latest.get("type"),
+            "notification_event_code": latest.get("event_code"),
             "notification_history": deepcopy(
                 messages[:_NOTIFICATION_ATTR_HISTORY_LIMIT]
             ),
-            "notification_total": normalized.get("total"),
-            "notification_page": normalized.get("page"),
+            "notification_total": normalized.get("count"),
+            "notification_count": normalized.get("count"),
+            "notification_page": None,
+            "notification_has_history_message": normalized.get(
+                "has_history_message"
+            ),
+            "notification_next_message_id": normalized.get("next_message_id"),
+            "notification_filter_state": _NOTIFICATION_FILTER,
             "notification_source": (
-                "private_cloud_message_history" if cache is not None else None
+                "private_cloud_vehicle_message_feed" if cache is not None else None
             ),
             "notification_source_age": source_age,
             "notification_error": getattr(
@@ -137,10 +202,10 @@ def _refresh_notification_cache(coordinator: Any) -> None:
 
     coordinator._beta26_notification_last_attempt_mono = now  # noqa: SLF001
     try:
-        response = coordinator.client.notification_history(  # type: ignore[attr-defined]
+        response = coordinator.client.notification_feed(  # type: ignore[attr-defined]
             coordinator.sn,
-            page=1,
-            size=_NOTIFICATION_PAGE_SIZE,
+            message_id="",
+            filter_state=_NOTIFICATION_FILTER,
         )
     except Exception as err:  # noqa: BLE001 - optional feed must not break core poll.
         coordinator._beta26_notification_error = (  # noqa: SLF001
@@ -163,7 +228,7 @@ def _install_notification_sensor() -> None:
         title = data.get("notification_title")
         if title:
             return str(title)[:255]
-        if data.get("notification_total") == 0:
+        if data.get("notification_count") == 0:
             return "No notifications"
         return None
 
@@ -175,8 +240,12 @@ def _install_notification_sensor() -> None:
             "addtime": data.get("notification_addtime"),
             "read": data.get("notification_read"),
             "level": data.get("notification_level"),
-            "total": data.get("notification_total"),
-            "page": data.get("notification_page"),
+            "type": data.get("notification_type"),
+            "event_code": data.get("notification_event_code"),
+            "count": data.get("notification_count"),
+            "has_history_message": data.get("notification_has_history_message"),
+            "next_message_id": data.get("notification_next_message_id"),
+            "filter_state": data.get("notification_filter_state"),
             "source": data.get("notification_source"),
             "source_age": data.get("notification_source_age"),
             "last_error": data.get("notification_error"),
@@ -200,12 +269,13 @@ def _install_notification_sensor() -> None:
 
 
 def install_beta26_runtime() -> None:
-    """Install notification-history transport, polling and sensor once."""
+    """Install notification transport, polling and sensor once."""
     cls = _coordinator.NavimowCoordinator
     if getattr(cls, "_beta26_runtime_installed", False):
         _install_notification_sensor()
         return
 
+    # Historical beta26 endpoint remains callable for explicit debugging only.
     if not hasattr(NavimowCloudClient, "notification_history"):
         def notification_history(
             self: NavimowCloudClient,
@@ -214,7 +284,7 @@ def install_beta26_runtime() -> None:
             size: int = _NOTIFICATION_PAGE_SIZE,
         ) -> dict[str, Any]:
             data = self.call(
-                _NOTIFICATION_PATH,
+                _LEGACY_NOTIFICATION_PATH,
                 {
                     "vehicle_sn": str(sn),
                     "page": int(page),
@@ -224,6 +294,25 @@ def install_beta26_runtime() -> None:
             return data if isinstance(data, dict) else {}
 
         NavimowCloudClient.notification_history = notification_history  # type: ignore[attr-defined]
+
+    if not hasattr(NavimowCloudClient, "notification_feed"):
+        def notification_feed(
+            self: NavimowCloudClient,
+            sn: str,
+            message_id: str = "",
+            filter_state: str = _NOTIFICATION_FILTER,
+        ) -> dict[str, Any]:
+            data = self.call(
+                _NOTIFICATION_PATH,
+                {
+                    "message_id": str(message_id or ""),
+                    "vehicle_sn": str(sn),
+                    "filter_state": str(filter_state or _NOTIFICATION_FILTER),
+                },
+            )
+            return data if isinstance(data, dict) else {}
+
+        NavimowCloudClient.notification_feed = notification_feed  # type: ignore[attr-defined]
 
     original_fetch = cls._fetch_blocking
     original_bootstrap = cls._bootstrap_snapshot

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -8,9 +8,8 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .diagnostics_export import async_build_diagnostics, inventory, sanitize
-from .notification_feed_discovery import probe_main_notification_feed
 
-_NOTIFICATION_PATH = "/mowerbot/user/message/get-vehicle-history-message"
+_NOTIFICATION_PATH = "/mowerbot/user/message/vehicleMessageListField"
 
 
 async def async_get_config_entry_diagnostics(
@@ -40,63 +39,44 @@ async def async_get_config_entry_diagnostics(
             coordinator.state_transition_diagnostics()
         )
 
-    # Keep the exact beta26 vehicle-history contract visible while beta28
-    # investigates whether the main Notification -> Device feed is a different
-    # request path. The vendor call is read-only and uses the existing p:101
-    # client; no message is marked read.
+    # Beta29 stops public H5 bundle discovery and directly probes the exact
+    # read-only Notification -> Device feed recovered by beta28. The existing
+    # private-cloud client supplies the authenticated/encrypted p:101 transport.
+    # No read-state endpoint is called and no notification is marked read.
     try:
         response = await hass.async_add_executor_job(
-            coordinator.client.notification_history,
+            coordinator.client.notification_feed,
             coordinator.sn,
-            1,
-            20,
+            "",
+            "all",
         )
     except Exception as err:  # noqa: BLE001 - diagnostics records probe failure.
-        document["notification_history_probe"] = {
+        document["notification_feed_probe"] = {
             "ok": False,
             "read_only": True,
             "endpoint": _NOTIFICATION_PATH,
             "request": {
+                "message_id": "",
                 "vehicle_sn": "<redacted>",
-                "page": 1,
-                "size": 20,
+                "filter_state": "all",
             },
-            "error_type": type(err).__name__,
-            "error": str(err),
-        }
-    else:
-        clean = sanitize(response)
-        document["notification_history_probe"] = {
-            "ok": True,
-            "read_only": True,
-            "endpoint": _NOTIFICATION_PATH,
-            "request": {
-                "vehicle_sn": "<redacted>",
-                "page": 1,
-                "size": 20,
-            },
-            "response": clean,
-            "inventory": inventory(clean),
-        }
-
-    # Beta28 maps exact Notification UI translations to translation keys first,
-    # then uses only high-signal phrases/keys to select lazy H5 chunks. The
-    # scanner never receives credentials or mower identity and persists only
-    # bounded request structure and source context.
-    try:
-        discovery = await hass.async_add_executor_job(
-            probe_main_notification_feed,
-            coordinator.client,
-        )
-    except Exception as err:  # noqa: BLE001 - optional diagnostics discovery.
-        document["notification_feed_discovery"] = {
-            "ok": False,
-            "read_only": True,
             "error_type": type(err).__name__,
             "error": sanitize(str(err)),
         }
     else:
-        document["notification_feed_discovery"] = sanitize(discovery)
+        clean = sanitize(response)
+        document["notification_feed_probe"] = {
+            "ok": True,
+            "read_only": True,
+            "endpoint": _NOTIFICATION_PATH,
+            "request": {
+                "message_id": "",
+                "vehicle_sn": "<redacted>",
+                "filter_state": "all",
+            },
+            "response": clean,
+            "inventory": inventory(clean),
+        }
 
     document["diagnostics_source"] = "home_assistant_download"
     return document

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta28"
+  "version": "0.4.1-beta29"
 }

--- a/tests/test_v041_beta26.py
+++ b/tests/test_v041_beta26.py
@@ -9,6 +9,11 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
+def _beta_number() -> int:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    return int(manifest["version"].split("beta", 1)[1])
+
+
 def test_beta26_release_contract_remains_present() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
     assert manifest["version"].startswith("0.4.1-beta")
@@ -51,22 +56,32 @@ def test_beta26_notification_sensor_is_bounded_and_last_good() -> None:
         'icon="mdi:bell-outline"',
         '"notification_history"',
         '"notification_error"',
-        '"private_cloud_message_history"',
         "_beta26_notification_cache",
     ):
         assert phrase in source
+    if _beta_number() >= 29:
+        assert '"private_cloud_vehicle_message_feed"' in source
+    else:
+        assert '"private_cloud_message_history"' in source
     failure = source[source.index("except Exception as err"):source.index("def _install_notification_sensor")]
     assert "_beta26_notification_error" in failure
     assert "_beta26_notification_cache = None" not in failure
 
 
-def test_beta26_download_diagnostics_keeps_exact_history_probe() -> None:
+def test_beta26_download_diagnostics_contract_is_superseded_safely() -> None:
     diagnostics = (COMPONENT / "diagnostics.py").read_text()
     action = (COMPONENT / "action_diagnostics.py").read_text()
-    assert "notification_history_probe" in diagnostics
-    assert "coordinator.client.notification_history" in diagnostics
+    if _beta_number() >= 29:
+        assert "notification_feed_probe" in diagnostics
+        assert "coordinator.client.notification_feed" in diagnostics
+        assert "notification_history_probe" not in diagnostics
+        assert "probe_main_notification_feed" not in diagnostics
+    else:
+        assert "notification_history_probe" in diagnostics
+        assert "coordinator.client.notification_history" in diagnostics
     assert '"vehicle_sn": "<redacted>"' in diagnostics
     assert "inventory(clean)" in diagnostics
+    assert "notification_feed_probe" not in action
     assert "notification_history_probe" not in action
 
 

--- a/tests/test_v041_beta27.py
+++ b/tests/test_v041_beta27.py
@@ -9,6 +9,11 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
+def _beta_number() -> int:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    return int(manifest["version"].rsplit("beta", 1)[1])
+
+
 def test_beta27_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
     version = manifest["version"]
@@ -54,12 +59,18 @@ def test_beta27_targeted_notification_feed_scanner_contract() -> None:
     assert "device_id" not in source
 
 
-def test_beta27_download_diagnostics_runs_both_history_and_targeted_discovery() -> None:
+def test_beta27_download_discovery_is_historical_after_exact_feed_recovery() -> None:
     diagnostics = (COMPONENT / "diagnostics.py").read_text()
-    assert "notification_history_probe" in diagnostics
-    assert "notification_feed_discovery" in diagnostics
-    assert "probe_main_notification_feed" in diagnostics
-    assert "coordinator.client.notification_history" in diagnostics
+    if _beta_number() >= 29:
+        assert "notification_feed_probe" in diagnostics
+        assert "probe_main_notification_feed" not in diagnostics
+        assert "notification_feed_discovery" not in diagnostics
+        assert "coordinator.client.notification_feed" in diagnostics
+    else:
+        assert "notification_history_probe" in diagnostics
+        assert "notification_feed_discovery" in diagnostics
+        assert "probe_main_notification_feed" in diagnostics
+        assert "coordinator.client.notification_history" in diagnostics
 
 
 def test_beta27_action_export_remains_without_h5_discovery() -> None:

--- a/tests/test_v041_beta28.py
+++ b/tests/test_v041_beta28.py
@@ -9,6 +9,11 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
+def _beta_number() -> int:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    return int(manifest["version"].rsplit("beta", 1)[1])
+
+
 def test_beta28_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
     version = manifest["version"]
@@ -69,12 +74,19 @@ def test_beta28_extracts_request_structure_from_target_chunks() -> None:
     assert "device_id" not in source
 
 
-def test_beta28_download_only_discovery_and_beta26_probe_remain() -> None:
+def test_beta28_download_discovery_retires_after_exact_feed_recovery() -> None:
     diagnostics = (COMPONENT / "diagnostics.py").read_text()
     action = (COMPONENT / "action_diagnostics.py").read_text()
-    assert "notification_history_probe" in diagnostics
-    assert "notification_feed_discovery" in diagnostics
-    assert "probe_main_notification_feed" in diagnostics
-    assert "coordinator.client.notification_history" in diagnostics
+    if _beta_number() >= 29:
+        assert "notification_feed_probe" in diagnostics
+        assert "notification_history_probe" not in diagnostics
+        assert "notification_feed_discovery" not in diagnostics
+        assert "probe_main_notification_feed" not in diagnostics
+        assert "coordinator.client.notification_feed" in diagnostics
+    else:
+        assert "notification_history_probe" in diagnostics
+        assert "notification_feed_discovery" in diagnostics
+        assert "probe_main_notification_feed" in diagnostics
+        assert "coordinator.client.notification_history" in diagnostics
     assert "probe_main_notification_feed" not in action
     assert "notification_feed_discovery" not in action

--- a/tests/test_v041_beta29.py
+++ b/tests/test_v041_beta29.py
@@ -1,0 +1,87 @@
+"""Regression contracts for Navimower 0.4.1-beta29."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta29_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta29"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta29.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta29")
+    for phrase in (
+        "vehicleMessageListField",
+        "vehicle_message_list",
+        "has_history_message",
+        "filter_state",
+        "Download diagnostics",
+        "does not mark",
+    ):
+        assert phrase in notes
+
+
+def test_beta29_runtime_uses_exact_main_device_feed_contract() -> None:
+    source = (COMPONENT / "beta26_runtime.py").read_text()
+    ast.parse(source)
+    for phrase in (
+        '"/mowerbot/user/message/vehicleMessageListField"',
+        '"message_id": str(message_id or "")',
+        '"vehicle_sn": str(sn)',
+        '"filter_state": str(filter_state or _NOTIFICATION_FILTER)',
+        'response.get("vehicle_message_list")',
+        'response.get("has_history_message")',
+        '"private_cloud_vehicle_message_feed"',
+        '_NOTIFICATION_FILTER = "all"',
+        "_NOTIFICATION_TTL_SECONDS = 60",
+    ):
+        assert phrase in source
+    refresh = source[source.index("def _refresh_notification_cache"):source.index("def _install_notification_sensor")]
+    assert "coordinator.client.notification_feed" in refresh
+    assert "coordinator.client.notification_history" not in refresh
+
+
+def test_beta29_sensor_stays_bounded_and_exposes_feed_metadata() -> None:
+    source = (COMPONENT / "beta26_runtime.py").read_text()
+    assert "_NOTIFICATION_ATTR_HISTORY_LIMIT = 5" in source
+    for phrase in (
+        'key="notification"',
+        '"has_history_message"',
+        '"next_message_id"',
+        '"filter_state"',
+        '"event_code"',
+        '"recent"',
+    ):
+        assert phrase in source
+    assert "clearBatchMessageRead" not in source
+    assert "mark-read" not in source.lower()
+
+
+def test_beta29_download_diagnostics_probes_only_exact_feed() -> None:
+    diagnostics = (COMPONENT / "diagnostics.py").read_text()
+    ast.parse(diagnostics)
+    for phrase in (
+        '"/mowerbot/user/message/vehicleMessageListField"',
+        'document["notification_feed_probe"]',
+        "coordinator.client.notification_feed",
+        '"message_id": ""',
+        '"vehicle_sn": "<redacted>"',
+        '"filter_state": "all"',
+        "inventory(clean)",
+    ):
+        assert phrase in diagnostics
+    assert "probe_main_notification_feed" not in diagnostics
+    assert "notification_feed_discovery" not in diagnostics
+    assert "notification_history_probe" not in diagnostics
+    assert "clearBatchMessageRead" not in diagnostics
+
+
+def test_beta29_action_export_remains_fast_and_without_notification_probe() -> None:
+    action = (COMPONENT / "action_diagnostics.py").read_text()
+    assert "notification_feed_probe" not in action
+    assert "notification_feed_discovery" not in action
+    assert "vehicleMessageListField" not in action


### PR DESCRIPTION
## Summary
- switch live Notification sensor polling to the exact main Navimow Notification -> Device endpoint recovered in beta28
- use encrypted p:101 `POST /mowerbot/user/message/vehicleMessageListField` with `message_id`, `vehicle_sn`, and `filter_state=all`
- parse `vehicle_message_list` / `has_history_message` conservatively and retain last-known-good data
- replace the large H5 scanner in Download diagnostics with one exact read-only `notification_feed_probe`
- keep the older vehicle-history helper inert for compatibility/debugging only
- keep action export and all notification read-state mutations untouched

## Safety
This PR only reads the Device notification feed. It does not call `clearBatchMessageRead`, mark any message read, or change mower state.