### PR TITLE
Navimower 0.4.1-beta30 notification cleanup

### DIFF
--- a/.github/release-notes/0.4.1-beta30.md
+++ b/.github/release-notes/0.4.1-beta30.md
@@ -1,0 +1,14 @@
+title: Navimower 0.4.1-beta30
+
+Beta30 turns the notification work from discovery into normal production logic after the main Device feed was confirmed on both H215 and X390.
+
+- Keeps the confirmed encrypted read-only `/mowerbot/user/message/vehicleMessageListField` polling introduced in beta29.
+- Aligns normalization with the real vendor response schema: `error_code`, `message_id`, `title`, `content`, `addtime`, `read`, `level`, `type`, `style`, `url`, and `variable`.
+- Preserves vendor notification codes as strings so alphanumeric values such as `150A` are not lost or coerced.
+- Exposes the canonical code as `notification_code` and `vendor_code`, while also exposing the raw-compatible `error_code` name.
+- Retains the beta29 `event_code` attribute as a backward-compatible alias for existing Home Assistant automations.
+- Preserves `read` as a boolean instead of converting it to `0`/`1`.
+- Keeps the Notification sensor history bounded to the five most recent normalized items and retains the one-minute polling TTL plus last-known-good behavior.
+- Removes the now-confirmed `notification_feed_probe` from **Download diagnostics**. Download diagnostics no longer issues an extra notification API request and remains focused on general mower/error diagnostics.
+- `navimower.export_diagnostics` remains unchanged and does not probe notification endpoints.
+- Does not call `clearBatchMessageRead`, does not mark notifications read, and performs no notification write operation.

--- a/custom_components/navimower/beta26_runtime.py
+++ b/custom_components/navimower/beta26_runtime.py
@@ -1,12 +1,12 @@
-"""Vendor notification support introduced in beta26 and refined in beta29.
+"""Vendor notification support introduced in beta26 and refined through beta30.
 
 Beta26 initially used Navimow's separate vehicle message-history route. Beta28
 then recovered the actual main app Notification -> Device feed contract from the
-public H5 MessageCenter component. Beta29 switches the live sensor to that
-read-only encrypted feed while keeping the old history method available only as
-an inert compatibility/debug helper.
+public H5 MessageCenter component. Beta29 switched the live sensor to that
+read-only encrypted feed. Beta30 aligns the normalized sensor schema with real
+H215 and X390 responses and removes the last discovery-era assumptions.
 
-Main Device feed contract recovered from H5:
+Main Device feed contract:
 
 * POST ``/mowerbot/user/message/vehicleMessageListField`` through p:101,
 * payload ``message_id`` + ``vehicle_sn`` + ``filter_state``,
@@ -27,14 +27,12 @@ from typing import Any
 from . import coordinator as _coordinator
 from .api.client import NavimowCloudClient
 
-# Main Notification -> Device feed used from beta29 onward.
 _NOTIFICATION_PATH = "/mowerbot/user/message/vehicleMessageListField"
 _NOTIFICATION_FILTER = "all"
 _NOTIFICATION_TTL_SECONDS = 60
 _NOTIFICATION_ATTR_HISTORY_LIMIT = 5
 
 # Historical beta26 route kept as a callable compatibility/debug helper only.
-# It is no longer used by normal polling or Download diagnostics from beta29.
 _LEGACY_NOTIFICATION_PATH = "/mowerbot/user/message/get-vehicle-history-message"
 _NOTIFICATION_PAGE_SIZE = 20
 
@@ -46,6 +44,26 @@ def _as_int(value: Any) -> int | None:
         return None
 
 
+def _as_bool(value: Any) -> bool | None:
+    """Preserve vendor read state as a boolean when it is representable."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        if value == 0:
+            return False
+        if value == 1:
+            return True
+        return None
+    text = str(value).strip().lower()
+    if text in {"0", "false", "no", "off"}:
+        return False
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    return None
+
+
 def _bounded_text(value: Any, limit: int) -> str | None:
     if value is None:
         return None
@@ -53,6 +71,11 @@ def _bounded_text(value: Any, limit: int) -> str | None:
     if not text:
         return None
     return text[:limit]
+
+
+def _code_text(value: Any) -> str | None:
+    """Keep vendor notification codes verbatim, including alphanumeric codes."""
+    return _bounded_text(value, 64)
 
 
 def _first_present(item: dict[str, Any], *keys: str) -> Any:
@@ -76,7 +99,7 @@ def _created_at(value: Any) -> str | None:
 
 
 def _normalize_item(item: Any) -> dict[str, Any] | None:
-    """Normalize known/likely vendor field aliases without inventing values."""
+    """Normalize confirmed vendor notification fields without inventing values."""
     if not isinstance(item, dict):
         return None
 
@@ -88,6 +111,17 @@ def _normalize_item(item: Any) -> dict[str, Any] | None:
         "createTime",
         "timestamp",
         "time",
+    )
+    vendor_code = _code_text(
+        _first_present(
+            item,
+            "error_code",
+            "errorCode",
+            "event_code",
+            "eventCode",
+            "message_code",
+            "messageCode",
+        )
     )
     return {
         "id": _first_present(item, "id", "message_record_id"),
@@ -102,16 +136,19 @@ def _normalize_item(item: Any) -> dict[str, Any] | None:
         ),
         "addtime": addtime,
         "created_at": _created_at(addtime),
-        "read": _as_int(_first_present(item, "read", "is_read", "isRead")),
+        "read": _as_bool(_first_present(item, "read", "is_read", "isRead")),
         "level": _as_int(_first_present(item, "level", "message_level")),
         "type": _first_present(item, "type", "message_type", "messageType"),
-        "event_code": _first_present(
-            item,
-            "event_code",
-            "eventCode",
-            "message_code",
-            "messageCode",
-        ),
+        "style": _first_present(item, "style", "message_style", "messageStyle"),
+        "url": _bounded_text(_first_present(item, "url", "jump_url", "jumpUrl"), 1200),
+        "variable": deepcopy(item.get("variable")),
+        # Canonical beta30 naming. These are notification/event codes, not
+        # necessarily faults: real feeds include values such as 150A.
+        "notification_code": vendor_code,
+        "vendor_code": vendor_code,
+        "error_code": vendor_code,
+        # Backward-compatible alias retained for automations built on beta29.
+        "event_code": vendor_code,
     }
 
 
@@ -137,9 +174,7 @@ def _normalize_response(value: Any) -> dict[str, Any]:
         "count": len(messages),
         "has_history_message": response.get("has_history_message"),
         "source_key": source_key,
-        "next_message_id": (
-            messages[-1].get("message_id") if messages else None
-        ),
+        "next_message_id": messages[-1].get("message_id") if messages else None,
     }
 
 
@@ -165,6 +200,13 @@ def _decorate_snapshot(coordinator: Any, snapshot: dict[str, Any]) -> dict[str, 
             "notification_read": latest.get("read"),
             "notification_level": latest.get("level"),
             "notification_type": latest.get("type"),
+            "notification_style": latest.get("style"),
+            "notification_url": latest.get("url"),
+            "notification_variable": deepcopy(latest.get("variable")),
+            "notification_code": latest.get("notification_code"),
+            "notification_vendor_code": latest.get("vendor_code"),
+            "notification_error_code": latest.get("error_code"),
+            # Backward-compatible snapshot key from beta29.
             "notification_event_code": latest.get("event_code"),
             "notification_history": deepcopy(
                 messages[:_NOTIFICATION_ATTR_HISTORY_LIMIT]
@@ -241,6 +283,13 @@ def _install_notification_sensor() -> None:
             "read": data.get("notification_read"),
             "level": data.get("notification_level"),
             "type": data.get("notification_type"),
+            "style": data.get("notification_style"),
+            "url": data.get("notification_url"),
+            "variable": deepcopy(data.get("notification_variable")),
+            "notification_code": data.get("notification_code"),
+            "vendor_code": data.get("notification_vendor_code"),
+            "error_code": data.get("notification_error_code"),
+            # Backward-compatible alias from beta29.
             "event_code": data.get("notification_event_code"),
             "count": data.get("notification_count"),
             "has_history_message": data.get("notification_has_history_message"),

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -7,9 +7,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
-from .diagnostics_export import async_build_diagnostics, inventory, sanitize
-
-_NOTIFICATION_PATH = "/mowerbot/user/message/vehicleMessageListField"
+from .diagnostics_export import async_build_diagnostics, sanitize
 
 
 async def async_get_config_entry_diagnostics(
@@ -39,44 +37,9 @@ async def async_get_config_entry_diagnostics(
             coordinator.state_transition_diagnostics()
         )
 
-    # Beta29 stops public H5 bundle discovery and directly probes the exact
-    # read-only Notification -> Device feed recovered by beta28. The existing
-    # private-cloud client supplies the authenticated/encrypted p:101 transport.
-    # No read-state endpoint is called and no notification is marked read.
-    try:
-        response = await hass.async_add_executor_job(
-            coordinator.client.notification_feed,
-            coordinator.sn,
-            "",
-            "all",
-        )
-    except Exception as err:  # noqa: BLE001 - diagnostics records probe failure.
-        document["notification_feed_probe"] = {
-            "ok": False,
-            "read_only": True,
-            "endpoint": _NOTIFICATION_PATH,
-            "request": {
-                "message_id": "",
-                "vehicle_sn": "<redacted>",
-                "filter_state": "all",
-            },
-            "error_type": type(err).__name__,
-            "error": sanitize(str(err)),
-        }
-    else:
-        clean = sanitize(response)
-        document["notification_feed_probe"] = {
-            "ok": True,
-            "read_only": True,
-            "endpoint": _NOTIFICATION_PATH,
-            "request": {
-                "message_id": "",
-                "vehicle_sn": "<redacted>",
-                "filter_state": "all",
-            },
-            "response": clean,
-            "inventory": inventory(clean),
-        }
-
+    # Beta30 removes the discovery-era notification feed probe. The Device feed
+    # contract is now confirmed on both H215 and X390 and is already polled by
+    # normal integration runtime, so Download diagnostics must stay fast and
+    # must not issue an extra vendor notification request.
     document["diagnostics_source"] = "home_assistant_download"
     return document

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta29"
+  "version": "0.4.1-beta30"
 }

--- a/tests/test_v041_beta26.py
+++ b/tests/test_v041_beta26.py
@@ -71,16 +71,24 @@ def test_beta26_notification_sensor_is_bounded_and_last_good() -> None:
 def test_beta26_download_diagnostics_contract_is_superseded_safely() -> None:
     diagnostics = (COMPONENT / "diagnostics.py").read_text()
     action = (COMPONENT / "action_diagnostics.py").read_text()
-    if _beta_number() >= 29:
+    if _beta_number() >= 30:
+        assert "notification_feed_probe" not in diagnostics
+        assert "coordinator.client.notification_feed" not in diagnostics
+        assert "notification_history_probe" not in diagnostics
+        assert "probe_main_notification_feed" not in diagnostics
+        assert "inventory(clean)" not in diagnostics
+    elif _beta_number() >= 29:
         assert "notification_feed_probe" in diagnostics
         assert "coordinator.client.notification_feed" in diagnostics
         assert "notification_history_probe" not in diagnostics
         assert "probe_main_notification_feed" not in diagnostics
+        assert '"vehicle_sn": "<redacted>"' in diagnostics
+        assert "inventory(clean)" in diagnostics
     else:
         assert "notification_history_probe" in diagnostics
         assert "coordinator.client.notification_history" in diagnostics
-    assert '"vehicle_sn": "<redacted>"' in diagnostics
-    assert "inventory(clean)" in diagnostics
+        assert '"vehicle_sn": "<redacted>"' in diagnostics
+        assert "inventory(clean)" in diagnostics
     assert "notification_feed_probe" not in action
     assert "notification_history_probe" not in action
 

--- a/tests/test_v041_beta27.py
+++ b/tests/test_v041_beta27.py
@@ -61,7 +61,12 @@ def test_beta27_targeted_notification_feed_scanner_contract() -> None:
 
 def test_beta27_download_discovery_is_historical_after_exact_feed_recovery() -> None:
     diagnostics = (COMPONENT / "diagnostics.py").read_text()
-    if _beta_number() >= 29:
+    if _beta_number() >= 30:
+        assert "notification_feed_probe" not in diagnostics
+        assert "probe_main_notification_feed" not in diagnostics
+        assert "notification_feed_discovery" not in diagnostics
+        assert "coordinator.client.notification_feed" not in diagnostics
+    elif _beta_number() >= 29:
         assert "notification_feed_probe" in diagnostics
         assert "probe_main_notification_feed" not in diagnostics
         assert "notification_feed_discovery" not in diagnostics

--- a/tests/test_v041_beta28.py
+++ b/tests/test_v041_beta28.py
@@ -77,7 +77,13 @@ def test_beta28_extracts_request_structure_from_target_chunks() -> None:
 def test_beta28_download_discovery_retires_after_exact_feed_recovery() -> None:
     diagnostics = (COMPONENT / "diagnostics.py").read_text()
     action = (COMPONENT / "action_diagnostics.py").read_text()
-    if _beta_number() >= 29:
+    if _beta_number() >= 30:
+        assert "notification_feed_probe" not in diagnostics
+        assert "notification_history_probe" not in diagnostics
+        assert "notification_feed_discovery" not in diagnostics
+        assert "probe_main_notification_feed" not in diagnostics
+        assert "coordinator.client.notification_feed" not in diagnostics
+    elif _beta_number() >= 29:
         assert "notification_feed_probe" in diagnostics
         assert "notification_history_probe" not in diagnostics
         assert "notification_feed_discovery" not in diagnostics

--- a/tests/test_v041_beta29.py
+++ b/tests/test_v041_beta29.py
@@ -1,4 +1,4 @@
-"""Regression contracts for Navimower 0.4.1-beta29."""
+"""Regression contracts introduced with Navimower 0.4.1-beta29."""
 from __future__ import annotations
 
 import ast
@@ -9,9 +9,10 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta29_manifest_and_release_notes() -> None:
+def test_beta29_release_contract_remains_documented() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta29"
+    assert manifest["version"].startswith("0.4.1-beta")
+    assert int(manifest["version"].rsplit("beta", 1)[1]) >= 29
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta29.md").read_text()
     assert notes.startswith("title: Navimower 0.4.1-beta29")
     for phrase in (
@@ -40,12 +41,15 @@ def test_beta29_runtime_uses_exact_main_device_feed_contract() -> None:
         "_NOTIFICATION_TTL_SECONDS = 60",
     ):
         assert phrase in source
-    refresh = source[source.index("def _refresh_notification_cache"):source.index("def _install_notification_sensor")]
+    refresh = source[
+        source.index("def _refresh_notification_cache"):
+        source.index("def _install_notification_sensor")
+    ]
     assert "coordinator.client.notification_feed" in refresh
     assert "coordinator.client.notification_history" not in refresh
 
 
-def test_beta29_sensor_stays_bounded_and_exposes_feed_metadata() -> None:
+def test_beta29_sensor_stays_bounded_and_keeps_compatibility_alias() -> None:
     source = (COMPONENT / "beta26_runtime.py").read_text()
     assert "_NOTIFICATION_ATTR_HISTORY_LIMIT = 5" in source
     for phrase in (
@@ -61,19 +65,9 @@ def test_beta29_sensor_stays_bounded_and_exposes_feed_metadata() -> None:
     assert "mark-read" not in source.lower()
 
 
-def test_beta29_download_diagnostics_probes_only_exact_feed() -> None:
+def test_beta29_and_later_download_diagnostics_has_no_old_h5_discovery() -> None:
     diagnostics = (COMPONENT / "diagnostics.py").read_text()
     ast.parse(diagnostics)
-    for phrase in (
-        '"/mowerbot/user/message/vehicleMessageListField"',
-        'document["notification_feed_probe"]',
-        "coordinator.client.notification_feed",
-        '"message_id": ""',
-        '"vehicle_sn": "<redacted>"',
-        '"filter_state": "all"',
-        "inventory(clean)",
-    ):
-        assert phrase in diagnostics
     assert "probe_main_notification_feed" not in diagnostics
     assert "notification_feed_discovery" not in diagnostics
     assert "notification_history_probe" not in diagnostics

--- a/tests/test_v041_beta30.py
+++ b/tests/test_v041_beta30.py
@@ -1,0 +1,97 @@
+"""Regression contracts for Navimower 0.4.1-beta30."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta30_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta30"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta30.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta30")
+    for phrase in (
+        "150A",
+        "notification_code",
+        "vendor_code",
+        "boolean",
+        "style",
+        "url",
+        "Download diagnostics",
+    ):
+        assert phrase in notes
+
+
+def test_beta30_notification_codes_are_preserved_as_strings() -> None:
+    source = (COMPONENT / "beta26_runtime.py").read_text()
+    ast.parse(source)
+    normalize = source[
+        source.index("def _normalize_item"):
+        source.index("def _normalize_response")
+    ]
+    assert '"error_code"' in normalize
+    assert '"errorCode"' in normalize
+    assert '"notification_code": vendor_code' in normalize
+    assert '"vendor_code": vendor_code' in normalize
+    assert '"error_code": vendor_code' in normalize
+    assert '"event_code": vendor_code' in normalize
+    assert "_code_text(" in normalize
+    assert "_as_int(" not in normalize.split('"level"', 1)[0]
+
+
+def test_beta30_preserves_real_feed_metadata() -> None:
+    source = (COMPONENT / "beta26_runtime.py").read_text()
+    for phrase in (
+        '"read": _as_bool(',
+        '"style": _first_present(',
+        '"url": _bounded_text(',
+        '"variable": deepcopy(',
+        '"notification_style"',
+        '"notification_url"',
+        '"notification_variable"',
+        '"notification_code"',
+        '"notification_vendor_code"',
+        '"notification_error_code"',
+    ):
+        assert phrase in source
+
+
+def test_beta30_sensor_exposes_new_schema_and_compat_alias() -> None:
+    source = (COMPONENT / "beta26_runtime.py").read_text()
+    sensor = source[source.index("def _install_notification_sensor"):]
+    for phrase in (
+        '"notification_code"',
+        '"vendor_code"',
+        '"error_code"',
+        '"event_code"',
+        '"read"',
+        '"style"',
+        '"url"',
+        '"variable"',
+        '"recent"',
+    ):
+        assert phrase in sensor
+    assert "_NOTIFICATION_ATTR_HISTORY_LIMIT = 5" in source
+    assert "clearBatchMessageRead" not in source
+
+
+def test_beta30_download_diagnostics_no_longer_probes_notifications() -> None:
+    diagnostics = (COMPONENT / "diagnostics.py").read_text()
+    ast.parse(diagnostics)
+    assert "notification_feed_probe" not in diagnostics
+    assert "vehicleMessageListField" not in diagnostics
+    assert "notification_feed_discovery" not in diagnostics
+    assert "notification_history_probe" not in diagnostics
+    assert "coordinator.client.notification_feed" not in diagnostics
+    assert "inventory(" not in diagnostics
+    assert 'document["diagnostics_source"] = "home_assistant_download"' in diagnostics
+
+
+def test_beta30_action_export_stays_without_notification_probe() -> None:
+    action = (COMPONENT / "action_diagnostics.py").read_text()
+    assert "notification_feed_probe" not in action
+    assert "vehicleMessageListField" not in action


### PR DESCRIPTION
## Summary
- align Notification sensor normalization with confirmed H215/X390 Device-feed schema
- preserve alphanumeric vendor notification codes such as `150A` as strings
- expose `notification_code`, `vendor_code`, `error_code`, `style`, `url`, `variable`, and boolean `read`
- keep `event_code` as a backward-compatible alias
- remove the confirmed notification feed probe from Download diagnostics
- keep action diagnostics, mower controls, one-minute polling TTL, LKG behavior, and read-only semantics unchanged

## Safety
- no notification read-state writes
- no `clearBatchMessageRead`
- no mower control changes

## Release
- bumps manifest to `0.4.1-beta30`
- adds beta30 release notes and regression tests