### PR TITLE
Navimower 0.4.1-beta31 legacy setting dual writes

### DIFF
--- a/.github/release-notes/0.4.1-beta31.md
+++ b/.github/release-notes/0.4.1-beta31.md
@@ -1,0 +1,14 @@
+title: Navimower 0.4.1-beta31
+
+Beta31 is a focused field-validation release for three legacy boolean controls whose cloud-only writes can be overwritten later by the mower's onboard setting.
+
+- **Night mowing**, **Rain detection**, and **Rain sensor** now use a robot-first/cloud-second transaction.
+- The mower receives an immediate `s:mower` setting value (`0`/`1`) through the existing device-setting command path.
+- The private cloud still receives the already confirmed legacy plain `save-set-data` value using `"00"/"01"`; these controls are **not** migrated to `iot_set`.
+- Night mowing keeps the confirmed read priority from `camerabox.nightMowSwitch`, with the existing top-level fallbacks unchanged.
+- Night mowing's device-side write restores the behavior that existed before the beta8 legacy-write repair, while preserving the later confirmed cloud format.
+- Rain detection and Rain sensor use the same hybrid write as a field-validation candidate so their persistence can be tested from Home Assistant against the Navimow app and subsequent cloud readback.
+- Existing write-through cache and delayed authoritative readback behavior remain unchanged.
+- All other switch, select, number, notification, diagnostics, mower-control, map, and history behavior is unchanged.
+
+Recommended field validation: toggle each of the three controls from Home Assistant, verify the Navimow app follows, then wait several minutes and confirm the value does not revert after mower/cloud synchronization. Restore the original value after testing where appropriate.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta30"
+  "version": "0.4.1-beta31"
 }

--- a/custom_components/navimower/switch.py
+++ b/custom_components/navimower/switch.py
@@ -1,9 +1,10 @@
 """Switch platform for Navimower cloud settings.
 
-``nightMowSwitch`` is a legacy setting written through the plain
-``save-set-data`` form with a zero-padded boolean string (``"01"``/``"00"``).
-Modern MowerSettingBean toggles use ``operation_type:"iot_set"`` and are sent
-to the mower first so the change applies immediately.
+Legacy boolean settings keep their confirmed plain ``save-set-data`` cloud
+format with zero-padded strings (``"01"``/``"00"``). Selected legacy controls
+also send the matching value to the mower first so its onboard setting cannot
+later overwrite the cloud copy. Modern MowerSettingBean toggles use
+``operation_type:"iot_set"`` and are likewise sent to the mower first.
 
 Settings writes use one transaction and delayed cloud readback so an eventually
 consistent ``set_list`` cannot briefly restore the previous switch state.
@@ -38,6 +39,7 @@ class NavimowSwitchDescription(SwitchEntityDescription):
     numeric: bool = False
     robot_key: str | None = None
     robot_numeric: bool = True
+    legacy_device_write: bool = False
     enabled_default: bool = True
     assumed: bool = False
     gate_key: str | None = None
@@ -67,6 +69,7 @@ SWITCHES: tuple[NavimowSwitchDescription, ...] = (
         value_fn=lambda s: s.get("night_mow"),
         write_key="nightMowSwitch",
         proven=True,
+        legacy_device_write=True,
         raw_read_path=("camerabox", "nightMowSwitch"),
         raw_fallback_keys=("nightMowSwitch", "night_mow_switch"),
     ),
@@ -89,6 +92,7 @@ SWITCHES: tuple[NavimowSwitchDescription, ...] = (
         value_fn=lambda s: s.get("rain_detection"),
         write_key="rainDetectionSwitch",
         proven=True,
+        legacy_device_write=True,
     ),
     NavimowSwitchDescription(
         key="rain_sensor",
@@ -98,6 +102,7 @@ SWITCHES: tuple[NavimowSwitchDescription, ...] = (
         value_fn=lambda s: s.get("rain_sensor"),
         write_key="rainSensor",
         proven=True,
+        legacy_device_write=True,
     ),
     NavimowSwitchDescription(
         key="weather_rain",
@@ -491,6 +496,18 @@ class NavimowSwitch(NavimowEntity, SwitchEntity):
             )
         else:
             cloud_value = "01" if on else "00"
+            if desc.legacy_device_write:
+                robot_value = (
+                    (1 if on else 0)
+                    if desc.robot_numeric
+                    else ("1" if on else "0")
+                )
+                operations.append(
+                    (
+                        self.coordinator.client.send_setting_device,
+                        (self._sn, {desc.robot_key or desc.write_key: robot_value}),
+                    )
+                )
             operations.append(
                 (
                     self.coordinator.client.set_bool_setting,

--- a/tests/test_v041_beta30.py
+++ b/tests/test_v041_beta30.py
@@ -11,7 +11,8 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_beta30_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta30"
+    assert manifest["domain"] == "navimower"
+    assert manifest["version"].startswith("0.4.1-beta")
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta30.md").read_text()
     assert notes.startswith("title: Navimower 0.4.1-beta30")
     for phrase in (

--- a/tests/test_v041_beta31.py
+++ b/tests/test_v041_beta31.py
@@ -1,0 +1,72 @@
+"""Regression contracts for Navimower 0.4.1-beta31."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _description_block(source: str, key: str) -> str:
+    marker = f'key="{key}"'
+    start = source.index("NavimowSwitchDescription(", source.index(marker) - 80)
+    end = source.index("    ),", source.index(marker)) + 6
+    return source[start:end]
+
+
+def test_beta31_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta31"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta31.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta31")
+    for phrase in (
+        "Night mowing",
+        "Rain detection",
+        "Rain sensor",
+        "robot-first",
+        '"00"/"01"',
+        "field validation",
+    ):
+        assert phrase in notes
+
+
+def test_beta31_legacy_switches_request_device_write() -> None:
+    source = (COMPONENT / "switch.py").read_text()
+    ast.parse(source)
+    assert "legacy_device_write: bool = False" in source
+    for key in ("night_mow", "rain_detection", "rain_sensor"):
+        block = _description_block(source, key)
+        assert "legacy_device_write=True" in block
+        assert "iot=True" not in block
+
+
+def test_beta31_legacy_path_is_robot_first_cloud_second() -> None:
+    source = (COMPONENT / "switch.py").read_text()
+    write = source[source.index("    async def _write"):source.index("    async def async_turn_on")]
+    legacy = write[write.index("        else:"):]
+    assert 'cloud_value = "01" if on else "00"' in legacy
+    assert "if desc.legacy_device_write:" in legacy
+    assert "self.coordinator.client.send_setting_device" in legacy
+    assert "self.coordinator.client.set_bool_setting" in legacy
+    assert legacy.index("self.coordinator.client.send_setting_device") < legacy.index(
+        "self.coordinator.client.set_bool_setting"
+    )
+    assert "self.coordinator.client.set_iot_bool" not in legacy
+
+
+def test_beta31_legacy_device_value_is_numeric_by_default() -> None:
+    source = (COMPONENT / "switch.py").read_text()
+    write = source[source.index("    async def _write"):source.index("    async def async_turn_on")]
+    legacy = write[write.index("        else:"):]
+    assert "if desc.robot_numeric" in legacy
+    assert "(1 if on else 0)" in legacy
+    assert "desc.robot_key or desc.write_key" in legacy
+
+
+def test_beta31_night_mow_keeps_nested_read_contract() -> None:
+    source = (COMPONENT / "switch.py").read_text()
+    block = _description_block(source, "night_mow")
+    assert 'raw_read_path=("camerabox", "nightMowSwitch")' in block
+    assert 'raw_fallback_keys=("nightMowSwitch", "night_mow_switch")' in block


### PR DESCRIPTION
## Summary

- add robot-first + legacy-cloud persistence for Night mowing, Rain detection, and Rain sensor
- keep the confirmed plain `"00"/"01"` cloud format; do not move these controls to `iot_set`
- restore Night mowing's historical mower-side `s:mower` write while retaining the beta8+ nested `camerabox.nightMowSwitch` read contract
- field-test the same hybrid device/cloud transaction for Rain detection and Rain sensor
- keep notification, diagnostics, map/history, action export, and mower controls unchanged
- add beta31 regressions and release notes

## Field validation target

Toggle each setting from Home Assistant, confirm the Navimow app follows, then wait several minutes to verify the mower does not synchronize the previous onboard value back into the cloud.