### PR TITLE
Navimower 0.4.1-beta32 notification and legacy camera cleanup

### DIFF
--- a/.github/release-notes/0.4.1-beta32.md
+++ b/.github/release-notes/0.4.1-beta32.md
@@ -1,0 +1,11 @@
+title: Navimower 0.4.1-beta32
+prerelease: true
+
+## Notification and legacy map cleanup
+
+- Rename the Home Assistant **Notification** sensor display name to **Latest notification** so its state is clearly understood as the most recent vendor message, not the mower's current activity.
+- Remove vendor-native notification `url` values from normalized data, the latest sensor attributes and the bounded `recent` list. These links are intended for the Navimow mobile app, are not useful from Home Assistant and may contain mower-identifying parameters.
+- Keep the existing notification entity key/unique ID and all confirmed read-only Device-feed behavior, vendor codes, read state, metadata, one-minute polling TTL and last-known-good handling unchanged.
+- Mark the built-in SVG **Map Camera** as **Legacy Map Camera**. The entity remains available in this beta for compatibility, but the separately maintained Navimower Map Card is the supported map UI going forward.
+- The Legacy Map Camera is deprecated and is planned for removal when the next stable/latest release is prepared.
+- No notification read-state mutation or mower/map write behavior is added by this cleanup.

--- a/custom_components/navimower/beta26_runtime.py
+++ b/custom_components/navimower/beta26_runtime.py
@@ -1,10 +1,12 @@
-"""Vendor notification support introduced in beta26 and refined through beta30.
+"""Vendor notification support introduced in beta26 and refined through beta32.
 
 Beta26 initially used Navimow's separate vehicle message-history route. Beta28
 then recovered the actual main app Notification -> Device feed contract from the
 public H5 MessageCenter component. Beta29 switched the live sensor to that
-read-only encrypted feed. Beta30 aligns the normalized sensor schema with real
-H215 and X390 responses and removes the last discovery-era assumptions.
+read-only encrypted feed. Beta30 aligned the normalized sensor schema with real
+H215 and X390 responses. Beta32 removes vendor-native jump URLs from retained
+notification data, renames the entity to Latest notification, and marks the old
+SVG Map Camera as legacy while keeping its unique ID for compatibility.
 
 Main Device feed contract:
 
@@ -14,8 +16,8 @@ Main Device feed contract:
 * response exposes ``vehicle_message_list`` and ``has_history_message``.
 
 The integration polls at most once per minute, retains the last successful
-response across transient failures, exposes a bounded recent list, and never
-marks messages read or calls any read-state mutation endpoint.
+sanitized response across transient failures, exposes a bounded recent list, and
+never marks messages read or calls any read-state mutation endpoint.
 """
 from __future__ import annotations
 
@@ -140,7 +142,6 @@ def _normalize_item(item: Any) -> dict[str, Any] | None:
         "level": _as_int(_first_present(item, "level", "message_level")),
         "type": _first_present(item, "type", "message_type", "messageType"),
         "style": _first_present(item, "style", "message_style", "messageStyle"),
-        "url": _bounded_text(_first_present(item, "url", "jump_url", "jumpUrl"), 1200),
         "variable": deepcopy(item.get("variable")),
         # Canonical beta30 naming. These are notification/event codes, not
         # necessarily faults: real feeds include values such as 150A.
@@ -201,7 +202,6 @@ def _decorate_snapshot(coordinator: Any, snapshot: dict[str, Any]) -> dict[str, 
             "notification_level": latest.get("level"),
             "notification_type": latest.get("type"),
             "notification_style": latest.get("style"),
-            "notification_url": latest.get("url"),
             "notification_variable": deepcopy(latest.get("variable")),
             "notification_code": latest.get("notification_code"),
             "notification_vendor_code": latest.get("vendor_code"),
@@ -255,7 +255,13 @@ def _refresh_notification_cache(coordinator: Any) -> None:
         )
         return
 
-    coordinator._beta26_notification_cache = response  # noqa: SLF001
+    # Keep only the normalized read-only notification fields. Vendor jump URLs
+    # are native app links, can embed the mower serial and are not useful in HA.
+    normalized = _normalize_response(response)
+    coordinator._beta26_notification_cache = {  # noqa: SLF001
+        "list": deepcopy(normalized["list"]),
+        "has_history_message": normalized.get("has_history_message"),
+    }
     coordinator._beta26_notification_last_success_mono = now  # noqa: SLF001
     coordinator._beta26_notification_error = None  # noqa: SLF001
 
@@ -284,7 +290,6 @@ def _install_notification_sensor() -> None:
             "level": data.get("notification_level"),
             "type": data.get("notification_type"),
             "style": data.get("notification_style"),
-            "url": data.get("notification_url"),
             "variable": deepcopy(data.get("notification_variable")),
             "notification_code": data.get("notification_code"),
             "vendor_code": data.get("notification_vendor_code"),
@@ -309,7 +314,7 @@ def _install_notification_sensor() -> None:
         *platform.SENSORS,
         platform.NavimowSensorDescription(
             key="notification",
-            name="Notification",
+            name="Latest notification",
             icon="mdi:bell-outline",
             value_fn=value,
             attrs_fn=attrs,
@@ -317,11 +322,20 @@ def _install_notification_sensor() -> None:
     )
 
 
+def _mark_map_camera_legacy() -> None:
+    """Keep the existing camera entity but make its deprecated status explicit."""
+    from .camera import NavimowMapCamera
+
+    NavimowMapCamera._attr_translation_key = None
+    NavimowMapCamera._attr_name = "Legacy Map Camera"
+
+
 def install_beta26_runtime() -> None:
     """Install notification transport, polling and sensor once."""
     cls = _coordinator.NavimowCoordinator
     if getattr(cls, "_beta26_runtime_installed", False):
         _install_notification_sensor()
+        _mark_map_camera_legacy()
         return
 
     # Historical beta26 endpoint remains callable for explicit debugging only.
@@ -378,3 +392,4 @@ def install_beta26_runtime() -> None:
     cls._bootstrap_snapshot = bootstrap_snapshot
     cls._beta26_runtime_installed = True
     _install_notification_sensor()
+    _mark_map_camera_legacy()

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.1-beta31"
+  "version": "0.4.1-beta32"
 }

--- a/tests/test_v041_beta26.py
+++ b/tests/test_v041_beta26.py
@@ -50,9 +50,14 @@ def test_beta26_runtime_uses_exact_encrypted_history_contract() -> None:
 def test_beta26_notification_sensor_is_bounded_and_last_good() -> None:
     source = (COMPONENT / "beta26_runtime.py").read_text()
     assert "_NOTIFICATION_ATTR_HISTORY_LIMIT = 5" in source
+    expected_name = (
+        'name="Latest notification"'
+        if _beta_number() >= 32
+        else 'name="Notification"'
+    )
     for phrase in (
         'key="notification"',
-        'name="Notification"',
+        expected_name,
         'icon="mdi:bell-outline"',
         '"notification_history"',
         '"notification_error"',

--- a/tests/test_v041_beta30.py
+++ b/tests/test_v041_beta30.py
@@ -44,15 +44,13 @@ def test_beta30_notification_codes_are_preserved_as_strings() -> None:
     assert "_as_int(" not in normalize.split('"level"', 1)[0]
 
 
-def test_beta30_preserves_real_feed_metadata() -> None:
+def test_beta30_preserves_confirmed_feed_metadata_still_exposed() -> None:
     source = (COMPONENT / "beta26_runtime.py").read_text()
     for phrase in (
         '"read": _as_bool(',
         '"style": _first_present(',
-        '"url": _bounded_text(',
         '"variable": deepcopy(',
         '"notification_style"',
-        '"notification_url"',
         '"notification_variable"',
         '"notification_code"',
         '"notification_vendor_code"',
@@ -61,7 +59,7 @@ def test_beta30_preserves_real_feed_metadata() -> None:
         assert phrase in source
 
 
-def test_beta30_sensor_exposes_new_schema_and_compat_alias() -> None:
+def test_beta30_sensor_keeps_new_schema_and_compat_alias() -> None:
     source = (COMPONENT / "beta26_runtime.py").read_text()
     sensor = source[source.index("def _install_notification_sensor"):]
     for phrase in (
@@ -71,7 +69,6 @@ def test_beta30_sensor_exposes_new_schema_and_compat_alias() -> None:
         '"event_code"',
         '"read"',
         '"style"',
-        '"url"',
         '"variable"',
         '"recent"',
     ):

--- a/tests/test_v041_beta31.py
+++ b/tests/test_v041_beta31.py
@@ -18,7 +18,7 @@ def _description_block(source: str, key: str) -> str:
 
 def test_beta31_manifest_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.1-beta31"
+    assert manifest["version"].startswith("0.4.1-beta")
     notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta31.md").read_text()
     assert notes.startswith("title: Navimower 0.4.1-beta31")
     for phrase in (

--- a/tests/test_v041_beta32.py
+++ b/tests/test_v041_beta32.py
@@ -1,0 +1,77 @@
+"""Regression contracts for Navimower 0.4.1-beta32."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta32_manifest_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.1-beta32"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.1-beta32.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.1-beta32")
+    for phrase in (
+        "Latest notification",
+        "url",
+        "Legacy Map Camera",
+        "deprecated",
+        "stable/latest",
+    ):
+        assert phrase in notes
+
+
+def test_beta32_notification_url_is_not_normalized_or_exposed() -> None:
+    source = (COMPONENT / "beta26_runtime.py").read_text()
+    ast.parse(source)
+    normalize = source[
+        source.index("def _normalize_item"):
+        source.index("def _normalize_response")
+    ]
+    decorate = source[
+        source.index("def _decorate_snapshot"):
+        source.index("def _refresh_notification_cache")
+    ]
+    sensor = source[
+        source.index("def _install_notification_sensor"):
+        source.index("def _mark_map_camera_legacy")
+    ]
+    assert '"url"' not in normalize
+    assert "notification_url" not in decorate
+    assert '"url"' not in sensor
+
+
+def test_beta32_cache_keeps_only_normalized_notification_data() -> None:
+    source = (COMPONENT / "beta26_runtime.py").read_text()
+    refresh = source[
+        source.index("def _refresh_notification_cache"):
+        source.index("def _install_notification_sensor")
+    ]
+    assert "normalized = _normalize_response(response)" in refresh
+    assert '"list": deepcopy(normalized["list"])' in refresh
+    assert '"has_history_message": normalized.get("has_history_message")' in refresh
+    assert "coordinator._beta26_notification_cache = response" not in refresh
+
+
+def test_beta32_sensor_is_named_latest_notification_without_id_break() -> None:
+    source = (COMPONENT / "beta26_runtime.py").read_text()
+    sensor = source[source.index("def _install_notification_sensor"):]
+    assert 'key="notification"' in sensor
+    assert 'name="Latest notification"' in sensor
+    assert "_NOTIFICATION_ATTR_HISTORY_LIMIT = 5" in source
+
+
+def test_beta32_map_camera_is_marked_legacy_without_unique_id_change() -> None:
+    source = (COMPONENT / "beta26_runtime.py").read_text()
+    legacy = source[
+        source.index("def _mark_map_camera_legacy"):
+        source.index("def install_beta26_runtime")
+    ]
+    assert 'NavimowMapCamera._attr_name = "Legacy Map Camera"' in legacy
+    assert "NavimowMapCamera._attr_translation_key = None" in legacy
+
+    camera = (COMPONENT / "camera.py").read_text()
+    assert 'NavimowEntity.__init__(self, coordinator, "map")' in camera


### PR DESCRIPTION
## Summary

- remove vendor-native notification URLs from normalized/cache/entity data
- rename the notification entity display name to **Latest notification** while keeping its key/unique ID
- mark the built-in SVG map camera as **Legacy Map Camera** without changing its unique ID
- document the legacy camera deprecation and planned removal in the next stable/latest release
- bump the integration to `0.4.1-beta32` and add regression coverage

No notification write/read-marking behavior is added. Device-feed polling, vendor codes, read state, one-minute TTL and last-known-good handling remain unchanged.