### PR TITLE
Navimower 0.4.3-beta2 diagnostics hotfix

### DIFF
--- a/.github/release-notes/0.4.3-beta2.md
+++ b/.github/release-notes/0.4.3-beta2.md
@@ -1,0 +1,19 @@
+title: Navimower 0.4.3-beta2
+
+Navimower 0.4.3-beta2 is a focused hotfix for the Maintenance & Tools discovery introduced in beta1.
+
+### Fixed: Download diagnostics registration
+
+- Fixed an import-time `re.PatternError` in `maintenance_h5_discovery.py` caused by an extra regex escaping layer generated in beta1.
+- Because `diagnostics.py` imports that discovery module, the import failure prevented Home Assistant from detecting Navimower diagnostics support and **Download diagnostics** disappeared from the menu.
+- Removed the extra escaping layer from every Maintenance H5 regex, not only the `BRIDGE_RE` pattern that failed immediately. The other beta1 patterns compiled but matched literal backslashes instead of actual JavaScript syntax.
+- Corrected JavaScript whitespace normalization for the same escaping issue.
+
+### Regression protection
+
+- Added a test that extracts and compiles every `re.compile(...)` expression from the discovery module so import-time regex failures are caught by CI rather than Python syntax compilation alone.
+- Added syntax assertions proving the discovery patterns now target real H5 JavaScript syntax.
+
+### Scope
+
+Beta2 otherwise keeps the beta1 plan unchanged. Maintenance H5 discovery runs only when Download diagnostics is explicitly requested, remains public/unauthenticated/read-only, and executes no blade reset, maintenance-mode command, cutting-height mutation or other mower control.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.4.3-beta2
+
+Focused hotfix for beta1 Maintenance & Tools H5 discovery.
+
+### Fixed
+
+- Fixed the malformed import-time `BRIDGE_RE` expression that prevented Home Assistant from loading Navimower diagnostics and hid Download diagnostics.
+- Removed beta1's extra escaping layer from all Maintenance H5 regular expressions and JavaScript whitespace normalization.
+
+### Validation
+
+- Added regression coverage that compiles every discovery `re.compile(...)` expression and verifies intended JavaScript regex syntax.
+- Maintenance discovery remains read-only and Download-diagnostics-only; no maintenance mutation is added in beta2.
+
 ## 0.4.3-beta1
 
 First beta in the cumulative 0.4.3 line, based directly on stable 0.4.2.

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -28,7 +28,7 @@ async def async_get_config_entry_diagnostics(
     """Return a sanitized snapshot for Home Assistant Download diagnostics.
 
     Normal diagnostics use the config entry, coordinator state and caches.
-    0.4.3-beta1 additionally performs a bounded read-only public-H5 inspection for
+    0.4.3-beta2 performs the corrected bounded read-only public-H5 inspection for
     Maintenance & Tools request structure and executes no mutation action.
     """
     coordinator = (hass.data.get(DOMAIN) or {}).get(entry.entry_id)
@@ -271,7 +271,7 @@ async def async_get_config_entry_diagnostics(
         "mqtt_health": sanitize(deepcopy(mqtt_health)),
         "raw": sanitize(deepcopy(raw)),
         "notes": [
-            "Normal diagnostics use current coordinator state and caches; 0.4.3-beta1 additionally performs bounded public H5 Maintenance & Tools discovery.",
+            "Normal diagnostics use current coordinator state and caches; 0.4.3-beta2 performs corrected bounded public H5 Maintenance & Tools discovery.",
             "The beta H5 inspection sends no account or mower identity and executes no maintenance mutation or mower command.",
             "Private-cloud account region/host routing is separate from Smart Home OAuth/MQTT; MQTT continues to use the broker details returned by the official API.",
             "Capability profile entries are positive observations or narrow proven model constraints. An empty/missing endpoint in one snapshot is not treated as unsupported.",

--- a/custom_components/navimower/maintenance_h5_discovery.py
+++ b/custom_components/navimower/maintenance_h5_discovery.py
@@ -26,15 +26,15 @@ MAX_CONTEXTS = 48
 RADIUS = 6000
 TIMEOUT = 5
 
-SCRIPT_RE = re.compile(r"<script\\b[^>]*\\bsrc\\s*=\\s*[\"']([^\"']+)[\"']", re.I)
-JS_RE = re.compile(r"[\"']([^\"'\\r\\n]{1,420}\\.js(?:\\?[^\"'\\r\\n]{0,120})?)[\"']", re.I)
-MOWERBOT_RE = re.compile(r"[\"'](/mowerbot/[^\"'\\r\\n]{1,280})[\"']", re.I)
-HTTP_RE = re.compile(r"method\\s*:\\s*[\"']?(GET|POST|PUT|DELETE|PATCH)[\"']?", re.I)
-SKIP_RE = re.compile(r"skipEncryption\\s*:\\s*(true|false)", re.I)
-OBJECT_KEY_RE = re.compile(r"(?:^|[,{])\\s*[\"']?([A-Za-z_$][\\w$]{0,90})[\"']?\\s*:")
+SCRIPT_RE = re.compile(r"<script\b[^>]*\bsrc\s*=\s*[\"']([^\"']+)[\"']", re.I)
+JS_RE = re.compile(r"[\"']([^\"'\r\n]{1,420}\.js(?:\?[^\"'\r\n]{0,120})?)[\"']", re.I)
+MOWERBOT_RE = re.compile(r"[\"'](/mowerbot/[^\"'\r\n]{1,280})[\"']", re.I)
+HTTP_RE = re.compile(r"method\s*:\s*[\"']?(GET|POST|PUT|DELETE|PATCH)[\"']?", re.I)
+SKIP_RE = re.compile(r"skipEncryption\s*:\s*(true|false)", re.I)
+OBJECT_KEY_RE = re.compile(r"(?:^|[,{])\s*[\"']?([A-Za-z_$][\w$]{0,90})[\"']?\s*:")
 BRIDGE_RE = re.compile(
-    r"(?P<callee>(?:[A-Za-z_$][\\w$]*\\.)*(?:sendEncryptionData|callNative|sendMessageToNative))"
-    r"\\s*\\(\\s*[\"'](?P<method>[^\"']{1,160})[\"']", re.I
+    r"(?P<callee>(?:[A-Za-z_$][\w$]*\.)*(?:sendEncryptionData|callNative|sendMessageToNative))"
+    r"\s*\(\s*[\"'](?P<method>[^\"']{1,160})[\"']", re.I
 )
 
 def _host(client: Any) -> str:
@@ -50,7 +50,7 @@ def _fetch(url: str, limit: int) -> dict[str, Any]:
         url,
         headers={
             "Accept": "text/html,application/javascript,text/javascript,*/*;q=0.8",
-            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.3-beta1",
+            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.3-beta2",
         },
         method="GET",
     )
@@ -120,7 +120,7 @@ def _contexts(text: str, source: str) -> list[dict[str, Any]]:
                 "term": term,
                 "source": _safe_url(source),
                 **_structure(nearby),
-                "context": re.sub(r"\\s+", " ", nearby).strip(),
+                "context": re.sub(r"\s+", " ", nearby).strip(),
             })
             start = idx + len(term)
     return rows
@@ -219,5 +219,5 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
         "assets": assets,
         "contexts": unique_contexts,
         "request_candidates": requests,
-        "note": "0.4.3-beta1 records bounded public H5 source context only. It does not reset maintenance counters, enter maintenance mode, change cutting height or execute any mower command.",
+        "note": "0.4.3-beta2 records bounded public H5 source context only. It does not reset maintenance counters, enter maintenance mode, change cutting height or execute any mower command.",
     }

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta1"
+  "version": "0.4.3-beta2"
 }

--- a/tests/test_v043_beta2.py
+++ b/tests/test_v043_beta2.py
@@ -1,0 +1,64 @@
+"""Regression contracts for Navimower 0.4.3-beta2 diagnostics hotfix."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta2_version_and_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta2"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta2.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta2")
+    assert "Download diagnostics" in notes
+    assert "re.PatternError" in notes
+    assert "literal backslashes" in notes
+
+
+def test_beta2_all_discovery_regexes_compile() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    patterns: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "re"
+            and node.func.attr == "compile"
+        ):
+            continue
+        assert node.args
+        pattern = ast.literal_eval(node.args[0])
+        assert isinstance(pattern, str)
+        patterns.append(pattern)
+        re.compile(pattern)
+    assert len(patterns) >= 7
+
+
+def test_beta2_patterns_target_real_javascript_syntax() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    assert r'<script\b' in source
+    assert r'method\s*:\s*' in source
+    assert r'skipEncryption\s*:\s*' in source
+    assert r'\s*\(\s*' in source
+    assert r're.sub(r"\s+"' in source
+    assert r'<script\\b' not in source
+    assert r'\\s*\\(' not in source
+    assert "NavimowerDiagnostics/0.4.3-beta2" in source
+
+
+def test_beta2_diagnostics_keeps_read_only_maintenance_probe() -> None:
+    diagnostics = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
+    discovery = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    assert "from .maintenance_h5_discovery import probe_maintenance_h5" in diagnostics
+    assert "await hass.async_add_executor_job" in diagnostics
+    assert '"maintenance_h5_discovery": maintenance_h5_discovery' in diagnostics
+    assert '"mutation_calls_executed": False' in discovery
+    assert "client.call(" not in discovery


### PR DESCRIPTION
## What changed

- Fixes the 0.4.3-beta1 import-time Maintenance H5 regex failure that hid Home Assistant Download diagnostics.
- Removes the extra escaping layer from all Maintenance H5 regexes and JavaScript whitespace normalization.
- Adds regression coverage that actually compiles every discovery regex instead of relying on Python syntax compilation alone.
- Keeps the beta1 discovery scope unchanged: public, unauthenticated, read-only, and only executed when Download diagnostics is explicitly requested.

## Root cause

`maintenance_h5_discovery.py` was generated through an extra raw-string escaping layer. `BRIDGE_RE` became invalid and raised `re.PatternError` during module import. Other expressions compiled but matched literal backslashes rather than real H5 JavaScript syntax.

Because `diagnostics.py` imports the discovery module, Home Assistant could not load the diagnostics module and no longer exposed Download diagnostics.

## Validation

Remote GitHub Actions builder completed successfully with **98 tests passing** and created commit `0125455` on `release/0.4.3-beta2`.