### PR TITLE
Navimower 0.4.3-beta3 broader Maintenance H5 discovery

### DIFF
--- a/.github/release-notes/0.4.3-beta3.md
+++ b/.github/release-notes/0.4.3-beta3.md
@@ -1,0 +1,18 @@
+title: Navimower 0.4.3-beta3
+
+Navimower 0.4.3-beta3 broadens the temporary read-only Maintenance & Tools H5 discovery after beta2 diagnostics showed that the public H5 entry pages and JavaScript assets were reachable but the first scanner did not reach the relevant lazy chunk.
+
+### Broader lazy-chunk discovery
+
+- Inspect up to 48 public JavaScript assets during Download diagnostics. Root scripts are always inspected first; lazy chunks with nearby maintenance/toolbox/blade/knife/component/service clues are prioritized, while bounded zero-score chunks are no longer discarded.
+- Record discovered JavaScript candidates and which candidates remain unfetched when the request budget is exhausted. This makes the next refinement evidence-driven instead of guessing chunk names.
+- Search every fetched asset globally for endpoint-like `/vehicle/`, `/mowerbot/`, `/setting/`, `/maintenance/`, `/toolbox/` and related paths, plus native bridge calls, HTTP methods and `skipEncryption` flags. These are no longer visible only when a target keyword happened to be nearby.
+- Expand target vocabulary with the already observed private-cloud maintenance keys `knifeDurationSet`, `chassisDurationSet`, `knifeDefaultDuration`, `chassisDefaultDuration`, `usedTime` and `setTime`.
+
+### Small JSON route responses
+
+- Preserve a sanitized parsed preview of public `application/json` responses up to 8 KiB. This specifically lets us see the 49-byte response previously observed from `/vehicle/maintenance/` without sending credentials or mower identity.
+
+### Safety
+
+Beta3 remains Download-diagnostics-only and strictly read-only. It uses only public HTTPS GET requests, follows only JavaScript URLs on the already observed H5/script hosts, sends no account or mower identifiers, and executes no blade reset, maintenance-mode command, cutting-height change or other mower mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.4.3-beta3
+
+Broader read-only Maintenance & Tools discovery based on the first successful beta2 diagnostics sample.
+
+### Changed
+
+- Crawl a bounded set of public lazy JavaScript chunks instead of discarding chunks whose import reference has no nearby maintenance keyword.
+- Collect endpoint paths and native bridge calls globally from each fetched asset, with maintenance-related chunks prioritized within the fixed request budget.
+- Add observed maintenance setting names such as `knifeDurationSet`, `chassisDurationSet`, `usedTime` and `setTime` to the discovery vocabulary.
+- Preserve sanitized previews of small public JSON route responses, including the `/vehicle/maintenance/` route seen in beta2 diagnostics.
+
+### Safety
+
+- Discovery remains Download-diagnostics-only, public, unauthenticated and GET-only.
+- No maintenance counter reset, maintenance mode, cutting-height mutation or mower command is executed.
+
 ## 0.4.3-beta2
 
 Focused hotfix for beta1 Maintenance & Tools H5 discovery.

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -28,8 +28,8 @@ async def async_get_config_entry_diagnostics(
     """Return a sanitized snapshot for Home Assistant Download diagnostics.
 
     Normal diagnostics use the config entry, coordinator state and caches.
-    0.4.3-beta2 performs the corrected bounded read-only public-H5 inspection for
-    Maintenance & Tools request structure and executes no mutation action.
+    0.4.3-beta3 performs broadened bounded read-only public-H5 inspection for
+    Maintenance & Tools lazy chunks and request structure; no mutation runs.
     """
     coordinator = (hass.data.get(DOMAIN) or {}).get(entry.entry_id)
     if coordinator is None:
@@ -271,7 +271,7 @@ async def async_get_config_entry_diagnostics(
         "mqtt_health": sanitize(deepcopy(mqtt_health)),
         "raw": sanitize(deepcopy(raw)),
         "notes": [
-            "Normal diagnostics use current coordinator state and caches; 0.4.3-beta2 performs corrected bounded public H5 Maintenance & Tools discovery.",
+            "Normal diagnostics use current coordinator state and caches; 0.4.3-beta3 broadens bounded public H5 Maintenance & Tools lazy-chunk discovery.",
             "The beta H5 inspection sends no account or mower identity and executes no maintenance mutation or mower command.",
             "Private-cloud account region/host routing is separate from Smart Home OAuth/MQTT; MQTT continues to use the broker details returned by the official API.",
             "Capability profile entries are positive observations or narrow proven model constraints. An empty/missing endpoint in one snapshot is not treated as unsupported.",

--- a/custom_components/navimower/maintenance_h5_discovery.py
+++ b/custom_components/navimower/maintenance_h5_discovery.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import hashlib
+import heapq
+import json
 import re
 from typing import Any
 import urllib.error
@@ -11,197 +13,485 @@ import urllib.request
 from .api.regions import canonical_region
 from .diagnostics_sanitize import sanitize
 
-ENTRY_PATHS = ("/old/", "/maintenance/", "/vehicle/maintenance/", "/setting/maintenance/")
-TARGET_TERMS = (
-    "componentMaintenance", "partsMaintenance", "partMaintenance",
-    "get-component-maintenance", "resetBlade", "resetKnife", "changeBlade",
-    "maintenanceMode", "enterMaintenance", "exitMaintenance",
-    "cutHeight", "cuttingHeight", "ToolBox",
+ENTRY_PATHS = (
+    "/old/",
+    "/maintenance/",
+    "/vehicle/maintenance/",
+    "/setting/maintenance/",
 )
-THEME_TERMS = ("maintenance", "blade", "knife", "toolbox", "cutheight", "cuttingheight")
+TARGET_TERMS = (
+    "componentMaintenance",
+    "partsMaintenance",
+    "partMaintenance",
+    "get-component-maintenance",
+    "resetBlade",
+    "resetKnife",
+    "changeBlade",
+    "maintenanceMode",
+    "enterMaintenance",
+    "exitMaintenance",
+    "cutHeight",
+    "cuttingHeight",
+    "ToolBox",
+    "knifeDurationSet",
+    "chassisDurationSet",
+    "knifeDefaultDuration",
+    "chassisDefaultDuration",
+    "usedTime",
+    "setTime",
+)
+THEME_TERMS = (
+    "maintenance",
+    "component",
+    "blade",
+    "knife",
+    "toolbox",
+    "service",
+    "repair",
+    "cutheight",
+    "cuttingheight",
+    "duration",
+)
 MAX_HTML = 256 * 1024
 MAX_JS = 2 * 1024 * 1024
-MAX_ASSETS = 16
-MAX_CONTEXTS = 48
-RADIUS = 6000
+MAX_ASSETS = 48
+MAX_CONTEXTS = 80
+MAX_REQUESTS = 120
+MAX_JS_CANDIDATES = 160
+MAX_UNFETCHED_CANDIDATES = 80
+SMALL_JSON_MAX = 8192
+CONTEXT_RADIUS = 1800
+CANDIDATE_RADIUS = 1400
 TIMEOUT = 5
 
-SCRIPT_RE = re.compile(r"<script\b[^>]*\bsrc\s*=\s*[\"']([^\"']+)[\"']", re.I)
-JS_RE = re.compile(r"[\"']([^\"'\r\n]{1,420}\.js(?:\?[^\"'\r\n]{0,120})?)[\"']", re.I)
-MOWERBOT_RE = re.compile(r"[\"'](/mowerbot/[^\"'\r\n]{1,280})[\"']", re.I)
-HTTP_RE = re.compile(r"method\s*:\s*[\"']?(GET|POST|PUT|DELETE|PATCH)[\"']?", re.I)
+SCRIPT_RE = re.compile(
+    r"<script\b[^>]*\bsrc\s*=\s*[\"']([^\"']+)[\"']",
+    re.I,
+)
+JS_RE = re.compile(
+    r"[\"']([^\"'\r\n]{1,420}\.js(?:\?[^\"'\r\n]{0,120})?)[\"']",
+    re.I,
+)
+ENDPOINT_RE = re.compile(
+    r"[\"']((?:https?://[^\"'\s]+)?/?(?:mowerbot|vehicle|setting|robot|maintenance|toolbox|api)/[^\"'\r\n]{1,320})[\"']",
+    re.I,
+)
+HTTP_RE = re.compile(
+    r"method\s*:\s*[\"']?(GET|POST|PUT|DELETE|PATCH)[\"']?",
+    re.I,
+)
 SKIP_RE = re.compile(r"skipEncryption\s*:\s*(true|false)", re.I)
-OBJECT_KEY_RE = re.compile(r"(?:^|[,{])\s*[\"']?([A-Za-z_$][\w$]{0,90})[\"']?\s*:")
+OBJECT_KEY_RE = re.compile(
+    r"(?:^|[,{])\s*[\"']?([A-Za-z_$][\w$]{0,90})[\"']?\s*:"
+)
 BRIDGE_RE = re.compile(
     r"(?P<callee>(?:[A-Za-z_$][\w$]*\.)*(?:sendEncryptionData|callNative|sendMessageToNative))"
-    r"\s*\(\s*[\"'](?P<method>[^\"']{1,160})[\"']", re.I
+    r"\s*\(\s*[\"'](?P<method>[^\"']{1,160})[\"']",
+    re.I,
 )
+
 
 def _host(client: Any) -> str:
     region = canonical_region(getattr(client, "region", "fra"))
     return f"https://navimow-h5-{region}.willand.com"
 
+
 def _safe_url(url: str) -> str:
-    p = urllib.parse.urlsplit(str(url))
-    return urllib.parse.urlunsplit((p.scheme, p.netloc, p.path, "", ""))
+    parsed = urllib.parse.urlsplit(str(url))
+    return urllib.parse.urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, "", "")
+    )
+
 
 def _fetch(url: str, limit: int) -> dict[str, Any]:
-    req = urllib.request.Request(
+    request = urllib.request.Request(
         url,
         headers={
-            "Accept": "text/html,application/javascript,text/javascript,*/*;q=0.8",
-            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.3-beta2",
+            "Accept": (
+                "text/html,application/json,application/javascript,"
+                "text/javascript,*/*;q=0.8"
+            ),
+            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.3-beta3",
         },
         method="GET",
     )
     try:
-        with urllib.request.urlopen(req, timeout=TIMEOUT) as response:
+        with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
             raw = response.read(limit + 1)
             status = int(getattr(response, "status", 200))
-            ctype = str(response.headers.get("Content-Type", ""))
+            content_type = str(response.headers.get("Content-Type", ""))
     except urllib.error.HTTPError as err:
         raw = err.read(limit + 1)
         status = int(err.code)
-        ctype = str(err.headers.get("Content-Type", ""))
+        content_type = str(err.headers.get("Content-Type", ""))
     except urllib.error.URLError as err:
-        return {"ok": False, "url": _safe_url(url), "transport_error": sanitize(str(err.reason))}
-    except Exception as err:  # noqa: BLE001
-        return {"ok": False, "url": _safe_url(url), "transport_error": sanitize(f"{type(err).__name__}: {err}")}
+        return {
+            "ok": False,
+            "url": _safe_url(url),
+            "transport_error": sanitize(str(err.reason)),
+        }
+    except Exception as err:  # noqa: BLE001 - optional beta diagnostics
+        return {
+            "ok": False,
+            "url": _safe_url(url),
+            "transport_error": sanitize(f"{type(err).__name__}: {err}"),
+        }
+
     truncated = len(raw) > limit
     raw = raw[:limit]
     return {
         "ok": 200 <= status < 400,
         "url": _safe_url(url),
         "http_status": status,
-        "content_type": ctype,
+        "content_type": content_type,
         "body_length_read": len(raw),
         "body_sha256": hashlib.sha256(raw).hexdigest(),
         "truncated": truncated,
         "_text": raw.decode("utf-8", errors="replace"),
     }
 
-def _public(row: dict[str, Any]) -> dict[str, Any]:
-    return {k: v for k, v in row.items() if k != "_text"}
+
+def _public(result: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in result.items() if key != "_text"}
+
+
+def _small_json(result: dict[str, Any]) -> Any | None:
+    text = str(result.get("_text") or "")
+    content_type = str(result.get("content_type") or "").lower()
+    body_length = int(result.get("body_length_read") or 0)
+    if not text or "json" not in content_type or body_length > SMALL_JSON_MAX:
+        return None
+    try:
+        return sanitize(json.loads(text))
+    except Exception:  # noqa: BLE001 - diagnostics preview only
+        return sanitize(text[:SMALL_JSON_MAX])
+
+
+def _endpoint_path(value: str) -> str:
+    parsed = urllib.parse.urlsplit(value)
+    if parsed.scheme and parsed.netloc:
+        return parsed.path
+    return value.split("?", 1)[0].split("#", 1)[0]
+
+
+def _object_keys(text: str) -> list[str]:
+    ignored = {"class", "style", "children", "props", "key", "ref", "render"}
+    rows: list[str] = []
+    for key in OBJECT_KEY_RE.findall(text):
+        if key.lower() in ignored or key in rows:
+            continue
+        rows.append(key)
+        if len(rows) >= 100:
+            break
+    return rows
+
+
+def _bridge_calls(text: str) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for match in BRIDGE_RE.finditer(text):
+        row = {
+            "callee": match.group("callee"),
+            "method": match.group("method"),
+        }
+        if row not in rows:
+            rows.append(row)
+        if len(rows) >= 48:
+            break
+    return rows
+
+
+def _matched_terms(text: str) -> list[str]:
+    lower = text.lower()
+    return [term for term in TARGET_TERMS if term.lower() in lower]
+
 
 def _structure(text: str) -> dict[str, Any]:
-    keys = []
-    for key in OBJECT_KEY_RE.findall(text):
-        if key not in keys:
-            keys.append(key)
-        if len(keys) >= 80:
-            break
-    bridges = []
-    for m in BRIDGE_RE.finditer(text):
-        item = {"callee": m.group("callee"), "method": m.group("method")}
-        if item not in bridges:
-            bridges.append(item)
-        if len(bridges) >= 32:
-            break
+    endpoint_paths = sorted(
+        {
+            _endpoint_path(value)
+            for value in ENDPOINT_RE.findall(text)
+            if value
+        }
+    )[:96]
     return {
-        "mowerbot_paths": sorted(set(MOWERBOT_RE.findall(text)))[:48],
-        "http_methods": sorted({v.upper() for v in HTTP_RE.findall(text)}),
-        "skip_encryption": sorted({v.lower() for v in SKIP_RE.findall(text)}),
-        "object_keys": keys,
-        "bridge_calls": bridges,
+        "matched_terms": _matched_terms(text),
+        "endpoint_paths": endpoint_paths,
+        "http_methods": sorted(
+            {value.upper() for value in HTTP_RE.findall(text)}
+        ),
+        "skip_encryption": sorted(
+            {value.lower() for value in SKIP_RE.findall(text)}
+        ),
+        "object_keys": _object_keys(text),
+        "bridge_calls": _bridge_calls(text),
     }
+
 
 def _contexts(text: str, source: str) -> list[dict[str, Any]]:
     lower = text.lower()
-    rows = []
+    rows: list[dict[str, Any]] = []
     for term in TARGET_TERMS:
         start = 0
-        for _ in range(4):
-            idx = lower.find(term.lower(), start)
-            if idx < 0 or len(rows) >= MAX_CONTEXTS:
+        found = 0
+        needle = term.lower()
+        while found < 3 and len(rows) < MAX_CONTEXTS:
+            index = lower.find(needle, start)
+            if index < 0:
                 break
-            lo, hi = max(0, idx - RADIUS), min(len(text), idx + len(term) + RADIUS)
+            lo = max(0, index - CONTEXT_RADIUS)
+            hi = min(len(text), index + len(term) + CONTEXT_RADIUS)
             nearby = text[lo:hi]
-            rows.append({
-                "term": term,
-                "source": _safe_url(source),
-                **_structure(nearby),
-                "context": re.sub(r"\s+", " ", nearby).strip(),
-            })
-            start = idx + len(term)
+            rows.append(
+                {
+                    "term": term,
+                    "source": _safe_url(source),
+                    **_structure(nearby),
+                    "context": re.sub(r"\s+", " ", nearby).strip(),
+                }
+            )
+            start = index + len(needle)
+            found += 1
     return rows
 
+
+def _candidate_score(text: str, match: re.Match[str], url: str) -> tuple[int, list[str]]:
+    lo = max(0, match.start() - CANDIDATE_RADIUS)
+    hi = min(len(text), match.end() + CANDIDATE_RADIUS)
+    nearby = text[lo:hi].lower()
+    url_lower = url.lower()
+    terms = sorted(
+        {
+            term
+            for term in THEME_TERMS
+            if term in nearby or term in url_lower
+        }
+    )
+    score = len(terms) * 8
+    if any(term.lower() in nearby for term in TARGET_TERMS):
+        score += 80
+    if any(
+        token in url_lower
+        for token in (
+            "maintenance",
+            "toolbox",
+            "knife",
+            "blade",
+            "component",
+            "service",
+            "repair",
+        )
+    ):
+        score += 40
+    return score, terms
+
+
+def _js_candidates(
+    text: str,
+    base_url: str,
+    allowed_hosts: set[str],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for order, match in enumerate(JS_RE.finditer(text)):
+        url = _safe_url(
+            urllib.parse.urljoin(base_url, match.group(1).strip())
+        )
+        parsed = urllib.parse.urlsplit(url)
+        if (
+            parsed.scheme != "https"
+            or not parsed.netloc
+            or parsed.netloc not in allowed_hosts
+            or url in seen
+        ):
+            continue
+        seen.add(url)
+        score, terms = _candidate_score(text, match, url)
+        rows.append(
+            {
+                "url": url,
+                "source": _safe_url(base_url),
+                "score": score,
+                "theme_terms": terms,
+                "order": order,
+            }
+        )
+    rows.sort(
+        key=lambda row: (
+            -int(row["score"]),
+            int(row["order"]),
+            str(row["url"]),
+        )
+    )
+    return rows
+
+
 def probe_maintenance_h5(client: Any) -> dict[str, Any]:
+    """Inspect public H5 source for Maintenance & Tools request structure."""
     host = _host(client)
-    pages = []
-    queue = []
-    seen = set()
-    for path in ENTRY_PATHS:
-        url = urllib.parse.urljoin(host + "/", path.lstrip("/"))
+    host_name = urllib.parse.urlsplit(host).netloc
+    pages: list[dict[str, Any]] = []
+    root_scripts: list[str] = []
+    allowed_hosts: set[str] = {host_name}
+
+    for entry_path in ENTRY_PATHS:
+        url = urllib.parse.urljoin(host + "/", entry_path.lstrip("/"))
         result = _fetch(url, MAX_HTML)
         text = str(result.get("_text") or "")
         row = _public(result)
-        scripts = []
+        json_body = _small_json(result)
+        if json_body is not None:
+            row["json_body"] = json_body
+        scripts: list[str] = []
         if text:
             for value in SCRIPT_RE.findall(text):
-                asset = _safe_url(urllib.parse.urljoin(url, value.strip()))
+                asset = _safe_url(
+                    urllib.parse.urljoin(url, value.strip())
+                )
+                parsed = urllib.parse.urlsplit(asset)
+                if parsed.scheme != "https" or not parsed.netloc:
+                    continue
+                allowed_hosts.add(parsed.netloc)
                 if asset not in scripts:
                     scripts.append(asset)
-            row["script_urls"] = scripts[:8]
-            queue.extend(scripts[:8])
+            row["script_urls"] = scripts[:12]
+            root_scripts.extend(scripts[:12])
         pages.append(row)
 
-    assets = []
-    contexts = []
-    index = 0
-    while index < len(queue) and len(assets) < MAX_ASSETS:
-        url = queue[index]
-        index += 1
-        if url in seen:
+    queue: list[tuple[int, int, str, str]] = []
+    queued: set[str] = set()
+    sequence = 0
+    for url in root_scripts:
+        if url in queued:
             continue
-        seen.add(url)
+        queued.add(url)
+        heapq.heappush(queue, (-1000, sequence, url, "root_script"))
+        sequence += 1
+
+    assets: list[dict[str, Any]] = []
+    contexts: list[dict[str, Any]] = []
+    request_candidates: list[dict[str, Any]] = []
+    bridge_candidates: list[dict[str, Any]] = []
+    js_candidates: dict[str, dict[str, Any]] = {}
+    fetched: set[str] = set()
+    request_markers: set[tuple[str, str]] = set()
+    bridge_markers: set[tuple[str, str, str]] = set()
+
+    while queue and len(assets) < MAX_ASSETS:
+        neg_score, _, url, reason = heapq.heappop(queue)
+        if url in fetched:
+            continue
+        fetched.add(url)
         result = _fetch(url, MAX_JS)
         text = str(result.get("_text") or "")
         row = _public(result)
         row["kind"] = "asset"
+        row["discovery_reason"] = reason
+        row["candidate_score"] = -neg_score if neg_score != -1000 else None
+
         if text:
-            found = _contexts(text, url)
-            contexts.extend(found)
-            row["target_terms"] = sorted({item["term"] for item in found})
-            row["request_paths"] = sorted({p for item in found for p in item["mowerbot_paths"]})
-            lower = text.lower()
-            for match in JS_RE.finditer(text):
-                lo, hi = max(0, match.start() - 3500), min(len(text), match.end() + 3500)
-                nearby = lower[lo:hi]
-                if not any(term in nearby for term in THEME_TERMS):
+            structure = _structure(text)
+            row.update(structure)
+            found_contexts = _contexts(text, url)
+            contexts.extend(found_contexts)
+
+            for path in structure["endpoint_paths"]:
+                marker = (str(path), _safe_url(url))
+                if marker in request_markers:
                     continue
-                dynamic = _safe_url(urllib.parse.urljoin(url, match.group(1).strip()))
-                if dynamic not in seen and dynamic not in queue:
-                    queue.append(dynamic)
+                request_markers.add(marker)
+                request_candidates.append(
+                    {
+                        "path": path,
+                        "source": _safe_url(url),
+                        "matched_terms": structure["matched_terms"],
+                        "http_methods": structure["http_methods"],
+                        "skip_encryption": structure["skip_encryption"],
+                        "object_keys": structure["object_keys"],
+                        "bridge_calls": structure["bridge_calls"],
+                    }
+                )
+
+            for bridge in structure["bridge_calls"]:
+                marker = (
+                    str(bridge.get("callee")),
+                    str(bridge.get("method")),
+                    _safe_url(url),
+                )
+                if marker in bridge_markers:
+                    continue
+                bridge_markers.add(marker)
+                bridge_candidates.append(
+                    {
+                        **bridge,
+                        "source": _safe_url(url),
+                        "matched_terms": structure["matched_terms"],
+                    }
+                )
+
+            candidates = _js_candidates(text, url, allowed_hosts)
+            row["js_reference_count"] = len(candidates)
+            for candidate in candidates:
+                candidate_url = str(candidate["url"])
+                previous = js_candidates.get(candidate_url)
+                if previous is None or int(candidate["score"]) > int(previous["score"]):
+                    js_candidates[candidate_url] = candidate
+                if candidate_url in queued or candidate_url in fetched:
+                    continue
+                queued.add(candidate_url)
+                score = int(candidate["score"])
+                reason_text = (
+                    "scored_lazy_chunk" if score > 0 else "bounded_lazy_chunk"
+                )
+                heapq.heappush(
+                    queue,
+                    (-score, sequence, candidate_url, reason_text),
+                )
+                sequence += 1
         assets.append(row)
 
-    unique_contexts = []
-    markers = set()
+    unique_contexts: list[dict[str, Any]] = []
+    context_markers: set[tuple[str, str, str]] = set()
     for row in contexts:
-        marker = (row["term"], row["source"], row["context"])
-        if marker in markers:
+        marker = (
+            str(row["term"]),
+            str(row["source"]),
+            str(row["context"]),
+        )
+        if marker in context_markers:
             continue
-        markers.add(marker)
+        context_markers.add(marker)
         unique_contexts.append(row)
         if len(unique_contexts) >= MAX_CONTEXTS:
             break
 
-    requests = []
-    request_markers = set()
-    for row in unique_contexts:
-        for path in row["mowerbot_paths"]:
-            marker = (path, row["source"])
-            if marker in request_markers:
-                continue
-            request_markers.add(marker)
-            requests.append({
-                "path": path,
-                "source": row["source"],
-                "matched_term": row["term"],
-                "http_methods": row["http_methods"],
-                "skip_encryption": row["skip_encryption"],
-                "object_keys": row["object_keys"],
-                "bridge_calls": row["bridge_calls"],
-            })
+    request_candidates.sort(
+        key=lambda row: (
+            0 if row["matched_terms"] else 1,
+            str(row["path"]),
+            str(row["source"]),
+        )
+    )
+    request_candidates = request_candidates[:MAX_REQUESTS]
+
+    bridge_candidates.sort(
+        key=lambda row: (
+            0 if row["matched_terms"] else 1,
+            str(row.get("method")),
+        )
+    )
+    bridge_candidates = bridge_candidates[:MAX_REQUESTS]
+
+    candidate_rows = sorted(
+        js_candidates.values(),
+        key=lambda row: (
+            -int(row["score"]),
+            int(row["order"]),
+            str(row["url"]),
+        ),
+    )[:MAX_JS_CANDIDATES]
+    unfetched = [
+        row for row in candidate_rows if str(row["url"]) not in fetched
+    ][:MAX_UNFETCHED_CANDIDATES]
 
     return {
         "read_only": True,
@@ -213,11 +503,44 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
         "host": host,
         "entry_paths": list(ENTRY_PATHS),
         "targets": list(TARGET_TERMS),
-        "credential_safety": "No token, cookie, uid, device id, mower serial or encrypted p:101 business payload is sent to H5. Only public GET resources are read.",
-        "investigation_goal": "Recover official Maintenance & Tools request structure for blade runtime reset and mower maintenance mode, including payload keys, HTTP methods, encryption flags and native bridge calls.",
+        "theme_terms": list(THEME_TERMS),
+        "limits": {
+            "timeout_seconds_per_request": TIMEOUT,
+            "max_html_bytes": MAX_HTML,
+            "max_js_bytes_per_asset": MAX_JS,
+            "max_assets": MAX_ASSETS,
+            "max_contexts": MAX_CONTEXTS,
+            "max_request_candidates": MAX_REQUESTS,
+            "max_js_candidates": MAX_JS_CANDIDATES,
+            "small_json_max_bytes": SMALL_JSON_MAX,
+        },
+        "credential_safety": (
+            "No token, cookie, uid, device id, mower serial or encrypted "
+            "p:101 business payload is sent to H5. Only public GET resources "
+            "are read."
+        ),
+        "investigation_goal": (
+            "Recover official Maintenance & Tools request structure for blade "
+            "runtime reset and mower maintenance mode, including lazy chunks, "
+            "small JSON route responses, endpoint paths, payload keys, HTTP "
+            "methods, encryption flags and native bridge calls."
+        ),
         "pages": pages,
         "assets": assets,
         "contexts": unique_contexts,
-        "request_candidates": requests,
-        "note": "0.4.3-beta2 records bounded public H5 source context only. It does not reset maintenance counters, enter maintenance mode, change cutting height or execute any mower command.",
+        "request_candidates": request_candidates,
+        "bridge_candidates": bridge_candidates,
+        "js_discovery": {
+            "allowed_hosts": sorted(allowed_hosts),
+            "root_script_count": len(set(root_scripts)),
+            "candidate_count": len(js_candidates),
+            "fetched_asset_count": len(fetched),
+            "candidates": candidate_rows,
+            "unfetched_candidates": unfetched,
+        },
+        "note": (
+            "0.4.3-beta3 broadens bounded public H5 discovery only. It does "
+            "not reset maintenance counters, enter maintenance mode, change "
+            "cutting height or execute any mower command."
+        ),
     }

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta2"
+  "version": "0.4.3-beta3"
 }

--- a/tests/test_v043_beta2.py
+++ b/tests/test_v043_beta2.py
@@ -12,7 +12,7 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 def test_beta2_version_and_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta2"
+    assert manifest["version"].startswith("0.4.3")
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta2.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta2")
     assert "Download diagnostics" in notes
@@ -51,7 +51,7 @@ def test_beta2_patterns_target_real_javascript_syntax() -> None:
     assert r're.sub(r"\s+"' in source
     assert r'<script\\b' not in source
     assert r'\\s*\\(' not in source
-    assert "NavimowerDiagnostics/0.4.3-beta2" in source
+    assert "NavimowerDiagnostics/0.4.3-beta" in source
 
 
 def test_beta2_diagnostics_keeps_read_only_maintenance_probe() -> None:

--- a/tests/test_v043_beta3.py
+++ b/tests/test_v043_beta3.py
@@ -1,0 +1,80 @@
+"""Regression contracts for Navimower 0.4.3-beta3 H5 discovery."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta3_version_notes_and_changelog() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta3"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta3.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta3")
+    assert "48 public JavaScript assets" in notes
+    assert "49-byte response" in notes
+    assert "strictly read-only" in notes
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert changelog.startswith("# Changelog\n\n## 0.4.3-beta3")
+
+
+def test_beta3_discovery_has_bounded_lazy_chunk_crawler() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    patterns: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "re"
+            and node.func.attr == "compile"
+        ):
+            continue
+        pattern = ast.literal_eval(node.args[0])
+        assert isinstance(pattern, str)
+        re.compile(pattern)
+        patterns.append(pattern)
+    assert len(patterns) >= 7
+    assert "MAX_ASSETS = 48" in source
+    assert "MAX_JS_CANDIDATES = 160" in source
+    assert "bounded_lazy_chunk" in source
+    assert '"unfetched_candidates": unfetched' in source
+    assert "heapq.heappush" in source
+
+
+def test_beta3_collects_small_json_and_global_request_structure() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    for phrase in (
+        "SMALL_JSON_MAX = 8192",
+        'row["json_body"] = json_body',
+        "ENDPOINT_RE = re.compile",
+        '"endpoint_paths": endpoint_paths',
+        '"bridge_candidates": bridge_candidates',
+        "knifeDurationSet",
+        "chassisDurationSet",
+        "knifeDefaultDuration",
+        "chassisDefaultDuration",
+        "usedTime",
+        "setTime",
+    ):
+        assert phrase in source
+    assert "ENDPOINT_RE.findall(text)" in source
+    assert "_structure(text)" in source
+
+
+def test_beta3_remains_public_get_only_and_non_mutating() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    diagnostics = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
+    assert 'method="GET"' in source
+    assert '"mutation_calls_executed": False' in source
+    assert '"public_unauthenticated_h5_only": True' in source
+    assert "client.call(" not in source
+    assert "Authorization" not in source
+    assert "Cookie" not in source
+    assert "0.4.3-beta3" in diagnostics


### PR DESCRIPTION
## What changed

- Broadens the temporary read-only Maintenance & Tools H5 discovery from the successful beta2 diagnostics sample.
- Preserves sanitized previews of small public JSON route responses, including the 49-byte `/vehicle/maintenance/` response observed in beta2.
- Crawls a bounded set of lazy JavaScript chunks instead of discarding zero-score chunks, while still prioritizing maintenance/toolbox/blade/knife/component clues.
- Collects endpoint-like paths, native bridge calls, HTTP methods and `skipEncryption` metadata globally from every fetched asset.
- Adds the already observed maintenance keys (`knifeDurationSet`, `chassisDurationSet`, `usedTime`, `setTime`, etc.) to the discovery vocabulary.
- Makes the beta2 regression contract cumulative for later 0.4.3 betas.

## Safety

The beta remains Download-diagnostics-only, public/unauthenticated and HTTPS GET-only. It sends no mower/account identifiers to H5 and executes no blade reset, maintenance mode, cutting-height change or other mower mutation.

## Validation

The reusable remote beta builder completed successfully with **102/102 tests passing** and created commit `ee033ecd707385c917eb023afaf6bbd29ba4690a` on `release/0.4.3-beta3`.