### PR TITLE
Navimower 0.4.3-beta4 Maintenance and Mowing Reports discovery

### DIFF
--- a/.github/release-notes/0.4.3-beta4.md
+++ b/.github/release-notes/0.4.3-beta4.md
@@ -1,0 +1,25 @@
+title: Navimower 0.4.3-beta4
+
+Navimower 0.4.3-beta4 changes the temporary public-H5 investigation from a Maintenance-only crawl into a focused **Maintenance + Mowing Reports contract recovery** pass.
+
+### Hash-agnostic H5 chunk discovery
+
+- H5 JavaScript filenames such as `native-d66fe239.js` and `request-e9a0ef42.js` contain a bundler content-hash suffix. Beta4 therefore prioritizes semantic chunk prefixes and import relationships instead of depending on one exact hash.
+- `native-*`, `request-*`, `service-*`, report, maintenance, blade, knife, mower and setting chunks are promoted ahead of generic `index-*` chunks.
+- Fix duplicate relative-path resolution that previously produced `/static/js/static/js/...` and `/assets/assets/...` 404 requests.
+- Failed asset requests no longer consume the 48-successful-JavaScript-asset budget; a separate bounded request cap remains in place.
+
+### Mowing Reports recovery
+
+- Capture focused contexts around `/vehicle/report/get-day-week-month-data` and `/vehicle/report/vehicle-main-report`.
+- Capture nearby request payload keys, HTTP methods, `skipEncryption`, `needRawResponse` and related request-wrapper structure.
+- Preserve dedicated report endpoint findings and report contexts so the next beta can implement proven read-only report calls instead of guessing response fields.
+
+### Maintenance recovery
+
+- Continue looking for blade-runtime reset and maintenance-mode contracts.
+- Capture call-site context for `handleH5MowerSet`, `handleEncipherment`, `handleDecrypt` and request-wrapper markers instead of recording only bridge method names.
+
+### Safety
+
+Beta4 remains **strictly read-only** and Download-diagnostics-only. It performs only bounded public HTTPS GET requests, sends no mower/account identifiers to H5, and executes no blade reset, maintenance-mode command, cutting-height change or other mower mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.4.3-beta4
+
+Focused Maintenance + Mowing Reports public-H5 contract recovery.
+
+### Changed
+
+- Fix lazy-chunk URL canonicalization so duplicate `static/js/static/js` and `assets/assets` paths do not waste the crawl budget.
+- Count only successful JavaScript fetches toward the 48-asset limit while keeping a separate bounded request limit.
+- Prioritize semantic hash-agnostic `native-*`, `request-*`, `service-*`, report, maintenance, blade and knife chunks.
+- Capture dedicated contexts for the day/week/month report and vehicle main report endpoints, plus request/encryption/native-bridge call sites.
+
+### Safety
+
+- Discovery remains Download-diagnostics-only, public, unauthenticated and GET-only.
+- No maintenance counter reset, maintenance mode, cutting-height mutation or mower command is executed.
+
 ## 0.4.3-beta3
 
 Broader read-only Maintenance & Tools discovery based on the first successful beta2 diagnostics sample.

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -28,8 +28,8 @@ async def async_get_config_entry_diagnostics(
     """Return a sanitized snapshot for Home Assistant Download diagnostics.
 
     Normal diagnostics use the config entry, coordinator state and caches.
-    0.4.3-beta3 performs broadened bounded read-only public-H5 inspection for
-    Maintenance & Tools lazy chunks and request structure; no mutation runs.
+    0.4.3-beta4 performs broadened bounded read-only public-H5 inspection for
+    Maintenance + Mowing Reports contracts and request structure; no mutation runs.
     """
     coordinator = (hass.data.get(DOMAIN) or {}).get(entry.entry_id)
     if coordinator is None:
@@ -271,7 +271,7 @@ async def async_get_config_entry_diagnostics(
         "mqtt_health": sanitize(deepcopy(mqtt_health)),
         "raw": sanitize(deepcopy(raw)),
         "notes": [
-            "Normal diagnostics use current coordinator state and caches; 0.4.3-beta3 broadens bounded public H5 Maintenance & Tools lazy-chunk discovery.",
+            "Normal diagnostics use current coordinator state and caches; 0.4.3-beta4 recovers bounded public H5 Maintenance + Mowing Reports contracts.",
             "The beta H5 inspection sends no account or mower identity and executes no maintenance mutation or mower command.",
             "Private-cloud account region/host routing is separate from Smart Home OAuth/MQTT; MQTT continues to use the broker details returned by the official API.",
             "Capability profile entries are positive observations or narrow proven model constraints. An empty/missing endpoint in one snapshot is not treated as unsupported.",

--- a/custom_components/navimower/maintenance_h5_discovery.py
+++ b/custom_components/navimower/maintenance_h5_discovery.py
@@ -1,4 +1,4 @@
-"""Read-only public H5 discovery for Navimow Maintenance & Tools."""
+"""Read-only public H5 contract discovery for Maintenance and Mowing Reports."""
 from __future__ import annotations
 
 import hashlib
@@ -16,10 +16,10 @@ from .diagnostics_sanitize import sanitize
 ENTRY_PATHS = (
     "/old/",
     "/maintenance/",
-    "/vehicle/maintenance/",
     "/setting/maintenance/",
 )
-TARGET_TERMS = (
+
+MAINTENANCE_TARGETS = (
     "componentMaintenance",
     "partsMaintenance",
     "partMaintenance",
@@ -32,7 +32,6 @@ TARGET_TERMS = (
     "exitMaintenance",
     "cutHeight",
     "cuttingHeight",
-    "ToolBox",
     "knifeDurationSet",
     "chassisDurationSet",
     "knifeDefaultDuration",
@@ -40,28 +39,65 @@ TARGET_TERMS = (
     "usedTime",
     "setTime",
 )
+
+REPORT_ENDPOINTS = (
+    "/vehicle/report/get-day-week-month-data",
+    "/vehicle/report/vehicle-main-report",
+)
+
+REPORT_TARGETS = (
+    "mowingReport",
+    "mowing_report",
+    "mowingArea",
+    "mowing_area",
+    "mowingTime",
+    "mowing_time",
+    "mowingCount",
+    "mowing_count",
+    "totalMowingArea",
+    "totalMowingTime",
+)
+
+TARGET_TERMS = MAINTENANCE_TARGETS + REPORT_ENDPOINTS + REPORT_TARGETS
+REQUEST_SHAPE_TERMS = (
+    "handleH5MowerSet",
+    "skipEncryption",
+    "needRawResponse",
+    "handleEncipherment",
+    "handleDecrypt",
+)
 THEME_TERMS = (
     "maintenance",
-    "component",
     "blade",
     "knife",
-    "toolbox",
-    "service",
     "repair",
-    "cutheight",
-    "cuttingheight",
+    "report",
+    "mowing",
     "duration",
 )
+PRIORITY_FILENAME_TOKENS = (
+    "maintenance",
+    "blade",
+    "knife",
+    "report",
+    "request-",
+    "native-",
+    "service-",
+    "mower",
+    "setting",
+)
+
 MAX_HTML = 256 * 1024
 MAX_JS = 2 * 1024 * 1024
 MAX_ASSETS = 48
-MAX_CONTEXTS = 80
-MAX_REQUESTS = 120
+MAX_REQUESTS = 96
+MAX_CONTEXTS = 96
+MAX_REQUEST_CANDIDATES = 160
 MAX_JS_CANDIDATES = 160
 MAX_UNFETCHED_CANDIDATES = 80
 SMALL_JSON_MAX = 8192
-CONTEXT_RADIUS = 1800
-CANDIDATE_RADIUS = 1400
+CONTEXT_RADIUS = 2200
+CANDIDATE_RADIUS = 1500
 TIMEOUT = 5
 
 SCRIPT_RE = re.compile(
@@ -98,9 +134,36 @@ def _host(client: Any) -> str:
 
 def _safe_url(url: str) -> str:
     parsed = urllib.parse.urlsplit(str(url))
-    return urllib.parse.urlunsplit(
-        (parsed.scheme, parsed.netloc, parsed.path, "", "")
-    )
+    path = parsed.path
+    while "/static/js/static/js/" in path:
+        path = path.replace("/static/js/static/js/", "/static/js/")
+    while "/assets/assets/" in path:
+        path = path.replace("/assets/assets/", "/assets/")
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+def _resolve_js_url(base_url: str, value: str) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    parsed_ref = urllib.parse.urlsplit(raw)
+    if parsed_ref.scheme and parsed_ref.netloc:
+        return _safe_url(raw)
+
+    base = urllib.parse.urlsplit(base_url)
+    clean = raw.lstrip("./")
+    for marker in ("static/js/", "assets/"):
+        if not clean.startswith(marker):
+            continue
+        marker_index = base.path.find("/" + marker)
+        if marker_index < 0:
+            continue
+        prefix = base.path[: marker_index + 1]
+        candidate = urllib.parse.urlunsplit(
+            (base.scheme, base.netloc, prefix + clean, "", "")
+        )
+        return _safe_url(candidate)
+    return _safe_url(urllib.parse.urljoin(base_url, raw))
 
 
 def _fetch(url: str, limit: int) -> dict[str, Any]:
@@ -111,7 +174,7 @@ def _fetch(url: str, limit: int) -> dict[str, Any]:
                 "text/html,application/json,application/javascript,"
                 "text/javascript,*/*;q=0.8"
             ),
-            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.3-beta3",
+            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.3-beta4",
         },
         method="GET",
     )
@@ -181,7 +244,7 @@ def _object_keys(text: str) -> list[str]:
         if key.lower() in ignored or key in rows:
             continue
         rows.append(key)
-        if len(rows) >= 100:
+        if len(rows) >= 120:
             break
     return rows
 
@@ -189,13 +252,10 @@ def _object_keys(text: str) -> list[str]:
 def _bridge_calls(text: str) -> list[dict[str, str]]:
     rows: list[dict[str, str]] = []
     for match in BRIDGE_RE.finditer(text):
-        row = {
-            "callee": match.group("callee"),
-            "method": match.group("method"),
-        }
+        row = {"callee": match.group("callee"), "method": match.group("method")}
         if row not in rows:
             rows.append(row)
-        if len(rows) >= 48:
+        if len(rows) >= 64:
             break
     return rows
 
@@ -212,29 +272,45 @@ def _structure(text: str) -> dict[str, Any]:
             for value in ENDPOINT_RE.findall(text)
             if value
         }
-    )[:96]
+    )[:128]
+    request_markers = [
+        term for term in REQUEST_SHAPE_TERMS if term.lower() in text.lower()
+    ]
     return {
         "matched_terms": _matched_terms(text),
         "endpoint_paths": endpoint_paths,
-        "http_methods": sorted(
-            {value.upper() for value in HTTP_RE.findall(text)}
-        ),
-        "skip_encryption": sorted(
-            {value.lower() for value in SKIP_RE.findall(text)}
-        ),
+        "http_methods": sorted({value.upper() for value in HTTP_RE.findall(text)}),
+        "skip_encryption": sorted({value.lower() for value in SKIP_RE.findall(text)}),
+        "request_shape_markers": request_markers,
         "object_keys": _object_keys(text),
         "bridge_calls": _bridge_calls(text),
     }
 
 
-def _contexts(text: str, source: str) -> list[dict[str, Any]]:
+def _context_around(text: str, needle: str, radius: int = CONTEXT_RADIUS) -> str:
+    index = text.lower().find(needle.lower())
+    if index < 0:
+        return ""
+    lo = max(0, index - radius)
+    hi = min(len(text), index + len(needle) + radius)
+    return re.sub(r"\s+", " ", text[lo:hi]).strip()
+
+
+def _contexts_for_terms(
+    text: str,
+    source: str,
+    terms: tuple[str, ...],
+    focus: str,
+    *,
+    max_per_term: int = 2,
+) -> list[dict[str, Any]]:
     lower = text.lower()
     rows: list[dict[str, Any]] = []
-    for term in TARGET_TERMS:
+    for term in terms:
         start = 0
         found = 0
         needle = term.lower()
-        while found < 3 and len(rows) < MAX_CONTEXTS:
+        while found < max_per_term and len(rows) < MAX_CONTEXTS:
             index = lower.find(needle, start)
             if index < 0:
                 break
@@ -243,6 +319,7 @@ def _contexts(text: str, source: str) -> list[dict[str, Any]]:
             nearby = text[lo:hi]
             rows.append(
                 {
+                    "focus": focus,
                     "term": term,
                     "source": _safe_url(source),
                     **_structure(nearby),
@@ -254,7 +331,27 @@ def _contexts(text: str, source: str) -> list[dict[str, Any]]:
     return rows
 
 
-def _candidate_score(text: str, match: re.Match[str], url: str) -> tuple[int, list[str]]:
+def _filename_bonus(url: str) -> int:
+    name = urllib.parse.urlsplit(url).path.rsplit("/", 1)[-1].lower()
+    rules = (
+        ("maintenance", 280),
+        ("blade", 260),
+        ("knife", 260),
+        ("report", 250),
+        ("request-", 240),
+        ("native-", 230),
+        ("service-", 190),
+        ("mower", 150),
+        ("setting", 130),
+    )
+    return max((score for token, score in rules if token in name), default=0)
+
+
+def _candidate_score(
+    text: str,
+    match: re.Match[str],
+    url: str,
+) -> tuple[int, list[str]]:
     lo = max(0, match.start() - CANDIDATE_RADIUS)
     hi = min(len(text), match.end() + CANDIDATE_RADIUS)
     nearby = text[lo:hi].lower()
@@ -266,22 +363,16 @@ def _candidate_score(text: str, match: re.Match[str], url: str) -> tuple[int, li
             if term in nearby or term in url_lower
         }
     )
-    score = len(terms) * 8
-    if any(term.lower() in nearby for term in TARGET_TERMS):
+    score = _filename_bonus(url)
+    score += min(120, len(terms) * 20)
+    if any(endpoint.lower() in nearby for endpoint in REPORT_ENDPOINTS):
+        score += 360
+    if any(term.lower() in nearby for term in MAINTENANCE_TARGETS):
+        score += 180
+    if "handleh5mowerset" in nearby:
+        score += 220
+    if "skipencryption" in nearby or "needrawresponse" in nearby:
         score += 80
-    if any(
-        token in url_lower
-        for token in (
-            "maintenance",
-            "toolbox",
-            "knife",
-            "blade",
-            "component",
-            "service",
-            "repair",
-        )
-    ):
-        score += 40
     return score, terms
 
 
@@ -293,12 +384,11 @@ def _js_candidates(
     rows: list[dict[str, Any]] = []
     seen: set[str] = set()
     for order, match in enumerate(JS_RE.finditer(text)):
-        url = _safe_url(
-            urllib.parse.urljoin(base_url, match.group(1).strip())
-        )
+        url = _resolve_js_url(base_url, match.group(1))
         parsed = urllib.parse.urlsplit(url)
         if (
-            parsed.scheme != "https"
+            not url
+            or parsed.scheme != "https"
             or not parsed.netloc
             or parsed.netloc not in allowed_hosts
             or url in seen
@@ -310,23 +400,20 @@ def _js_candidates(
             {
                 "url": url,
                 "source": _safe_url(base_url),
+                "basename": parsed.path.rsplit("/", 1)[-1],
                 "score": score,
                 "theme_terms": terms,
                 "order": order,
             }
         )
     rows.sort(
-        key=lambda row: (
-            -int(row["score"]),
-            int(row["order"]),
-            str(row["url"]),
-        )
+        key=lambda row: (-int(row["score"]), int(row["order"]), str(row["url"]))
     )
     return rows
 
 
 def probe_maintenance_h5(client: Any) -> dict[str, Any]:
-    """Inspect public H5 source for Maintenance & Tools request structure."""
+    """Recover public H5 contracts for Maintenance and Mowing Reports."""
     host = _host(client)
     host_name = urllib.parse.urlsplit(host).netloc
     pages: list[dict[str, Any]] = []
@@ -344,9 +431,7 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
         scripts: list[str] = []
         if text:
             for value in SCRIPT_RE.findall(text):
-                asset = _safe_url(
-                    urllib.parse.urljoin(url, value.strip())
-                )
+                asset = _resolve_js_url(url, value)
                 parsed = urllib.parse.urlsplit(asset)
                 if parsed.scheme != "https" or not parsed.netloc:
                     continue
@@ -358,137 +443,154 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
         pages.append(row)
 
     queue: list[tuple[int, int, str, str]] = []
-    queued: set[str] = set()
     sequence = 0
+    best_scores: dict[str, int] = {}
     for url in root_scripts:
-        if url in queued:
+        if url in best_scores:
             continue
-        queued.add(url)
-        heapq.heappush(queue, (-1000, sequence, url, "root_script"))
+        best_scores[url] = 10_000
+        heapq.heappush(queue, (-10_000, sequence, url, "root_script"))
         sequence += 1
 
     assets: list[dict[str, Any]] = []
     contexts: list[dict[str, Any]] = []
+    maintenance_contexts: list[dict[str, Any]] = []
+    report_contexts: list[dict[str, Any]] = []
+    request_shape_contexts: list[dict[str, Any]] = []
+    bridge_call_contexts: list[dict[str, Any]] = []
     request_candidates: list[dict[str, Any]] = []
     bridge_candidates: list[dict[str, Any]] = []
     js_candidates: dict[str, dict[str, Any]] = {}
     fetched: set[str] = set()
     request_markers: set[tuple[str, str]] = set()
     bridge_markers: set[tuple[str, str, str]] = set()
+    report_endpoints_found: set[str] = set()
+    successful_assets = 0
+    request_count = 0
 
-    while queue and len(assets) < MAX_ASSETS:
+    while queue and successful_assets < MAX_ASSETS and request_count < MAX_REQUESTS:
         neg_score, _, url, reason = heapq.heappop(queue)
         if url in fetched:
             continue
         fetched.add(url)
+        request_count += 1
         result = _fetch(url, MAX_JS)
         text = str(result.get("_text") or "")
         row = _public(result)
         row["kind"] = "asset"
         row["discovery_reason"] = reason
-        row["candidate_score"] = -neg_score if neg_score != -1000 else None
+        row["candidate_score"] = -neg_score if neg_score != -10_000 else None
+        counts_toward_limit = bool(result.get("ok") and text)
+        row["counts_toward_asset_limit"] = counts_toward_limit
+        if counts_toward_limit:
+            successful_assets += 1
 
-        if text:
-            structure = _structure(text)
-            row.update(structure)
-            found_contexts = _contexts(text, url)
-            contexts.extend(found_contexts)
-
-            for path in structure["endpoint_paths"]:
-                marker = (str(path), _safe_url(url))
-                if marker in request_markers:
-                    continue
-                request_markers.add(marker)
-                request_candidates.append(
-                    {
-                        "path": path,
-                        "source": _safe_url(url),
-                        "matched_terms": structure["matched_terms"],
-                        "http_methods": structure["http_methods"],
-                        "skip_encryption": structure["skip_encryption"],
-                        "object_keys": structure["object_keys"],
-                        "bridge_calls": structure["bridge_calls"],
-                    }
-                )
-
-            for bridge in structure["bridge_calls"]:
-                marker = (
-                    str(bridge.get("callee")),
-                    str(bridge.get("method")),
-                    _safe_url(url),
-                )
-                if marker in bridge_markers:
-                    continue
-                bridge_markers.add(marker)
-                bridge_candidates.append(
-                    {
-                        **bridge,
-                        "source": _safe_url(url),
-                        "matched_terms": structure["matched_terms"],
-                    }
-                )
-
-            candidates = _js_candidates(text, url, allowed_hosts)
-            row["js_reference_count"] = len(candidates)
-            for candidate in candidates:
-                candidate_url = str(candidate["url"])
-                previous = js_candidates.get(candidate_url)
-                if previous is None or int(candidate["score"]) > int(previous["score"]):
-                    js_candidates[candidate_url] = candidate
-                if candidate_url in queued or candidate_url in fetched:
-                    continue
-                queued.add(candidate_url)
-                score = int(candidate["score"])
-                reason_text = (
-                    "scored_lazy_chunk" if score > 0 else "bounded_lazy_chunk"
-                )
-                heapq.heappush(
-                    queue,
-                    (-score, sequence, candidate_url, reason_text),
-                )
-                sequence += 1
-        assets.append(row)
-
-    unique_contexts: list[dict[str, Any]] = []
-    context_markers: set[tuple[str, str, str]] = set()
-    for row in contexts:
-        marker = (
-            str(row["term"]),
-            str(row["source"]),
-            str(row["context"]),
-        )
-        if marker in context_markers:
+        if not counts_toward_limit:
+            row["matched_terms"] = []
+            row["endpoint_paths"] = []
+            row["http_methods"] = []
+            row["skip_encryption"] = []
+            row["request_shape_markers"] = []
+            row["object_keys"] = []
+            row["bridge_calls"] = []
+            row["js_reference_count"] = 0
+            assets.append(row)
             continue
-        context_markers.add(marker)
-        unique_contexts.append(row)
-        if len(unique_contexts) >= MAX_CONTEXTS:
-            break
 
-    request_candidates.sort(
-        key=lambda row: (
-            0 if row["matched_terms"] else 1,
-            str(row["path"]),
-            str(row["source"]),
-        )
-    )
-    request_candidates = request_candidates[:MAX_REQUESTS]
+        structure = _structure(text)
+        row.update(structure)
 
-    bridge_candidates.sort(
-        key=lambda row: (
-            0 if row["matched_terms"] else 1,
-            str(row.get("method")),
+        found_maintenance = _contexts_for_terms(
+            text, url, MAINTENANCE_TARGETS, "maintenance", max_per_term=2
         )
-    )
-    bridge_candidates = bridge_candidates[:MAX_REQUESTS]
+        found_reports = _contexts_for_terms(
+            text, url, REPORT_ENDPOINTS, "mowing_reports", max_per_term=3
+        )
+        found_request_shape = _contexts_for_terms(
+            text,
+            url,
+            REQUEST_SHAPE_TERMS,
+            "request_infrastructure",
+            max_per_term=2,
+        )
+        maintenance_contexts.extend(found_maintenance)
+        report_contexts.extend(found_reports)
+        request_shape_contexts.extend(found_request_shape)
+        bridge_call_contexts.extend(
+            [
+                item
+                for item in found_request_shape
+                if item["term"]
+                in ("handleH5MowerSet", "handleEncipherment", "handleDecrypt")
+            ]
+        )
+        contexts.extend(found_maintenance)
+        contexts.extend(found_reports)
+
+        for path in structure["endpoint_paths"]:
+            marker = (url, path)
+            if marker in request_markers:
+                continue
+            request_markers.add(marker)
+            nearby = _context_around(text, path)
+            focus = "supporting"
+            if path in REPORT_ENDPOINTS:
+                focus = "mowing_reports"
+                report_endpoints_found.add(path)
+            elif "maintenance" in path.lower():
+                focus = "maintenance"
+            request_candidates.append(
+                {
+                    "focus": focus,
+                    "source": _safe_url(url),
+                    "path": path,
+                    **(_structure(nearby) if nearby else {}),
+                    "context": nearby,
+                }
+            )
+            if len(request_candidates) >= MAX_REQUEST_CANDIDATES:
+                break
+
+        for bridge in structure["bridge_calls"]:
+            marker = (url, bridge["callee"], bridge["method"])
+            if marker in bridge_markers:
+                continue
+            bridge_markers.add(marker)
+            nearby = _context_around(text, bridge["method"])
+            bridge_candidates.append(
+                {
+                    "source": _safe_url(url),
+                    **bridge,
+                    **(_structure(nearby) if nearby else {}),
+                    "context": nearby,
+                }
+            )
+
+        discovered = _js_candidates(text, url, allowed_hosts)
+        row["js_reference_count"] = len(discovered)
+        for candidate in discovered:
+            candidate_url = str(candidate["url"])
+            previous = js_candidates.get(candidate_url)
+            if previous is None or int(candidate["score"]) > int(previous["score"]):
+                js_candidates[candidate_url] = candidate
+            new_score = int(candidate["score"])
+            if candidate_url in fetched:
+                continue
+            if new_score <= best_scores.get(candidate_url, -1):
+                continue
+            best_scores[candidate_url] = new_score
+            heapq.heappush(
+                queue,
+                (-new_score, sequence, candidate_url, "bounded_lazy_chunk"),
+            )
+            sequence += 1
+
+        assets.append(row)
 
     candidate_rows = sorted(
         js_candidates.values(),
-        key=lambda row: (
-            -int(row["score"]),
-            int(row["order"]),
-            str(row["url"]),
-        ),
-    )[:MAX_JS_CANDIDATES]
+        key=lambda row: (-int(row["score"]), int(row["order"]), str(row["url"])),
+    )
     unfetched = [
         row for row in candidate_rows if str(row["url"]) not in fetched
     ][:MAX_UNFETCHED_CANDIDATES]
@@ -501,46 +603,57 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
         "mutation_calls_executed": False,
         "source": "home_assistant_download",
         "host": host,
+        "focus": ["maintenance", "mowing_reports"],
         "entry_paths": list(ENTRY_PATHS),
-        "targets": list(TARGET_TERMS),
-        "theme_terms": list(THEME_TERMS),
+        "maintenance_targets": list(MAINTENANCE_TARGETS),
+        "report_endpoints": list(REPORT_ENDPOINTS),
+        "report_targets": list(REPORT_TARGETS),
+        "report_endpoints_found": sorted(report_endpoints_found),
+        "request_shape_terms": list(REQUEST_SHAPE_TERMS),
+        "priority_chunk_name_patterns": list(PRIORITY_FILENAME_TOKENS),
         "limits": {
             "timeout_seconds_per_request": TIMEOUT,
             "max_html_bytes": MAX_HTML,
             "max_js_bytes_per_asset": MAX_JS,
-            "max_assets": MAX_ASSETS,
+            "max_successful_assets": MAX_ASSETS,
+            "max_requests": MAX_REQUESTS,
             "max_contexts": MAX_CONTEXTS,
-            "max_request_candidates": MAX_REQUESTS,
-            "max_js_candidates": MAX_JS_CANDIDATES,
+            "max_request_candidates": MAX_REQUEST_CANDIDATES,
+            "max_js_candidates_in_output": MAX_JS_CANDIDATES,
             "small_json_max_bytes": SMALL_JSON_MAX,
         },
         "credential_safety": (
-            "No token, cookie, uid, device id, mower serial or encrypted "
-            "p:101 business payload is sent to H5. Only public GET resources "
-            "are read."
+            "No token, cookie, uid, device id, mower serial or encrypted p:101 "
+            "business payload is sent to H5. Only public GET resources are read."
         ),
         "investigation_goal": (
-            "Recover official Maintenance & Tools request structure for blade "
-            "runtime reset and mower maintenance mode, including lazy chunks, "
-            "small JSON route responses, endpoint paths, payload keys, HTTP "
-            "methods, encryption flags and native bridge calls."
+            "Recover official Maintenance & Tools write-contract structure for blade "
+            "runtime reset and maintenance mode, plus read-only Mowing Reports "
+            "contracts for day/week/month data and the main vehicle report."
         ),
         "pages": pages,
         "assets": assets,
-        "contexts": unique_contexts,
-        "request_candidates": request_candidates,
-        "bridge_candidates": bridge_candidates,
+        "contexts": contexts[:MAX_CONTEXTS],
+        "maintenance_contexts": maintenance_contexts[:MAX_CONTEXTS],
+        "report_contexts": report_contexts[:MAX_CONTEXTS],
+        "request_shape_contexts": request_shape_contexts[:MAX_CONTEXTS],
+        "bridge_call_contexts": bridge_call_contexts[:MAX_CONTEXTS],
+        "request_candidates": request_candidates[:MAX_REQUEST_CANDIDATES],
+        "bridge_candidates": bridge_candidates[:96],
         "js_discovery": {
-            "allowed_hosts": sorted(allowed_hosts),
-            "root_script_count": len(set(root_scripts)),
-            "candidate_count": len(js_candidates),
-            "fetched_asset_count": len(fetched),
-            "candidates": candidate_rows,
+            "strategy": "semantic_hash_agnostic_priority",
+            "candidate_count": len(candidate_rows),
+            "candidates": candidate_rows[:MAX_JS_CANDIDATES],
+            "fetched_count": len(fetched),
+            "successful_asset_count": successful_assets,
+            "request_count": request_count,
+            "failed_request_count": request_count - successful_assets,
             "unfetched_candidates": unfetched,
         },
         "note": (
-            "0.4.3-beta3 broadens bounded public H5 discovery only. It does "
-            "not reset maintenance counters, enter maintenance mode, change "
-            "cutting height or execute any mower command."
+            "0.4.3-beta4 is a bounded read-only contract-recovery pass. Hashed chunk "
+            "suffixes are treated as build artifacts; semantic chunk prefixes and "
+            "import relationships drive priority. No maintenance mutation or mower "
+            "command is executed."
         ),
     }

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta3"
+  "version": "0.4.3-beta4"
 }

--- a/tests/test_v043_beta4.py
+++ b/tests/test_v043_beta4.py
@@ -1,0 +1,87 @@
+"""Regression contracts for Navimower 0.4.3-beta4 H5 contract recovery."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta4_version_notes_and_focus() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta4"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta4.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta4")
+    assert "Maintenance + Mowing Reports" in notes
+    assert "content-hash" in notes
+    assert "strictly read-only" in notes
+
+
+def test_beta4_discovery_fixes_duplicate_asset_paths() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    assert '"/static/js/static/js/"' in source
+    assert '"/assets/assets/"' in source
+    assert "def _resolve_js_url" in source
+    assert 'for marker in ("static/js/", "assets/")' in source
+    assert "MAX_ASSETS = 48" in source
+    assert "MAX_REQUESTS = 96" in source
+    assert "successful_assets < MAX_ASSETS" in source
+    assert 'row["counts_toward_asset_limit"] = counts_toward_limit' in source
+
+
+def test_beta4_targets_report_contracts_and_hash_agnostic_chunks() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    for phrase in (
+        "/vehicle/report/get-day-week-month-data",
+        "/vehicle/report/vehicle-main-report",
+        "handleH5MowerSet",
+        "skipEncryption",
+        "needRawResponse",
+        '"request-"',
+        '"native-"',
+        '"service-"',
+        '"report_contexts": report_contexts',
+        '"request_shape_contexts": request_shape_contexts',
+        '"bridge_call_contexts": bridge_call_contexts',
+        '"report_endpoints_found": sorted(report_endpoints_found)',
+        '"strategy": "semantic_hash_agnostic_priority"',
+    ):
+        assert phrase in source
+
+
+def test_beta4_regexes_compile_and_probe_remains_non_mutating() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    patterns: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "re"
+            and node.func.attr == "compile"
+        ):
+            continue
+        pattern = ast.literal_eval(node.args[0])
+        assert isinstance(pattern, str)
+        re.compile(pattern)
+        patterns.append(pattern)
+    assert len(patterns) >= 7
+    assert 'method="GET"' in source
+    assert '"mutation_calls_executed": False' in source
+    assert '"public_unauthenticated_h5_only": True' in source
+    assert "client.call(" not in source
+    assert "Authorization" not in source
+    assert "Cookie" not in source
+
+
+def test_beta4_diagnostics_describes_both_contract_families() -> None:
+    diagnostics = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
+    assert "probe_maintenance_h5" in diagnostics
+    assert "0.4.3-beta4" in diagnostics
+    assert "Maintenance + Mowing Reports" in diagnostics
+    assert '"maintenance_h5_discovery": maintenance_h5_discovery' in diagnostics


### PR DESCRIPTION
## What changed

- Expands temporary public-H5 discovery to Maintenance and Mowing Reports contract recovery.
- Fixes duplicate lazy-chunk URL resolution and separates successful-asset and request limits.
- Prioritizes hash-agnostic semantic chunks such as `native-*`, `request-*`, `service-*`, report, maintenance and setting chunks.
- Captures focused contexts for `/vehicle/report/get-day-week-month-data` and `/vehicle/report/vehicle-main-report`.
- Captures request infrastructure around `handleH5MowerSet`, `skipEncryption`, `needRawResponse`, `handleEncipherment` and `handleDecrypt`.
- Keeps dedicated maintenance/report/request/bridge context groups in Download diagnostics.

## Safety

Discovery remains Download-diagnostics-only, public/unauthenticated, HTTPS GET-only and non-mutating. No mower state-changing command is executed.

## Validation

The reusable remote beta builder completed successfully, the full test suite passed, and `release/0.4.3-beta4` was pushed at `e4a041fa2f852a4db8b00052b81c8266c4085685`.