### PR TITLE
Navimower 0.4.3-beta7 independent targeted request reserve

### DIFF
--- a/.github/release-notes/0.4.3-beta7.md
+++ b/.github/release-notes/0.4.3-beta7.md
@@ -1,0 +1,30 @@
+title: Navimower 0.4.3-beta7
+
+Navimower 0.4.3-beta7 fixes the beta6 discovery-budget starvation and guarantees a real **targeted Parts maintenance + Mowing Reports pass** after the broad crawl.
+
+### Targeted request reserve
+
+- Broad and targeted asset phases now have independent bounded request ceilings instead of competing for one shared 160-request budget.
+- Broad discovery may use at most 104 asset requests; the targeted phase has its own reserve of up to 56 requests to obtain up to 24 successful high-value assets.
+- An overall 168-request ceiling remains in place, preserving bounded diagnostics behavior.
+- Diagnostics records the initial targeted queue size plus broad, targeted and source-map request counts, so it is immediately visible whether the reserve actually executed.
+- Targeted fetch rows now retain the candidate source and theme terms that caused the chunk to be selected.
+
+### Parts maintenance
+
+- Keep UI/route/theme tracing for Parts maintenance, Blades, Replacement done, Chassis and other parts and Clean now.
+- Add observed maintenance-notification wording such as `Time to clean your mower`, `Maintenance point reached`, `review parts usage`, `start cleaning` and `reset the timer` as additional correlation anchors.
+- Continue recovering `handleH5MowerSet` definitions and real call sites without executing them.
+
+### Mowing Reports
+
+- Preserve the recovered day/week/month and vehicle-main report business contracts and continue tracing `handleEncipherment` / `handleDecrypt` transport evidence.
+- No live report request is made until the H5 transport/encryption compatibility is proven.
+
+### Source maps
+
+- Beta6 found the sampled public `.js.map` URLs unavailable. Beta7 therefore runs targeted JavaScript recovery first and limits source-map probing to two high-value candidates.
+
+### Safety
+
+Beta7 remains **strictly read-only** and Download-diagnostics-only. It performs bounded public HTTPS GET requests only, sends no account/mower identifiers to H5, and executes no report API request, blade reset, Replacement done action, Clean now action, maintenance-mode command, cutting-height change or other mower mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.4.3-beta7
+
+Independent targeted-request reserve for Parts maintenance and Mowing Reports discovery.
+
+### Fixed
+
+- Fix beta6 crawl-budget starvation: broad crawling can no longer consume the request budget reserved for the targeted phase.
+- Give broad and targeted phases separate bounded request ceilings while retaining an overall request ceiling.
+- Expose broad/targeted/source-map request counts and the targeted queue size in diagnostics so the reserve can be verified directly.
+- Keep the 24-success targeted asset goal and include candidate source/theme evidence in targeted fetch diagnostics.
+- De-prioritize public source-map probing after beta6 showed the sampled `.map` URLs were unavailable; targeted JS contract recovery now runs first.
+- Add maintenance notification/UI evidence such as `Time to clean your mower`, `Maintenance point reached`, `review parts usage`, `start cleaning` and `reset the timer` to the search vocabulary.
+
+### Safety
+
+- Discovery remains Download-diagnostics-only, public, unauthenticated and GET-only.
+- No live Mowing Reports request, blade timer reset, Replacement done action, Clean now action, maintenance mode, cutting-height mutation or mower command is executed.
+
 ## 0.4.3-beta6
 
 Parts maintenance UI/source-map recovery and Mowing Reports transport proof.

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -28,8 +28,8 @@ async def async_get_config_entry_diagnostics(
     """Return a sanitized snapshot for Home Assistant Download diagnostics.
 
     Normal diagnostics use the config entry, coordinator state and caches.
-    0.4.3-beta6 performs Parts maintenance UI/i18n/source-map recovery plus Mowing Reports transport recovery
-    within the bounded read-only public-H5 inspection; no mutation or report API request runs.
+    0.4.3-beta7 performs Parts maintenance targeted-callsite recovery plus Mowing Reports transport recovery
+    within the bounded read-only public-H5 inspection; broad and targeted request budgets are independent, and no mutation or report API request runs.
     """
     coordinator = (hass.data.get(DOMAIN) or {}).get(entry.entry_id)
     if coordinator is None:
@@ -271,7 +271,7 @@ async def async_get_config_entry_diagnostics(
         "mqtt_health": sanitize(deepcopy(mqtt_health)),
         "raw": sanitize(deepcopy(raw)),
         "notes": [
-            "Normal diagnostics use current coordinator state and caches; 0.4.3-beta6 traces Parts maintenance UI/source maps and the remaining Mowing Reports transport layer.",
+            "Normal diagnostics use current coordinator state and caches; 0.4.3-beta7 reserves an independent targeted H5 request phase for Parts maintenance and Mowing Reports contract recovery.",
             "The beta H5 inspection sends no account or mower identity and executes no maintenance mutation or mower command.",
             "Private-cloud account region/host routing is separate from Smart Home OAuth/MQTT; MQTT continues to use the broker details returned by the official API.",
             "Capability profile entries are positive observations or narrow proven model constraints. An empty/missing endpoint in one snapshot is not treated as unsupported.",

--- a/custom_components/navimower/maintenance_h5_discovery.py
+++ b/custom_components/navimower/maintenance_h5_discovery.py
@@ -58,6 +58,14 @@ MAINTENANCE_UI_TARGETS = (
     "mallEntranceUrl",
     "knife",
     "chassis",
+    "Time to clean your mower",
+    "Maintenance point reached",
+    "review parts usage",
+    "start cleaning",
+    "reset the timer",
+    "partsUsage",
+    "maintenancePoint",
+    "cleanMower",
 )
 
 REPORT_ENDPOINTS = (
@@ -147,13 +155,17 @@ MAX_HTML = 256 * 1024
 MAX_JS = 2 * 1024 * 1024
 MAX_ASSETS = 48
 MAX_TARGETED_ASSETS = 24
-MAX_REQUESTS = 160
+MAX_BROAD_REQUESTS = 104
+MAX_TARGETED_REQUESTS = 56
+MAX_TOTAL_REQUESTS = 168
+# Compatibility alias for historical diagnostics/tests; phase limits above are authoritative.
+MAX_REQUESTS = MAX_TOTAL_REQUESTS
 MAX_CONTEXTS = 112
 MAX_REQUEST_CANDIDATES = 180
 MAX_JS_CANDIDATES = 220
 MAX_UNFETCHED_CANDIDATES = 120
 SMALL_JSON_MAX = 8192
-MAX_SOURCE_MAPS = 6
+MAX_SOURCE_MAPS = 2
 MAX_SOURCE_MAP = 4 * 1024 * 1024
 MAX_SOURCE_MAP_MATCHING_SOURCES = 32
 CONTEXT_RADIUS = 2200
@@ -260,7 +272,7 @@ def _fetch(url: str, limit: int) -> dict[str, Any]:
                 "text/html,application/json,application/javascript,"
                 "text/javascript,*/*;q=0.8"
             ),
-            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.3-beta6",
+            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.3-beta7",
         },
         method="GET",
     )
@@ -847,13 +859,22 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
     source_map_findings: list[dict[str, Any]] = []
     successful_assets = 0
     request_count = 0
+    broad_request_count = 0
+    targeted_request_count = 0
+    source_map_request_count = 0
 
-    while queue and successful_assets < MAX_ASSETS and request_count < MAX_REQUESTS:
+    while (
+        queue
+        and successful_assets < MAX_ASSETS
+        and broad_request_count < MAX_BROAD_REQUESTS
+        and request_count < MAX_TOTAL_REQUESTS
+    ):
         neg_score, _, url, reason = heapq.heappop(queue)
         if url in fetched:
             continue
         fetched.add(url)
         request_count += 1
+        broad_request_count += 1
         result = _fetch(url, MAX_JS)
         text = str(result.get("_text") or "")
         row = _public(result)
@@ -1021,17 +1042,20 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
         )
         targeted_sequence += 1
 
+    targeted_queue_initial_count = len(targeted_queue)
     targeted_success = 0
     while (
         targeted_queue
         and targeted_success < MAX_TARGETED_ASSETS
-        and request_count < MAX_REQUESTS
+        and targeted_request_count < MAX_TARGETED_REQUESTS
+        and request_count < MAX_TOTAL_REQUESTS
     ):
         neg_score, _, url, candidate = heapq.heappop(targeted_queue)
         if url in fetched:
             continue
         fetched.add(url)
         request_count += 1
+        targeted_request_count += 1
         result = _fetch(url, MAX_JS)
         text = str(result.get("_text") or "")
         row = _public(result)
@@ -1043,6 +1067,8 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
         targeted_record: dict[str, Any] = {
             "url": _safe_url(url),
             "basename": candidate.get("basename"),
+            "source": candidate.get("source"),
+            "theme_terms": candidate.get("theme_terms") or [],
             "candidate_score": -neg_score,
             "ok": bool(result.get("ok")),
             "http_status": result.get("http_status"),
@@ -1183,10 +1209,11 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
         key=lambda row: (-int(row["score"]), str(row["url"])),
     )
     for map_candidate in source_map_rows[:MAX_SOURCE_MAPS]:
-        if request_count >= MAX_REQUESTS:
+        if request_count >= MAX_TOTAL_REQUESTS:
             break
         map_url = str(map_candidate["url"])
         request_count += 1
+        source_map_request_count += 1
         result = _fetch(map_url, MAX_SOURCE_MAP)
         map_text = str(result.get("_text") or "")
         fetch_row = _public(result)
@@ -1240,6 +1267,9 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
             "max_broad_successful_assets": MAX_ASSETS,
             "max_targeted_successful_assets": MAX_TARGETED_ASSETS,
             "max_total_successful_assets": MAX_ASSETS + MAX_TARGETED_ASSETS,
+            "max_broad_requests": MAX_BROAD_REQUESTS,
+            "max_targeted_requests": MAX_TARGETED_REQUESTS,
+            "max_total_requests": MAX_TOTAL_REQUESTS,
             "max_requests": MAX_REQUESTS,
             "max_contexts": MAX_CONTEXTS,
             "max_request_candidates": MAX_REQUEST_CANDIDATES,
@@ -1265,7 +1295,7 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
             "h5_observed_outer_shape": "body.data after native handleEncipherment",
             "private_cloud_observed_outer_shape": "p:101 envelope fields d,h,k,p,t",
             "reason": (
-                "The observable envelope shapes differ, so beta6 does not guess that "
+                "The observable envelope shapes differ, so beta7 does not guess that "
                 "private-cloud p:101 is interchangeable with the H5 native bridge."
             ),
         },
@@ -1289,24 +1319,30 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
         "request_candidates": request_candidates[:MAX_REQUEST_CANDIDATES],
         "bridge_candidates": bridge_candidates[:96],
         "js_discovery": {
-            "strategy": "semantic_hash_agnostic_priority+targeted_callsite_recovery+ui_source_map_recovery",
+            "strategy": "semantic_hash_agnostic_priority+independent_targeted_request_reserve+callsite_recovery",
             "candidate_count": len(candidate_rows),
             "candidates": candidate_rows[:MAX_JS_CANDIDATES],
             "fetched_count": len(fetched),
             "successful_asset_count": successful_assets,
             "request_count": request_count,
+            "broad_request_count": broad_request_count,
+            "targeted_request_count": targeted_request_count,
+            "source_map_request_count": source_map_request_count,
             "failed_request_count": request_count - successful_assets - source_map_success,
+            "targeted_queue_initial_count": targeted_queue_initial_count,
             "targeted_fetch_count": len(targeted_fetches),
             "targeted_success_count": targeted_success,
+            "targeted_request_reserve_exhausted": targeted_request_count >= MAX_TARGETED_REQUESTS,
             "source_map_candidate_count": len(source_map_rows),
             "source_map_fetch_count": len(source_map_fetches),
             "source_map_success_count": source_map_success,
             "unfetched_candidates": unfetched,
         },
         "note": (
-            "0.4.3-beta6 steps back to Parts maintenance UI/i18n/route/source-map "
-            "recovery, fixes default-argument handleH5MowerSet wrapper detection, and "
-            "keeps Mowing Reports focused on transport proof. It remains read-only and "
-            "executes no report API request, maintenance mutation or mower command."
+            "0.4.3-beta7 fixes the beta6 crawl-budget starvation by reserving "
+            "independent request budgets for broad and targeted phases, then traces "
+            "Parts maintenance and Mowing Reports call sites before low-value source-map "
+            "probing. It remains read-only and executes no report API request, maintenance "
+            "mutation or mower command."
         ),
     }

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta6"
+  "version": "0.4.3-beta7"
 }

--- a/tests/test_v043_beta7.py
+++ b/tests/test_v043_beta7.py
@@ -1,0 +1,82 @@
+"""Regression contracts for Navimower 0.4.3-beta7 targeted request reserve."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta7_version_notes_and_changelog() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta7"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta7.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta7")
+    assert "targeted" in notes.lower()
+    assert "strictly read-only" in notes
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert changelog.startswith("# Changelog\n\n## 0.4.3-beta7")
+
+
+def test_beta7_separates_broad_and_targeted_request_budgets() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    for phrase in (
+        "MAX_BROAD_REQUESTS = 104",
+        "MAX_TARGETED_REQUESTS = 56",
+        "MAX_TOTAL_REQUESTS = 168",
+        "broad_request_count < MAX_BROAD_REQUESTS",
+        "targeted_request_count < MAX_TARGETED_REQUESTS",
+        "request_count < MAX_TOTAL_REQUESTS",
+        "broad_request_count += 1",
+        "targeted_request_count += 1",
+    ):
+        assert phrase in source
+
+
+def test_beta7_targeted_phase_is_observable_and_runs_before_source_maps() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    for phrase in (
+        "targeted_queue_initial_count = len(targeted_queue)",
+        '"broad_request_count": broad_request_count',
+        '"targeted_request_count": targeted_request_count',
+        '"targeted_queue_initial_count": targeted_queue_initial_count',
+        '"targeted_request_reserve_exhausted":',
+        '"source": candidate.get("source")',
+        '"theme_terms": candidate.get("theme_terms") or []',
+    ):
+        assert phrase in source
+    assert source.index("targeted_queue_initial_count = len(targeted_queue)") < source.index("source_map_success = 0")
+
+
+def test_beta7_deprioritizes_source_maps_after_beta6_404s() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    assert "MAX_SOURCE_MAPS = 2" in source
+    assert "source_map_request_count += 1" in source
+    assert source.index("while (\n        targeted_queue") < source.index("for map_candidate in source_map_rows[:MAX_SOURCE_MAPS]")
+
+
+def test_beta7_adds_observed_parts_maintenance_correlation_anchors() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    for phrase in (
+        '"Time to clean your mower"',
+        '"Maintenance point reached"',
+        '"review parts usage"',
+        '"start cleaning"',
+        '"reset the timer"',
+        '"handleH5MowerSet"',
+    ):
+        assert phrase in source
+
+
+def test_beta7_remains_public_get_only_and_non_mutating() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    diagnostics = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
+    assert 'method="GET"' in source
+    assert '"mutation_calls_executed": False' in source
+    assert '"live_report_request_executed": False' in source
+    assert "client.call(" not in source
+    assert "Authorization" not in source
+    assert "Cookie" not in source
+    assert "0.4.3-beta7" in diagnostics
+    assert "bounded read-only public-H5 inspection" in diagnostics


### PR DESCRIPTION
## What changed

- Fixes beta6 crawl-budget starvation by separating the broad and targeted public-H5 request budgets.
- Broad discovery is capped at 104 asset requests; the targeted reserve gets up to 56 requests for up to 24 successful high-value assets; an overall 168-request ceiling remains.
- Runs targeted JavaScript contract recovery before the now de-prioritized source-map probes and limits source-map probing to two candidates.
- Exposes `broad_request_count`, `targeted_request_count`, `source_map_request_count`, `targeted_queue_initial_count` and reserve-exhaustion state in diagnostics.
- Keeps candidate source/theme evidence in targeted fetch rows so repair/parts/blade/chassis/replacement/clean selection can be audited.
- Adds Parts-maintenance correlation anchors observed in vendor UI/events: `Time to clean your mower`, `Maintenance point reached`, `review parts usage`, `start cleaning` and `reset the timer`.
- Preserves the recovered Mowing Reports business contract and continues transport/encryption recovery without making a live report request.

## Safety

Download diagnostics remains public HTTPS GET-only and non-mutating. Beta7 sends no account/mower identifiers to H5 and executes no report request, blade reset, Replacement done action, Clean now action, maintenance-mode command, cutting-height mutation or other mower command.

## Validation

The reusable remote builder passed compileall, diff checks and the complete test suite: 124/124 tests. It pushed `release/0.4.3-beta7` at `0d5e1006f017311fe6783c5f9fac3f4ee8f861d6`. The release diff contains exactly the six intended beta7 release files.