### PR TITLE
Navimower 0.4.3-beta8 targeted candidate routing

### DIFF
--- a/.github/release-notes/0.4.3-beta8.md
+++ b/.github/release-notes/0.4.3-beta8.md
@@ -1,0 +1,29 @@
+title: Navimower 0.4.3-beta8
+
+Navimower 0.4.3-beta8 fixes the candidate-routing flaw exposed by beta7 and tightens `handleH5MowerSet` wrapper recovery.
+
+### Targeted routing
+
+- High-value lazy chunks are classified at discovery time and reserved from the broad queue instead of being reconsidered only after the broad phase.
+- `report` and `mowing` source context now qualify for the targeted phase alongside Parts maintenance/blade/knife/chassis/replacement/clean evidence.
+- Generic `repair` is deliberately de-prioritized because beta7 showed it mostly leads into unrelated after-sales workflows.
+- Candidate diagnostics retain a bounded source-context preview and explicit `targeted_reason`.
+- The already observed public-H5 Mowing Records asset `index-594ad42d.js` has a temporary beta-only exact fallback so the recovered report contract cannot be lost behind generic crawl ordering.
+
+### Parts maintenance
+
+- Arrow-wrapper extraction is anchored directly to `callNative("handleH5MowerSet", ...)`, so the observed `l5=(e={})=>...handleH5MowerSet...` wrapper is not confused with the preceding decrypt wrapper.
+- Continue tracing Parts maintenance / Blades / Replacement done / Chassis and other parts / Clean now from UI and source context to real call sites without executing them.
+
+### Mowing Reports
+
+- Preserve the recovered report business contract and prioritize the Mowing Records chunk plus report/mowing route context for transport/encryption recovery.
+- No live report request is made until H5 transport/encryption compatibility is proven.
+
+### Source maps
+
+- Public source-map probing is disabled in beta8 after repeated 404-only results; the request budget stays focused on JavaScript contract recovery.
+
+### Safety
+
+Beta8 remains **strictly read-only** and Download-diagnostics-only. It performs bounded public HTTPS GET requests only, sends no account/mower identifiers to H5, and executes no report API request, blade reset, Replacement done action, Clean now action, maintenance-mode command, cutting-height change or other mower mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.4.3-beta8
+
+Targeted candidate routing and precise mower-set wrapper recovery.
+
+### Fixed
+
+- Classify high-value H5 candidates when their import/reference is discovered and reserve them from the broad queue, fixing beta7's zero-sized targeted queue.
+- Treat `report` and `mowing` source-context evidence as targeted signals; generic `repair` alone is no longer enough to dominate discovery.
+- Preserve a bounded source-context preview and explicit targeted reason for each candidate/fetch so route/import decisions are auditable.
+- Add a temporary beta-only fallback for the already observed Mowing Records chunk `index-594ad42d.js`, while keeping semantic source-context routing authoritative.
+- Anchor arrow-wrapper detection directly to `callNative("handleH5MowerSet", ...)`, preventing the preceding `handleDecrypt` wrapper from being misidentified as the mower-set wrapper.
+- Disable public source-map requests after repeated beta6/beta7 404 results.
+
+### Safety
+
+- Discovery remains Download-diagnostics-only, public, unauthenticated and GET-only.
+- No live Mowing Reports request, blade timer reset, Replacement done action, Clean now action, maintenance mode, cutting-height mutation or mower command is executed.
+
 ## 0.4.3-beta7
 
 Independent targeted-request reserve for Parts maintenance and Mowing Reports discovery.

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -28,8 +28,8 @@ async def async_get_config_entry_diagnostics(
     """Return a sanitized snapshot for Home Assistant Download diagnostics.
 
     Normal diagnostics use the config entry, coordinator state and caches.
-    0.4.3-beta7 performs Parts maintenance targeted-callsite recovery plus Mowing Reports transport recovery
-    within the bounded read-only public-H5 inspection; broad and targeted request budgets are independent, and no mutation or report API request runs.
+    0.4.3-beta8 performs source-context candidate routing plus precise Parts maintenance and Mowing Reports call-site recovery
+    within the bounded read-only public-H5 inspection; targeted candidates are reserved before broad fetching, and no mutation or report API request runs.
     """
     coordinator = (hass.data.get(DOMAIN) or {}).get(entry.entry_id)
     if coordinator is None:
@@ -271,7 +271,7 @@ async def async_get_config_entry_diagnostics(
         "mqtt_health": sanitize(deepcopy(mqtt_health)),
         "raw": sanitize(deepcopy(raw)),
         "notes": [
-            "Normal diagnostics use current coordinator state and caches; 0.4.3-beta7 reserves an independent targeted H5 request phase for Parts maintenance and Mowing Reports contract recovery.",
+            "Normal diagnostics use current coordinator state and caches; 0.4.3-beta8 routes high-value H5 candidates into the targeted queue at discovery time and records the source context/reason for that routing.",
             "The beta H5 inspection sends no account or mower identity and executes no maintenance mutation or mower command.",
             "Private-cloud account region/host routing is separate from Smart Home OAuth/MQTT; MQTT continues to use the broker details returned by the official API.",
             "Capability profile entries are positive observations or narrow proven model constraints. An empty/missing endpoint in one snapshot is not treated as unsupported.",

--- a/custom_components/navimower/maintenance_h5_discovery.py
+++ b/custom_components/navimower/maintenance_h5_discovery.py
@@ -142,13 +142,21 @@ PRIORITY_FILENAME_TOKENS = (
 )
 TARGETED_THEME_TERMS = (
     "maintenance",
-    "repair",
     "parts",
     "blade",
     "knife",
     "chassis",
     "replacement",
     "clean",
+    "report",
+    "mowing",
+)
+
+# Temporary beta-only fallback for the exact Mowing Records chunk already observed in
+# current public H5. Semantic source-context routing remains authoritative and this hint
+# is removed with discovery cleanup once the contract is integrated.
+OBSERVED_REPORT_ASSET_BASENAMES = (
+    "index-594ad42d.js",
 )
 
 MAX_HTML = 256 * 1024
@@ -165,7 +173,7 @@ MAX_REQUEST_CANDIDATES = 180
 MAX_JS_CANDIDATES = 220
 MAX_UNFETCHED_CANDIDATES = 120
 SMALL_JSON_MAX = 8192
-MAX_SOURCE_MAPS = 2
+MAX_SOURCE_MAPS = 0
 MAX_SOURCE_MAP = 4 * 1024 * 1024
 MAX_SOURCE_MAP_MATCHING_SOURCES = 32
 CONTEXT_RADIUS = 2200
@@ -219,9 +227,10 @@ MOWER_SET_WRAPPER_RE = re.compile(
 )
 MOWER_SET_ARROW_WRAPPER_RE = re.compile(
     r"(?P<name>[A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(?\s*(?P<param>[A-Za-z_$][\w$]*)"
-    r"(?:\s*=\s*\{\})?\s*\)?\s*=>[^;]{0,700}?"
-    r"(?:callNative|sendMessageToNative)\s*\(\s*[\"']handleH5MowerSet[\"']",
-    re.I | re.S,
+    r"(?:\s*=\s*\{\})?\s*\)?\s*=>\s*"
+    r"(?:(?:[A-Za-z_$][\w$]*)\.)*(?:callNative|sendMessageToNative)"
+    r"\s*\(\s*[\"']handleH5MowerSet[\"']",
+    re.I,
 )
 
 
@@ -272,7 +281,7 @@ def _fetch(url: str, limit: int) -> dict[str, Any]:
                 "text/html,application/json,application/javascript,"
                 "text/javascript,*/*;q=0.8"
             ),
-            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.3-beta7",
+            "User-Agent": "Mozilla/5.0 NavimowerDiagnostics/0.4.3-beta8",
         },
         method="GET",
     )
@@ -697,20 +706,32 @@ def _source_map_findings(map_text: str, map_url: str, asset_url: str) -> dict[st
         "matching_sources": matching_sources,
     }
 
-def _is_targeted_candidate(candidate: dict[str, Any]) -> bool:
+def _targeted_reasons(candidate: dict[str, Any]) -> list[str]:
     url = str(candidate.get("url") or "")
+    basename = urllib.parse.urlsplit(url).path.rsplit("/", 1)[-1].lower()
     theme_terms = {str(value).lower() for value in candidate.get("theme_terms") or []}
-    return (
-        _filename_bonus(url) >= 130
-        or int(candidate.get("score") or 0) >= 180
-        or any(term in theme_terms for term in TARGETED_THEME_TERMS)
-    )
+    reasons: list[str] = []
+    if basename in OBSERVED_REPORT_ASSET_BASENAMES:
+        reasons.append("observed_report_asset")
+    for term in TARGETED_THEME_TERMS:
+        if term in theme_terms:
+            reasons.append(f"theme:{term}")
+    filename_bonus = _filename_bonus(url)
+    if filename_bonus >= 130:
+        reasons.append("semantic_filename")
+    if int(candidate.get("score") or 0) >= 180:
+        reasons.append("high_context_score")
+    return list(dict.fromkeys(reasons))
+
+
+def _is_targeted_candidate(candidate: dict[str, Any]) -> bool:
+    return bool(_targeted_reasons(candidate))
 
 def _filename_bonus(url: str) -> int:
     name = urllib.parse.urlsplit(url).path.rsplit("/", 1)[-1].lower()
     rules = (
         ("maintenance", 320),
-        ("repair", 310),
+        ("repair", 60),
         ("parts", 300),
         ("blade", 280),
         ("knife", 280),
@@ -754,6 +775,9 @@ def _candidate_score(
         score += 220
     if "skipencryption" in nearby or "needrawresponse" in nearby:
         score += 80
+    basename = urllib.parse.urlsplit(url).path.rsplit("/", 1)[-1].lower()
+    if basename in OBSERVED_REPORT_ASSET_BASENAMES:
+        score += 900
     return score, terms
 
 
@@ -777,16 +801,19 @@ def _js_candidates(
             continue
         seen.add(url)
         score, terms = _candidate_score(text, match, url)
-        rows.append(
-            {
-                "url": url,
-                "source": _safe_url(base_url),
-                "basename": parsed.path.rsplit("/", 1)[-1],
-                "score": score,
-                "theme_terms": terms,
-                "order": order,
-            }
-        )
+        context_lo = max(0, match.start() - 900)
+        context_hi = min(len(text), match.end() + 900)
+        candidate = {
+            "url": url,
+            "source": _safe_url(base_url),
+            "basename": parsed.path.rsplit("/", 1)[-1],
+            "score": score,
+            "theme_terms": terms,
+            "source_context": re.sub(r"\s+", " ", text[context_lo:context_hi]).strip(),
+            "order": order,
+        }
+        candidate["targeted_reason"] = _targeted_reasons(candidate)
+        rows.append(candidate)
     rows.sort(
         key=lambda row: (-int(row["score"]), int(row["order"]), str(row["url"]))
     )
@@ -844,6 +871,7 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
     request_candidates: list[dict[str, Any]] = []
     bridge_candidates: list[dict[str, Any]] = []
     js_candidates: dict[str, dict[str, Any]] = {}
+    targeted_candidates: dict[str, dict[str, Any]] = {}
     fetched: set[str] = set()
     request_markers: set[tuple[str, str]] = set()
     bridge_markers: set[tuple[str, str, str]] = set()
@@ -870,6 +898,8 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
         and request_count < MAX_TOTAL_REQUESTS
     ):
         neg_score, _, url, reason = heapq.heappop(queue)
+        if reason != "root_script" and url in targeted_candidates:
+            continue
         if url in fetched:
             continue
         fetched.add(url)
@@ -1014,9 +1044,13 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
             previous = js_candidates.get(candidate_url)
             if previous is None or int(candidate["score"]) > int(previous["score"]):
                 js_candidates[candidate_url] = candidate
-            new_score = int(candidate["score"])
+            selected = js_candidates[candidate_url]
             if candidate_url in fetched:
                 continue
+            if _is_targeted_candidate(selected):
+                targeted_candidates[candidate_url] = selected
+                continue
+            new_score = int(selected["score"])
             if new_score <= best_scores.get(candidate_url, -1):
                 continue
             best_scores[candidate_url] = new_score
@@ -1031,9 +1065,11 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
     targeted_queue: list[tuple[int, int, str, dict[str, Any]]] = []
     targeted_queued: set[str] = set()
     targeted_sequence = 0
-    for candidate in js_candidates.values():
+    targeted_candidate_count_before_targeted_phase = len(targeted_candidates)
+    targeted_enqueued_count = 0
+    for candidate in targeted_candidates.values():
         candidate_url = str(candidate["url"])
-        if candidate_url in fetched or not _is_targeted_candidate(candidate):
+        if candidate_url in fetched:
             continue
         targeted_queued.add(candidate_url)
         heapq.heappush(
@@ -1041,6 +1077,7 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
             (-int(candidate["score"]), targeted_sequence, candidate_url, candidate),
         )
         targeted_sequence += 1
+        targeted_enqueued_count += 1
 
     targeted_queue_initial_count = len(targeted_queue)
     targeted_success = 0
@@ -1069,6 +1106,8 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
             "basename": candidate.get("basename"),
             "source": candidate.get("source"),
             "theme_terms": candidate.get("theme_terms") or [],
+            "targeted_reason": candidate.get("targeted_reason") or [],
+            "source_context": candidate.get("source_context") or "",
             "candidate_score": -neg_score,
             "ok": bool(result.get("ok")),
             "http_status": result.get("http_status"),
@@ -1187,18 +1226,21 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
             previous = js_candidates.get(child_url)
             if previous is None or int(child["score"]) > int(previous["score"]):
                 js_candidates[child_url] = child
+            selected_child = js_candidates[child_url]
             if (
                 child_url in fetched
                 or child_url in targeted_queued
-                or not _is_targeted_candidate(child)
+                or not _is_targeted_candidate(selected_child)
             ):
                 continue
+            targeted_candidates[child_url] = selected_child
             targeted_queued.add(child_url)
             heapq.heappush(
                 targeted_queue,
-                (-int(child["score"]), targeted_sequence, child_url, child),
+                (-int(selected_child["score"]), targeted_sequence, child_url, selected_child),
             )
             targeted_sequence += 1
+            targeted_enqueued_count += 1
 
         targeted_fetches.append(targeted_record)
         assets.append(row)
@@ -1295,7 +1337,7 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
             "h5_observed_outer_shape": "body.data after native handleEncipherment",
             "private_cloud_observed_outer_shape": "p:101 envelope fields d,h,k,p,t",
             "reason": (
-                "The observable envelope shapes differ, so beta7 does not guess that "
+                "The observable envelope shapes differ, so beta8 does not guess that "
                 "private-cloud p:101 is interchangeable with the H5 native bridge."
             ),
         },
@@ -1319,7 +1361,7 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
         "request_candidates": request_candidates[:MAX_REQUEST_CANDIDATES],
         "bridge_candidates": bridge_candidates[:96],
         "js_discovery": {
-            "strategy": "semantic_hash_agnostic_priority+independent_targeted_request_reserve+callsite_recovery",
+            "strategy": "semantic_source_context_routing+reserved_targeted_queue+precise_mower_set_wrapper",
             "candidate_count": len(candidate_rows),
             "candidates": candidate_rows[:MAX_JS_CANDIDATES],
             "fetched_count": len(fetched),
@@ -1329,6 +1371,8 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
             "targeted_request_count": targeted_request_count,
             "source_map_request_count": source_map_request_count,
             "failed_request_count": request_count - successful_assets - source_map_success,
+            "targeted_candidate_count_before_targeted_phase": targeted_candidate_count_before_targeted_phase,
+            "targeted_enqueued_count": targeted_enqueued_count,
             "targeted_queue_initial_count": targeted_queue_initial_count,
             "targeted_fetch_count": len(targeted_fetches),
             "targeted_success_count": targeted_success,
@@ -1339,10 +1383,10 @@ def probe_maintenance_h5(client: Any) -> dict[str, Any]:
             "unfetched_candidates": unfetched,
         },
         "note": (
-            "0.4.3-beta7 fixes the beta6 crawl-budget starvation by reserving "
-            "independent request budgets for broad and targeted phases, then traces "
-            "Parts maintenance and Mowing Reports call sites before low-value source-map "
-            "probing. It remains read-only and executes no report API request, maintenance "
-            "mutation or mower command."
+            "0.4.3-beta8 fixes targeted candidate routing at discovery time, reserves "
+            "report/maintenance chunks before broad fetching, and anchors handleH5MowerSet "
+            "wrapper recovery to the actual native call expression. Public source-map "
+            "probing is disabled after repeated 404s. It remains read-only and executes no "
+            "report API request, maintenance mutation or mower command."
         ),
     }

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta7"
+  "version": "0.4.3-beta8"
 }

--- a/tests/test_v043_beta8.py
+++ b/tests/test_v043_beta8.py
@@ -1,0 +1,108 @@
+"""Regression contracts for Navimower 0.4.3-beta8 candidate routing."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _compiled_patterns(source: str) -> dict[str, tuple[str, int]]:
+    tree = ast.parse(source)
+    rows: dict[str, tuple[str, int]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        call = node.value
+        if not (
+            isinstance(target, ast.Name)
+            and isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id == "re"
+            and call.func.attr == "compile"
+            and call.args
+        ):
+            continue
+        pattern = ast.literal_eval(call.args[0])
+        flags = 0
+        if len(call.args) > 1:
+            flag_node = call.args[1]
+            if isinstance(flag_node, ast.Attribute) and flag_node.attr == "I":
+                flags = re.I
+        assert isinstance(pattern, str)
+        re.compile(pattern, flags)
+        rows[target.id] = (pattern, flags)
+    return rows
+
+
+def test_beta8_version_notes_and_changelog() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta8"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta8.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta8")
+    assert "candidate-routing" in notes
+    assert "strictly read-only" in notes
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert changelog.startswith("# Changelog\n\n## 0.4.3-beta8")
+
+
+def test_beta8_reserves_targeted_candidates_before_broad_fetch() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    for phrase in (
+        "targeted_candidates: dict[str, dict[str, Any]] = {}",
+        'if reason != "root_script" and url in targeted_candidates:',
+        "if _is_targeted_candidate(selected):",
+        "targeted_candidates[candidate_url] = selected",
+        "for candidate in targeted_candidates.values():",
+        '"targeted_candidate_count_before_targeted_phase":',
+        '"targeted_enqueued_count": targeted_enqueued_count',
+        '"targeted_reason": candidate.get("targeted_reason") or []',
+        '"source_context": candidate.get("source_context") or ""',
+    ):
+        assert phrase in source
+
+
+def test_beta8_targets_report_context_and_deprioritizes_generic_repair() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    block = source.split("TARGETED_THEME_TERMS = (", 1)[1].split(")", 1)[0]
+    assert '"report"' in block
+    assert '"mowing"' in block
+    assert '"repair"' not in block
+    assert '("repair", 60)' in source
+    assert '"index-594ad42d.js"' in source
+    assert 'reasons.append("observed_report_asset")' in source
+
+
+def test_beta8_mower_set_arrow_regex_anchors_to_actual_native_call() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    patterns = _compiled_patterns(source)
+    pattern, flags = patterns["MOWER_SET_ARROW_WRAPPER_RE"]
+    regex = re.compile(pattern, flags)
+    sample = '$H=(e={})=>je.sendEncryptionData("handleDecrypt",e),l5=(e={})=>je.callNative("handleH5MowerSet",e),x=1'
+    matches = list(regex.finditer(sample))
+    assert len(matches) == 1
+    assert matches[0].group("name") == "l5"
+    assert matches[0].group("param") == "e"
+
+
+def test_beta8_disables_unproductive_source_map_fetches() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    assert "MAX_SOURCE_MAPS = 0" in source
+
+
+def test_beta8_remains_public_get_only_and_non_mutating() -> None:
+    source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    diagnostics = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
+    assert 'method="GET"' in source
+    assert '"mutation_calls_executed": False' in source
+    assert '"live_report_request_executed": False' in source
+    assert "client.call(" not in source
+    assert "Authorization" not in source
+    assert "Cookie" not in source
+    assert "0.4.3-beta8" in diagnostics
+    assert "bounded read-only public-H5 inspection" in diagnostics


### PR DESCRIPTION
## What changed

- Fixes beta7's zero-sized targeted queue by classifying high-value H5 candidates when their import/reference is discovered and reserving them from the broad queue.
- Treats `report` and `mowing` source context as targeted evidence alongside Parts maintenance/blade/knife/chassis/replacement/clean signals.
- De-prioritizes generic `repair` evidence because beta7 showed it mostly leads into unrelated after-sales workflows.
- Preserves a bounded source-context preview plus explicit `targeted_reason` for candidate/fetch diagnostics.
- Adds a temporary beta-only fallback for the already observed Mowing Records chunk `index-594ad42d.js` while keeping semantic routing authoritative.
- Anchors arrow-wrapper extraction directly to `callNative("handleH5MowerSet", ...)`, preventing the preceding decrypt wrapper from being misidentified.
- Disables public source-map probes after repeated 404-only results.

## Safety

Download diagnostics remains public HTTPS GET-only and non-mutating. Beta8 sends no account/mower identifiers to H5 and executes no report request, blade reset, Replacement done action, Clean now action, maintenance-mode command, cutting-height mutation or other mower command.

## Validation

The reusable remote builder passed compileall, diff checks and the complete test suite: 130/130 tests. It pushed `release/0.4.3-beta8` at `5a7844d2bea45479718505f180b6f050e53c1f4d`. The release diff contains exactly the six intended beta8 release files.