### PR TITLE
Prepare Navimower 0.4.3-beta11 error command discovery

### DIFF
--- a/.github/release-notes/0.4.3-beta11.md
+++ b/.github/release-notes/0.4.3-beta11.md
@@ -1,0 +1,27 @@
+title: Navimower 0.4.3-beta11
+
+Navimower 0.4.3-beta11 keeps the active-error investigation read-only and fixes beta10's full-fetch starvation so the strongest Clear and resume / Reboot Mower evidence is inspected first.
+
+### Error command discovery
+
+- Change the public-H5 crawler to a two-pass selection model: scan bounded 64 KiB prefixes first, score all observed evidence, and only then spend the 18 full-JavaScript fetch slots on the strongest candidates.
+- Give exact error-action labels, `handleH5MowerSet`, private command-shape terms, `clear + resume`, and `clear + restart/reboot` combinations explicit full-fetch weight.
+- Keep a temporary beta-only priority hint for the `index-594ad42d.js` multi-signal chunk observed in beta10 diagnostics so it cannot be starved again.
+- Expose the ordered full-fetch plan, score and reasons in Download diagnostics.
+
+### Native bridge recovery
+
+- Reuse the beta9-proven `handleH5MowerSet` wrapper parser in the focused error crawler.
+- Follow recovered mower-set wrappers through ES-module export/import aliases into fetched consumer chunks.
+- Capture bounded imported call-site context and argument previews so the native bridge payload can be compared with the known private-cloud command family without guessing a new command type.
+
+### Notification detail evidence
+
+- Preserve the response from the already-explicit `navimower.mark_notification_read` vendor detail action in memory for diagnostics work.
+- The trace is created only when the user explicitly performs that action; Download diagnostics does not call the notification detail endpoint by itself.
+
+### Safety
+
+- Error H5 discovery remains public, unauthenticated and GET-only.
+- No mower command is sent by Download diagnostics.
+- Beta11 does not guess or try unproven `c:behavior` types such as 4 or 5.

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -14,6 +14,7 @@ from .diagnostics_sanitize import sanitize
 from .private_cloud_region import private_cloud_region_diagnostics
 from .maintenance_h5_discovery import probe_maintenance_h5
 from .error_h5_discovery import probe_error_h5
+from .notification_actions import notification_detail_diagnostics
 from .state_semantics import error_transition_diagnostics
 from .resume import resume_command_diagnostics
 
@@ -30,8 +31,10 @@ async def async_get_config_entry_diagnostics(
     """Return a sanitized snapshot for Home Assistant Download diagnostics.
 
     Normal diagnostics use the config entry, coordinator state and caches.
-    0.4.3-beta10 pauses Maintenance/Mowing Reports discovery and focuses Download diagnostics on the active error,
-    MQTT-to-private arbitration evidence, raw vendor notification fields and public-H5 recovery of Clear and resume / Reboot Mower contracts.
+    0.4.3-beta11 keeps Maintenance/Mowing Reports discovery paused and focuses
+    Download diagnostics on active error command recovery, including two-pass
+    public-H5 evidence and any notification-detail response already produced by
+    an explicit user Mark notification as read action.
     """
     coordinator = (hass.data.get(DOMAIN) or {}).get(entry.entry_id)
     if coordinator is None:
@@ -100,7 +103,7 @@ async def async_get_config_entry_diagnostics(
         "read_only": True,
         "beta_only": True,
         "paused": True,
-        "reason": "0.4.3-beta10 diagnostics focus only on active error action recovery",
+        "reason": "0.4.3-beta11 diagnostics focus only on active error action recovery",
         "mutation_calls_executed": False,
     }
     try:
@@ -273,6 +276,7 @@ async def async_get_config_entry_diagnostics(
                 "vendor_notification_normalized_cache": deepcopy(
                     getattr(coordinator, "_notification_cache", None)
                 ),
+                "last_notification_detail": notification_detail_diagnostics(coordinator),
                 "command_discovery": deepcopy(error_command_discovery),
             }
         ),
@@ -306,8 +310,9 @@ async def async_get_config_entry_diagnostics(
         "mqtt_health": sanitize(deepcopy(mqtt_health)),
         "raw": sanitize(deepcopy(raw)),
         "notes": [
-            "0.4.3-beta10 pauses Maintenance/Mowing Reports discovery and focuses the beta-only public H5 probe on Clear and resume / Reboot Mower evidence for the active error.",
+            "0.4.3-beta11 keeps Maintenance/Mowing Reports discovery paused and uses two-pass public H5 selection for Clear and resume / Reboot Mower evidence.",
             "The error-action H5 inspection sends no account or mower identity and executes no mower command or notification-detail/read action.",
+            "Notification detail evidence is retained only after an explicit user Mark notification as read action; downloading diagnostics never calls the detail endpoint.",
             "Private-cloud account region/host routing is separate from Smart Home OAuth/MQTT; MQTT continues to use the broker details returned by the official API.",
             "Capability profile entries are positive observations or narrow proven model constraints. An empty/missing endpoint in one snapshot is not treated as unsupported.",
             "Resume diagnostics record only the explicit command trace already held in memory; downloading diagnostics never sends Resume.",

--- a/custom_components/navimower/error_h5_discovery.py
+++ b/custom_components/navimower/error_h5_discovery.py
@@ -10,6 +10,14 @@ import urllib.request
 
 from .api.regions import canonical_region
 from .diagnostics_sanitize import sanitize
+from .maintenance_h5_discovery import (
+    MOWER_SET_ARROW_WRAPPER_RE,
+    MOWER_SET_WRAPPER_RE,
+    _exported_aliases,
+    _import_aliases_for_source,
+    _named_callsite_contexts,
+    _wrapper_definitions,
+)
 
 MAX_HTML = 256 * 1024
 MAX_ROOT_JS = 2 * 1024 * 1024
@@ -54,6 +62,7 @@ BASE_TARGET_TERMS = (
     "c:behavior",
     "cmdCode",
     "cmd_code",
+    "handleH5MowerSet",
     "sendEncryptionData",
     "callNative",
 )
@@ -68,6 +77,7 @@ COMMAND_NEEDLES = (
     "cmdCode",
     "c:behavior",
     "/vehicle/set/send",
+    "handleH5MowerSet",
     "callNative",
     "sendEncryptionData",
 )
@@ -84,6 +94,11 @@ PRIORITY_FILENAME_TOKENS = (
     "native-",
     "state",
 )
+
+# Temporary beta-only fallback for the multi-signal lazy chunk observed in the
+# beta10 diagnostics sample. Semantic scoring remains authoritative and this
+# hint is removed once the Clear and resume contract is integrated.
+OBSERVED_ERROR_COMMAND_ASSETS = ("index-594ad42d.js",)
 
 # Current public-app roots observed during the 0.4.3 beta line. They are only
 # fallback GET targets if the live HTML does not enumerate them; no identity is sent.
@@ -137,7 +152,7 @@ def _fetch(url: str, limit: int) -> dict[str, Any]:
         url,
         headers={
             "Accept": "text/html,application/javascript,text/javascript,*/*;q=0.8",
-            "User-Agent": "Mozilla/5.0 NavimowerErrorDiagnostics/0.4.3-beta10",
+            "User-Agent": "Mozilla/5.0 NavimowerErrorDiagnostics/0.4.3-beta11",
         },
         method="GET",
     )
@@ -190,6 +205,70 @@ def _priority(url: str, source_context: str = "") -> int:
     if "cloud-acc.navimow.com" in url:
         score += 25
     return score
+
+
+def _full_fetch_priority(
+    candidate: dict[str, Any],
+    hits: list[str],
+    keys: list[dict[str, str]],
+    known_key_hits: list[str],
+    command_hits: list[str],
+) -> tuple[int, list[str]]:
+    """Rank full-fetch candidates only after all prefix evidence is known."""
+    score = int(candidate.get("priority") or 0)
+    reasons: list[str] = []
+    lower_hits = {value.lower() for value in hits}
+    lower_commands = {value.lower() for value in command_hits}
+    basename = urllib.parse.urlsplit(str(candidate.get("url") or "")).path.rsplit("/", 1)[-1].lower()
+
+    if basename in OBSERVED_ERROR_COMMAND_ASSETS:
+        score += 1600
+        reasons.append("observed_beta10_multi_signal_asset")
+    if keys or known_key_hits:
+        score += 900 + 120 * (len(keys) + len(known_key_hits))
+        reasons.append("translation_key_evidence")
+    if any(label.lower() in lower_hits for label in UI_LABELS):
+        score += 1400
+        reasons.append("exact_error_action_label")
+    if "handleh5mowerset" in lower_commands or "handleh5mowerset" in lower_hits:
+        score += 1300
+        reasons.append("mower_set_native_bridge")
+    if any(value in lower_commands for value in ("cmdcode", "c:behavior", "/vehicle/set/send")):
+        score += 1200
+        reasons.append("private_command_shape")
+    if "clear" in lower_commands and "resume" in lower_commands:
+        score += 1500
+        reasons.append("clear_plus_resume_prefix")
+    if "clear" in lower_commands and ({"restart", "reboot"} & lower_commands):
+        score += 800
+        reasons.append("clear_plus_restart_prefix")
+    if {"fault", "error"} & lower_commands and {"resume", "restart", "reboot"} & lower_commands:
+        score += 500
+        reasons.append("fault_recovery_terms")
+
+    specific_hits = {
+        "clearandresume",
+        "clear_and_resume",
+        "clearresume",
+        "resumeaftererror",
+        "clearerror",
+        "reseterror",
+        "clearfault",
+        "resetfault",
+        "rebootmower",
+        "reboot_mower",
+        "restartmower",
+        "restart_mower",
+    }
+    if specific_hits & lower_hits:
+        score += 1200
+        reasons.append("specific_action_symbol")
+
+    score += min(500, len(hits) * 70)
+    score += min(350, len(command_hits) * 45)
+    if not reasons and (hits or command_hits or int(candidate.get("priority") or 0) >= 180):
+        reasons.append("generic_prefix_evidence")
+    return score, list(dict.fromkeys(reasons))
 
 
 def _contexts(text: str, source: str, terms: list[str]) -> list[dict[str, Any]]:
@@ -269,6 +348,46 @@ def _js_references(text: str, source: str, hosts: set[str]) -> list[dict[str, An
     return rows
 
 
+def _mower_set_findings(text: str, source: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    definitions = _wrapper_definitions(
+        text,
+        source,
+        (("function", MOWER_SET_WRAPPER_RE), ("arrow", MOWER_SET_ARROW_WRAPPER_RE)),
+        "error_mower_set_wrapper_definition",
+    )
+    callsites = _named_callsite_contexts(
+        text,
+        source,
+        definitions,
+        "error_mower_set_direct_callsite",
+    )
+    exports: list[dict[str, Any]] = []
+    for definition in definitions:
+        local_name = str(definition.get("name") or "")
+        for exported_name in _exported_aliases(text, local_name):
+            row = {
+                "source": _safe_url(source),
+                "local_name": local_name,
+                "exported_name": exported_name,
+            }
+            if row not in exports:
+                exports.append(row)
+    return definitions, exports, callsites
+
+
+def _error_terms_nearby(context: str) -> list[str]:
+    lower = str(context or "").lower()
+    return [term for term in (*UI_LABELS, *COMMAND_NEEDLES) if term.lower() in lower]
+
+
+def _append_unique(rows: list[dict[str, Any]], additions: list[dict[str, Any]], limit: int) -> None:
+    for row in additions:
+        if row not in rows:
+            rows.append(row)
+        if len(rows) >= limit:
+            break
+
+
 def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> dict[str, Any]:
     """Inspect only public H5 assets for error-dialog command evidence."""
     host = _host(client)
@@ -307,6 +426,11 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
     command_contexts: list[dict[str, Any]] = []
     translation_keys: list[dict[str, str]] = []
     matched_terms: set[str] = set()
+    fetched_texts: dict[str, str] = {}
+    mower_set_wrapper_definitions: list[dict[str, Any]] = []
+    mower_set_export_aliases: list[dict[str, Any]] = []
+    mower_set_import_aliases: list[dict[str, Any]] = []
+    mower_set_callsite_contexts: list[dict[str, Any]] = []
 
     for url in root_urls[:10]:
         row = _fetch(url, MAX_ROOT_JS)
@@ -316,6 +440,7 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
         root_rows.append({**_public(row), "matched_terms": hits[:40]})
         if not row.get("ok") or not text:
             continue
+        fetched_texts[_safe_url(url)] = text
         for item in _contexts(text, url, hits):
             if item not in ui_contexts:
                 ui_contexts.append(item)
@@ -325,6 +450,10 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
         for item in _translation_keys(text):
             if item not in translation_keys:
                 translation_keys.append(item)
+        definitions, exports, callsites = _mower_set_findings(text, url)
+        _append_unique(mower_set_wrapper_definitions, definitions, 32)
+        _append_unique(mower_set_export_aliases, exports, 32)
+        _append_unique(mower_set_callsite_contexts, callsites, 64)
         for candidate in _js_references(text, url, allowed_hosts):
             existing = candidate_map.get(candidate["url"])
             if existing is None or candidate["priority"] > existing["priority"]:
@@ -350,11 +479,13 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
     prefix_successes = 0
     full_requests = 0
     full_successes = 0
-    matched_assets: list[dict[str, Any]] = []
     scanned: set[str] = set()
-    full_fetched: set[str] = set()
+    prefix_evidence: list[dict[str, Any]] = []
     index = 0
 
+    # Pass 1: collect bounded prefix evidence from the whole candidate queue. Do
+    # not spend any full-fetch slots yet; beta10 could exhaust the 18-slot quota
+    # before later, stronger multi-signal candidates were reached.
     while index < len(queue) and prefix_requests < MAX_PREFIX_REQUESTS:
         candidate = queue[index]
         index += 1
@@ -379,11 +510,14 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
         for item in keys:
             if item not in translation_keys:
                 translation_keys.append(item)
+        full_score, full_reasons = _full_fetch_priority(
+            candidate, hits, keys, known_key_hits, command_hits
+        )
         should_full = bool(
             hits
             or keys
             or known_key_hits
-            or (command_hits and int(candidate.get("priority") or 0) >= 55)
+            or command_hits
             or int(candidate.get("priority") or 0) >= 180
         )
         asset_row = {
@@ -397,49 +531,139 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
             "translation_keys": keys[:20],
             "known_translation_key_hits": known_key_hits[:20],
             "command_terms": command_hits[:30],
+            "full_fetch_score": full_score,
+            "full_fetch_reasons": full_reasons,
+            "full_fetch_eligible": should_full,
             "full_fetched": False,
         }
+        prefix_evidence.append(asset_row)
 
-        if should_full and full_requests < MAX_FULL_MATCHES:
-            full = _fetch(url, MAX_FULL_JS)
-            full_requests += 1
-            full_fetched.add(url)
-            full_text = str(full.get("_text") or "")
-            if full.get("ok"):
-                full_successes += 1
-            full_hits = [term for term in target_terms if term.lower() in full_text.lower()]
-            full_keys = _translation_keys(full_text) if full_text else []
-            for item in full_keys:
-                if item not in translation_keys:
-                    translation_keys.append(item)
-            key_terms = [item["key"] for item in translation_keys if item.get("key")]
-            context_terms = list(dict.fromkeys([*full_hits, *key_terms, *COMMAND_NEEDLES]))
-            contexts = _contexts(full_text, url, [term for term in context_terms if term.lower() in full_text.lower()])
-            for context in contexts:
-                if context["term"] in COMMAND_NEEDLES or any(
-                    marker.lower() in context["context"].lower()
-                    for marker in ("cmdcode", "/vehicle/set/send", "callnative", "sendencryptiondata", "reboot", "clear")
-                ):
-                    if context not in command_contexts and len(command_contexts) < MAX_CONTEXTS:
-                        command_contexts.append(context)
-                elif context not in ui_contexts and len(ui_contexts) < MAX_CONTEXTS:
-                    ui_contexts.append(context)
-            for child in _js_references(full_text, url, allowed_hosts):
-                if child["url"] not in candidate_map:
-                    candidate_map[child["url"]] = child
-                    queue.append(child)
-            asset_row.update(
-                {
-                    "full_fetched": True,
-                    "full_http_status": full.get("http_status"),
-                    "full_length": full.get("body_length_read"),
-                    "full_sha256": full.get("body_sha256"),
-                    "full_matched_terms": full_hits[:50],
-                    "full_translation_keys": full_keys[:20],
-                }
+        if text:
+            for child in _js_references(text, url, allowed_hosts):
+                if child["url"] in candidate_map:
+                    continue
+                candidate_map[child["url"]] = child
+                queue.append(child)
+
+    full_plan = sorted(
+        [row for row in prefix_evidence if row.get("full_fetch_eligible")],
+        key=lambda row: (
+            -int(row.get("full_fetch_score") or 0),
+            -int(row.get("priority") or 0),
+            str(row.get("url") or ""),
+        ),
+    )
+    asset_by_url = {str(row.get("url") or ""): row for row in prefix_evidence}
+
+    # Pass 2: spend the full-fetch budget only on the strongest prefix evidence.
+    for rank, planned in enumerate(full_plan[:MAX_FULL_MATCHES], start=1):
+        url = str(planned.get("url") or "")
+        if not url:
+            continue
+        full = _fetch(url, MAX_FULL_JS)
+        full_requests += 1
+        full_text = str(full.get("_text") or "")
+        if full.get("ok"):
+            full_successes += 1
+            fetched_texts[_safe_url(url)] = full_text
+        full_hits = [term for term in target_terms if term.lower() in full_text.lower()]
+        full_keys = _translation_keys(full_text) if full_text else []
+        for item in full_keys:
+            if item not in translation_keys:
+                translation_keys.append(item)
+        key_terms = [item["key"] for item in translation_keys if item.get("key")]
+        context_terms = list(dict.fromkeys([*full_hits, *key_terms, *COMMAND_NEEDLES]))
+        contexts = _contexts(
+            full_text,
+            url,
+            [term for term in context_terms if term.lower() in full_text.lower()],
+        )
+        for context in contexts:
+            if context["term"] in COMMAND_NEEDLES or any(
+                marker.lower() in context["context"].lower()
+                for marker in (
+                    "cmdcode",
+                    "/vehicle/set/send",
+                    "handleh5mowerset",
+                    "callnative",
+                    "sendencryptiondata",
+                    "reboot",
+                    "clear",
+                )
+            ):
+                if context not in command_contexts and len(command_contexts) < MAX_CONTEXTS:
+                    command_contexts.append(context)
+            elif context not in ui_contexts and len(ui_contexts) < MAX_CONTEXTS:
+                ui_contexts.append(context)
+
+        definitions, exports, callsites = _mower_set_findings(full_text, url)
+        _append_unique(mower_set_wrapper_definitions, definitions, 32)
+        _append_unique(mower_set_export_aliases, exports, 32)
+        _append_unique(mower_set_callsite_contexts, callsites, 64)
+
+        asset_row = asset_by_url[url]
+        asset_row.update(
+            {
+                "full_fetch_rank": rank,
+                "full_fetched": True,
+                "full_http_status": full.get("http_status"),
+                "full_length": full.get("body_length_read"),
+                "full_sha256": full.get("body_sha256"),
+                "full_matched_terms": full_hits[:50],
+                "full_translation_keys": full_keys[:20],
+            }
+        )
+
+    # Recover the beta9-proven handleH5MowerSet wrapper across ES-module
+    # export/import aliases and capture the actual imported call arguments.
+    for export_row in list(mower_set_export_aliases):
+        source_url = str(export_row.get("source") or "")
+        exported_name = str(export_row.get("exported_name") or "")
+        if not source_url or not exported_name:
+            continue
+        for consumer_url, consumer_text in fetched_texts.items():
+            if consumer_url == source_url:
+                continue
+            imports = _import_aliases_for_source(
+                consumer_text,
+                consumer_url,
+                source_url,
+                [exported_name],
             )
-        if hits or keys or known_key_hits or command_hits or asset_row["full_fetched"]:
-            matched_assets.append(asset_row)
+            for import_row in imports:
+                enriched_import = {"source": consumer_url, **import_row}
+                _append_unique(mower_set_import_aliases, [enriched_import], 48)
+                local_name = str(import_row.get("local_name") or "")
+                if not local_name:
+                    continue
+                synthetic_definition = {
+                    "name": local_name,
+                    "endpoint": None,
+                    "definition_offset": -10_000,
+                }
+                imported_calls = _named_callsite_contexts(
+                    consumer_text,
+                    consumer_url,
+                    [synthetic_definition],
+                    "error_mower_set_imported_callsite",
+                )
+                for callsite in imported_calls:
+                    callsite["exported_name"] = exported_name
+                    callsite["imported_from"] = source_url
+                    callsite["error_terms_nearby"] = _error_terms_nearby(
+                        str(callsite.get("context") or "")
+                    )
+                _append_unique(mower_set_callsite_contexts, imported_calls, 64)
+
+    matched_assets = [
+        row
+        for row in prefix_evidence
+        if row.get("matched_terms")
+        or row.get("translation_keys")
+        or row.get("known_translation_key_hits")
+        or row.get("command_terms")
+        or row.get("full_fetched")
+    ]
 
     return {
         "ok": True,
@@ -459,6 +683,20 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
             "max_full_matches": MAX_FULL_MATCHES,
             "max_full_js": MAX_FULL_JS,
         },
+        "selection": {
+            "mode": "two_pass_prefix_score_then_full",
+            "full_fetch_candidate_count": len(full_plan),
+            "full_fetch_plan": [
+                {
+                    "url": row.get("url"),
+                    "score": row.get("full_fetch_score"),
+                    "reasons": row.get("full_fetch_reasons"),
+                    "command_terms": row.get("command_terms"),
+                    "matched_terms": row.get("matched_terms"),
+                }
+                for row in full_plan[: min(30, len(full_plan))]
+            ],
+        },
         "pages": pages,
         "root_scripts": root_rows,
         "candidate_count": len(candidate_map),
@@ -468,13 +706,17 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
         "full_success_count": full_successes,
         "matched_terms": sorted(matched_terms),
         "translation_keys": translation_keys[:40],
-        "matched_assets": matched_assets[:60],
+        "matched_assets": matched_assets[:80],
         "ui_contexts": ui_contexts[:MAX_CONTEXTS],
         "command_contexts": command_contexts[:MAX_CONTEXTS],
+        "mower_set_wrapper_definitions": mower_set_wrapper_definitions[:32],
+        "mower_set_export_aliases": mower_set_export_aliases[:32],
+        "mower_set_import_aliases": mower_set_import_aliases[:48],
+        "mower_set_callsite_contexts": mower_set_callsite_contexts[:64],
         "note": (
-            "Public GET-only discovery searches the current error code/title plus the exact "
-            "Clear and resume and Reboot Mower UI labels, their translation keys, command "
-            "wrappers and nearby request shapes. It never calls the private mower command "
-            "endpoint or the notification detail/read endpoint."
+            "Public GET-only discovery now scores all bounded prefix evidence before using "
+            "full-fetch slots, then follows the beta9-proven handleH5MowerSet wrapper through "
+            "ES-module aliases to bounded call arguments. It never calls the private mower "
+            "command endpoint or the notification detail/read endpoint."
         ),
     }

--- a/custom_components/navimower/error_h5_discovery.py
+++ b/custom_components/navimower/error_h5_discovery.py
@@ -223,7 +223,7 @@ def _full_fetch_priority(
 
     if basename in OBSERVED_ERROR_COMMAND_ASSETS:
         score += 1600
-        reasons.append("observed_beta10_multi_signal_asset")
+        reasons.append("observed_prior_multi_signal_asset")
     if keys or known_key_hits:
         score += 900 + 120 * (len(keys) + len(known_key_hits))
         reasons.append("translation_key_evidence")

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta10"
+  "version": "0.4.3-beta11"
 }

--- a/custom_components/navimower/notification_actions.py
+++ b/custom_components/navimower/notification_actions.py
@@ -7,6 +7,8 @@ persistent notification Store; they are never sent to a vendor message route.
 """
 from __future__ import annotations
 
+from copy import deepcopy
+from datetime import UTC, datetime
 from typing import Any
 
 from .notification_center import LOCAL_NOTIFICATION_PREFIX
@@ -19,6 +21,12 @@ _DEVICE_MESSAGE_DETAIL_TYPE = 2
 def _invalidate_notification_poll(coordinator: Any) -> None:
     """Make the next Device-feed refresh bypass the normal 60-second TTL."""
     coordinator._notification_last_attempt_mono = None  # noqa: SLF001
+
+
+def notification_detail_diagnostics(coordinator: Any) -> dict[str, Any] | None:
+    """Return the last explicit vendor notification-detail trace, if any."""
+    trace = getattr(coordinator, "_last_notification_detail_trace", None)
+    return deepcopy(trace) if isinstance(trace, dict) else None
 
 
 async def _async_vendor_call_and_refresh(
@@ -60,17 +68,35 @@ async def async_mark_notification_read(
             raise ValueError("Navimower local notification is no longer retained")
         return {"origin": "navimower", "message_id": message_id, "read": True}
 
-    # Vendor message IDs continue through the app's encrypted detail route. The
-    # following Device-feed refresh remains authoritative for vendor read state.
-    return await _async_vendor_call_and_refresh(
-        coordinator,
-        _NOTIFICATION_DETAIL_PATH,
-        {
-            "message_id": message_id,
-            "type": _DEVICE_MESSAGE_DETAIL_TYPE,
-            "vehicle_sn": str(coordinator.sn),
-        },
-    )
+    # Vendor message IDs continue through the app's encrypted detail route. Beta11
+    # records the response from this already-explicit user action in memory so a
+    # later Download diagnostics can inspect the real detail contract without
+    # issuing a hidden read/detail request itself.
+    trace: dict[str, Any] = {
+        "requested_at": datetime.now(UTC).isoformat(),
+        "path": _NOTIFICATION_DETAIL_PATH,
+        "message_id": message_id,
+        "type": _DEVICE_MESSAGE_DETAIL_TYPE,
+        "explicit_user_action": True,
+        "request_succeeded": False,
+    }
+    coordinator._last_notification_detail_trace = trace  # noqa: SLF001
+    try:
+        result = await _async_vendor_call_and_refresh(
+            coordinator,
+            _NOTIFICATION_DETAIL_PATH,
+            {
+                "message_id": message_id,
+                "type": _DEVICE_MESSAGE_DETAIL_TYPE,
+                "vehicle_sn": str(coordinator.sn),
+            },
+        )
+    except Exception as err:
+        trace["error"] = f"{type(err).__name__}: {err}"
+        raise
+    trace["request_succeeded"] = True
+    trace["response"] = deepcopy(result)
+    return result
 
 
 async def async_mark_all_notifications_read(coordinator: Any) -> Any:

--- a/tests/test_v043_beta10.py
+++ b/tests/test_v043_beta10.py
@@ -1,21 +1,18 @@
-"""Regression contracts for Navimower 0.4.3-beta10 error diagnostics."""
+"""Regression contracts retained from Navimower 0.4.3-beta10 error diagnostics."""
 from __future__ import annotations
 
 import ast
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta10_release_identity() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta10"
+def test_beta10_release_artifacts_remain_in_history() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta10.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta10")
     changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
-    assert changelog.startswith("# Changelog\n\n## 0.4.3-beta10")
+    assert "## 0.4.3-beta10" in changelog
 
 
 def test_beta10_error_sensor_is_cloud_canonical() -> None:
@@ -48,7 +45,7 @@ def test_beta10_diagnostics_focuses_only_error_action_discovery() -> None:
     assert "probe_maintenance_h5, coordinator.client" not in diagnostics
 
 
-def test_beta10_error_h5_probe_is_strictly_read_only() -> None:
+def test_beta10_error_h5_probe_remains_strictly_read_only() -> None:
     source = (COMPONENT / "error_h5_discovery.py").read_text(encoding="utf-8")
     ast.parse(source)
     for phrase in (

--- a/tests/test_v043_beta11.py
+++ b/tests/test_v043_beta11.py
@@ -1,0 +1,73 @@
+"""Regression contracts for Navimower 0.4.3-beta11 error command recovery."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta11_release_identity() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta11"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta11.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta11")
+
+
+def test_beta11_error_discovery_uses_two_pass_full_fetch_selection() -> None:
+    source = (COMPONENT / "error_h5_discovery.py").read_text(encoding="utf-8")
+    ast.parse(source)
+    for phrase in (
+        "def _full_fetch_priority",
+        "Pass 1: collect bounded prefix evidence",
+        "Pass 2: spend the full-fetch budget",
+        '"mode": "two_pass_prefix_score_then_full"',
+        '"full_fetch_plan"',
+        '"full_fetch_score"',
+        '"full_fetch_reasons"',
+        'OBSERVED_ERROR_COMMAND_ASSETS = ("index-594ad42d.js",)',
+        '"clear_plus_resume_prefix"',
+        '"mower_set_native_bridge"',
+    ):
+        assert phrase in source
+
+
+def test_beta11_recovers_handle_h5_mower_set_callsites() -> None:
+    source = (COMPONENT / "error_h5_discovery.py").read_text(encoding="utf-8")
+    for phrase in (
+        "MOWER_SET_ARROW_WRAPPER_RE",
+        "MOWER_SET_WRAPPER_RE",
+        "_exported_aliases",
+        "_import_aliases_for_source",
+        "_named_callsite_contexts",
+        '"mower_set_wrapper_definitions"',
+        '"mower_set_export_aliases"',
+        '"mower_set_import_aliases"',
+        '"mower_set_callsite_contexts"',
+        '"argument_preview"',
+    ):
+        assert phrase in source or phrase == '"argument_preview"'
+    maintenance = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    assert '"argument_preview": argument_preview[:1800]' in maintenance
+
+
+def test_beta11_notification_detail_trace_requires_explicit_action() -> None:
+    source = (COMPONENT / "notification_actions.py").read_text(encoding="utf-8")
+    ast.parse(source)
+    assert '"explicit_user_action": True' in source
+    assert 'coordinator._last_notification_detail_trace = trace' in source
+    assert 'trace["response"] = deepcopy(result)' in source
+    assert '"/mowerbot/user/message/getmessageDetailResp"' in source
+
+
+def test_beta11_h5_probe_stays_non_mutating() -> None:
+    source = (COMPONENT / "error_h5_discovery.py").read_text(encoding="utf-8")
+    assert 'method="GET"' in source
+    assert '"mutation_calls_executed": False' in source
+    assert '"live_command_call_executed": False' in source
+    assert '"notification_detail_call_executed": False' in source
+    assert "client.call(" not in source
+    assert "Authorization" not in source
+    assert "Cookie" not in source


### PR DESCRIPTION
## What changed

- Replace beta10's eager full-fetch allocation with a two-pass prefix-score-then-full strategy so later high-signal assets cannot be starved by the 18 full-fetch limit.
- Prioritize the beta10-observed `index-594ad42d.js` multi-signal chunk and explicit Clear/resume/reboot/native-command evidence.
- Reuse the beta9 `handleH5MowerSet` wrapper and ES-module alias recovery to capture bounded imported call-site argument previews.
- Preserve the response from an explicit vendor `mark_notification_read` detail action in memory and expose the sanitized trace through Download diagnostics without making a hidden detail request.
- Bump the manifest to `0.4.3-beta11`, retain beta10 regression history, and add beta11 release notes/tests.

## Why

Beta10 scanned the useful `index-594ad42d.js` prefix and found `clear`, `resume`, `restart`, `fault`, and `error`, but the full-fetch budget had already been consumed. Beta11 ranks all bounded prefix evidence before spending full-fetch slots.

## Safety

- Public H5 discovery remains unauthenticated GET-only.
- Download diagnostics sends no mower command and does not call the notification-detail endpoint.
- No unproven `c:behavior` type is tried.

## Validation

- `error_h5_discovery.py` was syntax-compiled locally in the tool environment.
- Repository CI should run on this draft PR; results will be inspected before promoting a release branch.
