### PR TITLE
Navimower 0.4.3-beta12 bounded error diagnostics

### DIFF
--- a/.github/release-notes/0.4.3-beta12.md
+++ b/.github/release-notes/0.4.3-beta12.md
@@ -1,0 +1,23 @@
+title: Navimower 0.4.3-beta12
+
+Navimower 0.4.3-beta12 fixes the beta11 Download diagnostics stall while preserving focused read-only recovery of the active error's Clear and resume / Reboot Mower command contracts.
+
+### Fixed
+
+- Bound the public-H5 error-action probe to a 24-second wall-clock budget with a 2.5-second per-request ceiling.
+- Reduce generic discovery from up to 180 prefix requests and 18 full JavaScript fetches to at most 32 prefixes and 6 full fetches, plus four root-script requests.
+- Add a 30-second Home Assistant diagnostics timeout as a final fail-safe so the download returns even if an unexpected H5/network operation stalls.
+- Return partial discovery evidence with explicit elapsed/budget-exhausted diagnostics instead of withholding the entire diagnostics file.
+- Prioritize the previously observed `index-594ad42d.js` error-command asset and native/request support chunks before generic lazy assets.
+- Limit the `Latest notification` sensor's `recent` attribute to five entries while keeping the full bounded vendor/local history internally and in Download diagnostics, preventing Recorder's 16 KiB attribute warning.
+
+### Preserved
+
+- Error remains private-cloud canonical; MQTT Error transitions are triggers for cloud refresh rather than display values.
+- Explicit user notification-detail traces remain available to diagnostics.
+- Maintenance and Mowing Reports discovery remains paused while the beta line focuses on active error recovery commands.
+
+### Safety
+
+- Error H5 discovery remains public, unauthenticated and GET-only.
+- Download diagnostics sends no Clear and resume, Reboot Mower, Resume, notification-detail/read or other mower command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.4.3-beta12
+
+Bounded active-error diagnostics and Recorder-safe notification attributes.
+
+### Fixed
+
+- Bound Clear and resume / Reboot Mower public-H5 discovery by wall clock, per-request timeout and smaller request budgets so Download diagnostics returns reliably.
+- Prioritize proven error-command assets before generic lazy chunks and retain partial evidence when the discovery budget expires.
+- Add an outer Home Assistant diagnostics timeout as a final fail-safe.
+- Limit the Latest notification entity's recent attribute to five entries to stay below Recorder's 16 KiB state-attribute limit while retaining full internal/diagnostic history.
+
+### Safety
+
+- Error-action discovery remains public HTTPS GET-only and executes no mower or notification-detail command.
+
+## 0.4.3-beta11
+
+Two-pass active-error command discovery and explicit notification-detail trace retention.
+
+### Changed
+
+- Score bounded public-H5 prefix evidence before spending full-fetch slots so strong Clear and resume / Reboot Mower candidates cannot be starved by earlier generic assets.
+- Reuse the proven handleH5MowerSet wrapper/export/import tracing to capture bounded command-call argument evidence.
+- Preserve the response from an explicit user Mark notification as read action for later diagnostics without making a hidden detail request.
+
+### Safety
+
+- Discovery remained public, unauthenticated and GET-only and did not guess or execute unproven mower commands.
+
 ## 0.4.3-beta10
 
 Focused active-error arbitration and command-contract diagnostics.

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -1,6 +1,7 @@
 """Native Home Assistant diagnostics for Navimower."""
 from __future__ import annotations
 
+import asyncio
 from copy import deepcopy
 from datetime import UTC, datetime
 from typing import Any
@@ -19,6 +20,9 @@ from .state_semantics import error_transition_diagnostics
 from .resume import resume_command_diagnostics
 
 
+ERROR_DISCOVERY_TIMEOUT_SECONDS = 30.0
+
+
 def _selected(data: dict[str, Any], keys: tuple[str, ...]) -> dict[str, Any]:
     """Return a compact copy of selected coordinator fields."""
     return {key: deepcopy(data.get(key)) for key in keys if key in data}
@@ -31,10 +35,10 @@ async def async_get_config_entry_diagnostics(
     """Return a sanitized snapshot for Home Assistant Download diagnostics.
 
     Normal diagnostics use the config entry, coordinator state and caches.
-    0.4.3-beta11 keeps Maintenance/Mowing Reports discovery paused and focuses
-    Download diagnostics on active error command recovery, including two-pass
-    public-H5 evidence and any notification-detail response already produced by
-    an explicit user Mark notification as read action.
+    0.4.3-beta12 keeps Maintenance/Mowing Reports discovery paused and makes
+    active-error command recovery diagnostics-safe: public-H5 inspection has a
+    strict wall-clock budget plus an outer Home Assistant timeout, while partial
+    evidence and explicit notification-detail traces remain downloadable.
     """
     coordinator = (hass.data.get(DOMAIN) or {}).get(entry.entry_id)
     if coordinator is None:
@@ -103,16 +107,30 @@ async def async_get_config_entry_diagnostics(
         "read_only": True,
         "beta_only": True,
         "paused": True,
-        "reason": "0.4.3-beta11 diagnostics focus only on active error action recovery",
+        "reason": "0.4.3-beta12 diagnostics focus only on bounded active error action recovery",
         "mutation_calls_executed": False,
     }
     try:
-        error_command_discovery = await hass.async_add_executor_job(
-            probe_error_h5,
-            coordinator.client,
-            str(data.get("error_code") or ""),
-            str(data.get("error_title") or data.get("error_text") or ""),
-        )
+        async with asyncio.timeout(ERROR_DISCOVERY_TIMEOUT_SECONDS):
+            error_command_discovery = await hass.async_add_executor_job(
+                probe_error_h5,
+                coordinator.client,
+                str(data.get("error_code") or ""),
+                str(data.get("error_title") or data.get("error_text") or ""),
+            )
+    except TimeoutError:
+        error_command_discovery = {
+            "ok": False,
+            "read_only": True,
+            "beta_only": True,
+            "timed_out": True,
+            "timeout_seconds": ERROR_DISCOVERY_TIMEOUT_SECONDS,
+            "mutation_calls_executed": False,
+            "live_command_call_executed": False,
+            "notification_detail_call_executed": False,
+            "error_type": "TimeoutError",
+            "error": "public H5 error discovery exceeded the diagnostics timeout",
+        }
     except Exception as err:  # noqa: BLE001 - optional beta diagnostics discovery
         error_command_discovery = {
             "ok": False,
@@ -310,7 +328,7 @@ async def async_get_config_entry_diagnostics(
         "mqtt_health": sanitize(deepcopy(mqtt_health)),
         "raw": sanitize(deepcopy(raw)),
         "notes": [
-            "0.4.3-beta11 keeps Maintenance/Mowing Reports discovery paused and uses two-pass public H5 selection for Clear and resume / Reboot Mower evidence.",
+            "0.4.3-beta12 keeps Maintenance/Mowing Reports discovery paused and bounds Clear and resume / Reboot Mower public-H5 recovery so Download diagnostics always returns partial evidence instead of waiting on the crawler.",
             "The error-action H5 inspection sends no account or mower identity and executes no mower command or notification-detail/read action.",
             "Notification detail evidence is retained only after an explicit user Mark notification as read action; downloading diagnostics never calls the detail endpoint.",
             "Private-cloud account region/host routing is separate from Smart Home OAuth/MQTT; MQTT continues to use the broker details returned by the official API.",

--- a/custom_components/navimower/error_h5_discovery.py
+++ b/custom_components/navimower/error_h5_discovery.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import time
 from typing import Any
 import urllib.error
 import urllib.parse
@@ -20,14 +21,17 @@ from .maintenance_h5_discovery import (
 )
 
 MAX_HTML = 256 * 1024
-MAX_ROOT_JS = 2 * 1024 * 1024
+MAX_ROOT_JS = 1024 * 1024
 PREFIX_BYTES = 64 * 1024
-MAX_PREFIX_REQUESTS = 180
-MAX_FULL_MATCHES = 18
+MAX_ROOT_REQUESTS = 4
+MAX_PREFIX_REQUESTS = 32
+MAX_FULL_MATCHES = 6
 MAX_FULL_JS = 2 * 1024 * 1024
 MAX_CONTEXTS = 80
 CONTEXT_RADIUS = 1800
-TIMEOUT = 5
+MAX_PROBE_SECONDS = 24.0
+TIMEOUT = 2.5
+MIN_REQUEST_TIMEOUT = 0.2
 
 SCRIPT_RE = re.compile(r"<script\b[^>]*\bsrc\s*=\s*[\"']([^\"']+)[\"']", re.I)
 JS_RE = re.compile(r"[\"']([^\"'\r\n]{1,420}\.js(?:\?[^\"'\r\n]{0,120})?)[\"']", re.I)
@@ -147,17 +151,17 @@ def _resolve(base_url: str, value: str) -> str:
     return _safe_url(urllib.parse.urljoin(base_url, raw))
 
 
-def _fetch(url: str, limit: int) -> dict[str, Any]:
+def _fetch(url: str, limit: int, timeout: float = TIMEOUT) -> dict[str, Any]:
     request = urllib.request.Request(
         url,
         headers={
             "Accept": "text/html,application/javascript,text/javascript,*/*;q=0.8",
-            "User-Agent": "Mozilla/5.0 NavimowerErrorDiagnostics/0.4.3-beta11",
+            "User-Agent": "Mozilla/5.0 NavimowerErrorDiagnostics/0.4.3-beta12",
         },
         method="GET",
     )
     try:
-        with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+        with urllib.request.urlopen(request, timeout=max(MIN_REQUEST_TIMEOUT, float(timeout))) as response:
             raw = response.read(limit + 1)
             status = int(getattr(response, "status", 200))
             content_type = str(response.headers.get("Content-Type", ""))
@@ -187,6 +191,19 @@ def _fetch(url: str, limit: int) -> dict[str, Any]:
     }
 
 
+def _deadline_fetch(url: str, limit: int, deadline: float) -> dict[str, Any]:
+    """Fetch without starting work after the diagnostics wall-clock budget."""
+    remaining = deadline - time.monotonic()
+    if remaining <= MIN_REQUEST_TIMEOUT:
+        return {
+            "ok": False,
+            "url": _safe_url(url),
+            "budget_exhausted": True,
+            "transport_error": "wall_clock_budget_exhausted",
+        }
+    return _fetch(url, limit, timeout=min(TIMEOUT, remaining))
+
+
 def _public(row: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in row.items() if key != "_text"}
 
@@ -205,6 +222,21 @@ def _priority(url: str, source_context: str = "") -> int:
     if "cloud-acc.navimow.com" in url:
         score += 25
     return score
+
+
+def _candidate_queue_key(item: dict[str, Any]) -> tuple[Any, ...]:
+    """Put proven error-command and native/request assets ahead of generic chunks."""
+    url = str(item.get("url") or "")
+    basename = urllib.parse.urlsplit(url).path.rsplit("/", 1)[-1].lower()
+    observed_rank = 0 if basename in OBSERVED_ERROR_COMMAND_ASSETS else 1
+    support_rank = 0 if url in OBSERVED_PUBLIC_SUPPORT_SCRIPTS else 1
+    return (
+        observed_rank,
+        support_rank,
+        -int(item.get("priority") or 0),
+        int(item.get("order") or 0),
+        url,
+    )
 
 
 def _full_fetch_priority(
@@ -389,12 +421,24 @@ def _append_unique(rows: list[dict[str, Any]], additions: list[dict[str, Any]], 
 
 
 def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> dict[str, Any]:
-    """Inspect only public H5 assets for error-dialog command evidence."""
+    """Inspect public H5 error-action assets within a strict diagnostics deadline."""
+    started = time.monotonic()
+    deadline = started + MAX_PROBE_SECONDS
+    budget_exhausted = False
+    stop_reason: str | None = None
+
+    def fetch_bounded(url: str, limit: int) -> dict[str, Any]:
+        nonlocal budget_exhausted, stop_reason
+        row = _deadline_fetch(url, limit, deadline)
+        if row.get("budget_exhausted") or time.monotonic() >= deadline:
+            budget_exhausted = True
+            stop_reason = stop_reason or "wall_clock_budget"
+        return row
+
     host = _host(client)
     allowed_hosts = {urllib.parse.urlsplit(host).netloc, "cloud-acc.navimow.com"}
     entry_urls = (
         f"{host}/old/",
-        f"{host}/maintenance/",
         "https://cloud-acc.navimow.com/navimow/",
     )
     dynamic_terms = [term for term in (str(error_code or ""), str(error_title or "")) if term]
@@ -403,7 +447,9 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
     pages: list[dict[str, Any]] = []
     root_urls: list[str] = []
     for url in entry_urls:
-        row = _fetch(url, MAX_HTML)
+        if budget_exhausted:
+            break
+        row = fetch_bounded(url, MAX_HTML)
         text = str(row.get("_text") or "")
         scripts: list[str] = []
         if text:
@@ -432,8 +478,10 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
     mower_set_import_aliases: list[dict[str, Any]] = []
     mower_set_callsite_contexts: list[dict[str, Any]] = []
 
-    for url in root_urls[:10]:
-        row = _fetch(url, MAX_ROOT_JS)
+    for url in root_urls[:MAX_ROOT_REQUESTS]:
+        if budget_exhausted:
+            break
+        row = fetch_bounded(url, MAX_ROOT_JS)
         text = str(row.get("_text") or "")
         hits = [term for term in target_terms if term.lower() in text.lower()]
         matched_terms.update(hits)
@@ -471,10 +519,20 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
             },
         )
 
-    queue = sorted(
-        candidate_map.values(),
-        key=lambda item: (-int(item.get("priority") or 0), int(item.get("order") or 0), str(item["url"])),
-    )
+    for basename in OBSERVED_ERROR_COMMAND_ASSETS:
+        observed_url = f"{host}/old/assets/{basename}"
+        candidate_map.setdefault(
+            observed_url,
+            {
+                "url": observed_url,
+                "source": "observed_error_command_asset",
+                "order": -2,
+                "source_context": "temporary proven error-command asset fallback",
+                "priority": _priority(observed_url) + 5000,
+            },
+        )
+
+    queue = sorted(candidate_map.values(), key=_candidate_queue_key)
     prefix_requests = 0
     prefix_successes = 0
     full_requests = 0
@@ -486,14 +544,14 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
     # Pass 1: collect bounded prefix evidence from the whole candidate queue. Do
     # not spend any full-fetch slots yet; beta10 could exhaust the 18-slot quota
     # before later, stronger multi-signal candidates were reached.
-    while index < len(queue) and prefix_requests < MAX_PREFIX_REQUESTS:
+    while index < len(queue) and prefix_requests < MAX_PREFIX_REQUESTS and not budget_exhausted:
         candidate = queue[index]
         index += 1
         url = str(candidate["url"])
         if url in scanned or not _allowed(url, allowed_hosts):
             continue
         scanned.add(url)
-        prefix = _fetch(url, PREFIX_BYTES)
+        prefix = fetch_bounded(url, PREFIX_BYTES)
         prefix_requests += 1
         text = str(prefix.get("_text") or "")
         if prefix.get("ok"):
@@ -544,6 +602,7 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
                     continue
                 candidate_map[child["url"]] = child
                 queue.append(child)
+            queue[index:] = sorted(queue[index:], key=_candidate_queue_key)
 
     full_plan = sorted(
         [row for row in prefix_evidence if row.get("full_fetch_eligible")],
@@ -557,10 +616,12 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
 
     # Pass 2: spend the full-fetch budget only on the strongest prefix evidence.
     for rank, planned in enumerate(full_plan[:MAX_FULL_MATCHES], start=1):
+        if budget_exhausted:
+            break
         url = str(planned.get("url") or "")
         if not url:
             continue
-        full = _fetch(url, MAX_FULL_JS)
+        full = fetch_bounded(url, MAX_FULL_JS)
         full_requests += 1
         full_text = str(full.get("_text") or "")
         if full.get("ok"):
@@ -679,12 +740,16 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
         "allowed_hosts": sorted(allowed_hosts),
         "limits": {
             "prefix_bytes": PREFIX_BYTES,
+            "max_root_requests": MAX_ROOT_REQUESTS,
             "max_prefix_requests": MAX_PREFIX_REQUESTS,
             "max_full_matches": MAX_FULL_MATCHES,
             "max_full_js": MAX_FULL_JS,
+            "max_probe_seconds": MAX_PROBE_SECONDS,
+            "per_request_timeout_seconds": TIMEOUT,
         },
         "selection": {
             "mode": "two_pass_prefix_score_then_full",
+            "bounded_by_wall_clock": True,
             "full_fetch_candidate_count": len(full_plan),
             "full_fetch_plan": [
                 {
@@ -696,6 +761,12 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
                 }
                 for row in full_plan[: min(30, len(full_plan))]
             ],
+        },
+        "execution": {
+            "wall_clock_budget_seconds": MAX_PROBE_SECONDS,
+            "elapsed_seconds": round(time.monotonic() - started, 3),
+            "budget_exhausted": budget_exhausted,
+            "stop_reason": stop_reason,
         },
         "pages": pages,
         "root_scripts": root_rows,
@@ -714,9 +785,9 @@ def probe_error_h5(client: Any, error_code: str = "", error_title: str = "") -> 
         "mower_set_import_aliases": mower_set_import_aliases[:48],
         "mower_set_callsite_contexts": mower_set_callsite_contexts[:64],
         "note": (
-            "Public GET-only discovery now scores all bounded prefix evidence before using "
-            "full-fetch slots, then follows the beta9-proven handleH5MowerSet wrapper through "
-            "ES-module aliases to bounded call arguments. It never calls the private mower "
-            "command endpoint or the notification detail/read endpoint."
+            "Public GET-only discovery prioritizes proven error-command assets and keeps "
+            "two-pass prefix/full-fetch recovery inside a strict wall-clock budget. Partial "
+            "evidence is returned when the budget is exhausted. It never calls the private "
+            "mower command endpoint or the notification detail/read endpoint."
         ),
     }

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta11"
+  "version": "0.4.3-beta12"
 }

--- a/custom_components/navimower/notification_feed.py
+++ b/custom_components/navimower/notification_feed.py
@@ -31,7 +31,8 @@ from .notification_center import (
 _NOTIFICATION_PATH = "/mowerbot/user/message/vehicleMessageListField"
 _NOTIFICATION_FILTER = "all"
 _NOTIFICATION_TTL_SECONDS = 60
-_NOTIFICATION_ATTR_HISTORY_LIMIT = MERGED_NOTIFICATION_LIMIT
+# Entity attributes are intentionally smaller than the internal merged history so Recorder stays below its 16 KiB state-attribute limit.
+_NOTIFICATION_ATTR_HISTORY_LIMIT = 5
 
 # Legacy notification-history route kept as a callable compatibility/debug helper only.
 _LEGACY_NOTIFICATION_PATH = "/mowerbot/user/message/get-vehicle-history-message"

--- a/tests/test_v043_beta11.py
+++ b/tests/test_v043_beta11.py
@@ -2,18 +2,17 @@
 from __future__ import annotations
 
 import ast
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta11_release_identity() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta11"
+def test_beta11_release_artifacts_remain_in_history() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta11.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta11")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "## 0.4.3-beta11" in changelog
 
 
 def test_beta11_error_discovery_uses_two_pass_full_fetch_selection() -> None:

--- a/tests/test_v043_beta12.py
+++ b/tests/test_v043_beta12.py
@@ -1,0 +1,73 @@
+"""Regression contracts for Navimower 0.4.3-beta12 bounded diagnostics."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta12_release_identity() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta12"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta12.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta12")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert changelog.startswith("# Changelog\n\n## 0.4.3-beta12")
+
+
+def test_beta12_error_discovery_is_wall_clock_bounded() -> None:
+    source = (COMPONENT / "error_h5_discovery.py").read_text(encoding="utf-8")
+    ast.parse(source)
+    for phrase in (
+        "MAX_ROOT_REQUESTS = 4",
+        "MAX_PREFIX_REQUESTS = 32",
+        "MAX_FULL_MATCHES = 6",
+        "MAX_PROBE_SECONDS = 24.0",
+        "TIMEOUT = 2.5",
+        "def _deadline_fetch",
+        "wall_clock_budget_exhausted",
+        "and not budget_exhausted",
+        '"bounded_by_wall_clock": True',
+        '"budget_exhausted": budget_exhausted',
+        '"elapsed_seconds"',
+    ):
+        assert phrase in source
+
+
+def test_beta12_prioritizes_proven_error_command_asset() -> None:
+    source = (COMPONENT / "error_h5_discovery.py").read_text(encoding="utf-8")
+    assert "def _candidate_queue_key" in source
+    assert '"source": "observed_error_command_asset"' in source
+    assert '"priority": _priority(observed_url) + 5000' in source
+    assert "queue = sorted(candidate_map.values(), key=_candidate_queue_key)" in source
+
+
+def test_beta12_diagnostics_has_outer_timeout_fail_safe() -> None:
+    source = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
+    ast.parse(source)
+    assert "ERROR_DISCOVERY_TIMEOUT_SECONDS = 30.0" in source
+    assert "async with asyncio.timeout(ERROR_DISCOVERY_TIMEOUT_SECONDS):" in source
+    assert '"timed_out": True' in source
+    assert "public H5 error discovery exceeded the diagnostics timeout" in source
+
+
+def test_beta12_notification_entity_history_is_recorder_safe() -> None:
+    source = (COMPONENT / "notification_feed.py").read_text(encoding="utf-8")
+    ast.parse(source)
+    assert "_NOTIFICATION_ATTR_HISTORY_LIMIT = 5" in source
+    assert "Recorder stays below its 16 KiB state-attribute limit" in source
+    assert "MERGED_NOTIFICATION_LIMIT = LOCAL_NOTIFICATION_LIMIT + VENDOR_NOTIFICATION_LIMIT" in (COMPONENT / "notification_center.py").read_text(encoding="utf-8")
+
+
+def test_beta12_discovery_remains_non_mutating() -> None:
+    source = (COMPONENT / "error_h5_discovery.py").read_text(encoding="utf-8")
+    assert 'method="GET"' in source
+    assert '"mutation_calls_executed": False' in source
+    assert '"live_command_call_executed": False' in source
+    assert '"notification_detail_call_executed": False' in source
+    assert "client.call(" not in source
+    assert "Authorization" not in source
+    assert "Cookie" not in source


### PR DESCRIPTION
## Scope

Fix the beta11 Download diagnostics stall while keeping the 0.4.3 line focused only on the active Error path and recovery-command discovery.

## Changes

- Bound public-H5 error discovery to a 24-second wall-clock budget with a 2.5-second per-request ceiling.
- Reduce generic discovery to 4 root-script requests, 32 prefix requests and 6 full JavaScript fetches.
- Add a 30-second Home Assistant diagnostics timeout as a final fail-safe; partial discovery evidence is returned when the H5 budget is exhausted.
- Prioritize the proven `index-594ad42d.js` error-command asset plus native/request support chunks before generic lazy assets.
- Keep beta11's two-pass scoring and `handleH5MowerSet` export/import/call-site recovery.
- Limit the Latest notification sensor `recent` attribute to five entries while retaining full bounded vendor/local history internally and in Download diagnostics, preventing Recorder's 16 KiB state-attribute warning.
- Restore beta11 to the changelog and make retained beta11 release tests cumulative.

## Safety

- Public H5 discovery remains unauthenticated HTTPS GET-only.
- Download diagnostics sends no Clear and resume, Reboot Mower, Resume, notification-detail/read or other mower command.
- Maintenance and Mowing Reports discovery remains paused.

## Validation

Remote build passed compileall, full pytest (154/154), `git diff --check`, exact changed-file scope validation and bounded-diagnostics smoke checks. Release branch: `release/0.4.3-beta12` at `b50e1a5f314772f6b8f8d0114a13d887652acdc8`.