### PR TITLE
Navimower 0.4.3-beta15: schedule-aware night resume notifications

### DIFF
--- a/.github/release-notes/0.4.3-beta15.md
+++ b/.github/release-notes/0.4.3-beta15.md
@@ -1,0 +1,14 @@
+title: Navimower 0.4.3-beta15
+
+Notification attribution beta for night-paused mowing resumes.
+
+### Changed
+- Native scheduled mowing paused by sunset now treats schedule availability and daylight as separate resume gates. If sunrise comes first, the notification attributes the later schedule-window opening; if the window is already open before sunrise, it attributes daylight/sunrise.
+- Night-pause notifications for native scheduled tasks now explain that both a native mowing window and daylight must allow the continuation.
+- Retained non-scheduled / one-time mowing keeps its existing sunrise continuation semantics and explicitly does not depend on the native mowing schedule.
+- Record the resolved night resume gate in retained task diagnostics so field reports can show whether `schedule_window` or `sunrise` allowed the continuation.
+
+### Unchanged
+- Navimower Schedule orchestration from beta13 is unchanged.
+- Maintenance and Mowing Reports discovery remains paused.
+- Clear and resume / Reboot Mower discovery remains unchanged and read-only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 
+## 0.4.3-beta15
+
+Schedule-aware night-pause and resume notification attribution.
+
+### Changed
+
+- Distinguish the two gates for native scheduled night resumes: an active schedule window and daylight.
+- Attribute a retained scheduled resume to the schedule window when sunrise was already past, or to sunrise when the schedule window opened before daylight.
+- Keep retained non-scheduled/one-time mowing independent from the native mowing schedule after a night pause.
+- Preserve the resolved resume gate in task diagnostics.
+
+
 ## 0.4.3-beta14
 
 Stabilization for task attribution, observed manual mowing state and transient private-cloud failures.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta14"
+  "version": "0.4.3-beta15"
 }

--- a/custom_components/navimower/notification_center.py
+++ b/custom_components/navimower/notification_center.py
@@ -441,24 +441,73 @@ class NavimowerNotificationCenter:
             return item is not None
 
         if self._active_task is not None and self._interrupted_reason == "night":
+            names = list(self._active_task.get("zone_names") or [])
+            origin = str(self._active_task.get("origin") or "")
             sunrise = self._sun_event_local(SUN_EVENT_SUNRISE, now_local.date())
+
+            if origin == "schedule":
+                resolved = self._scheduled_night_resume_gate(snapshot, now_local)
+                if resolved is None:
+                    # A retained native-schedule task must not be attributed to
+                    # sunrise alone. Wait until a real schedule/daylight gate is
+                    # observable instead of inventing an External start.
+                    return False
+                gate, period = resolved
+                start_dt = period["start_dt"]
+                end_dt = period["end_dt"]
+                if gate == "sunrise":
+                    content = "Resumed the unfinished scheduled mowing task after sunrise"
+                    if names:
+                        content += f" in {_zone_phrase(names)}"
+                    content += (
+                        f". The scheduled mowing window opened at {start_dt.strftime('%H:%M')}, "
+                        "but Night mowing is disabled, so daylight was the last remaining gate."
+                    )
+                    if sunrise is not None:
+                        content += f" Sunrise was around {sunrise.strftime('%H:%M')}."
+                    title = "Unfinished scheduled mowing resumed after sunrise"
+                else:
+                    content = "Resumed the unfinished scheduled mowing task"
+                    if names:
+                        content += f" in {_zone_phrase(names)}"
+                    content += (
+                        f" when the scheduled mowing window opened at {start_dt.strftime('%H:%M')}."
+                    )
+                    if sunrise is not None and sunrise <= start_dt:
+                        content += (
+                            f" Daylight was already available after sunrise around "
+                            f"{sunrise.strftime('%H:%M')}."
+                        )
+                    title = "Unfinished scheduled mowing resumed"
+
+                item = self._emit(
+                    "NM1005",
+                    title,
+                    content,
+                    kind="scheduled_night_resume",
+                    confidence="inferred_from_retained_schedule_and_daylight_gate",
+                    event_key=(
+                        f"{self._task_token()}-{now_local.date().isoformat()}-"
+                        f"{period['start_min']}-{gate}"
+                    ),
+                )
+                self._active_task["schedule_start"] = start_dt.isoformat()
+                self._active_task["schedule_end"] = end_dt.isoformat()
+                self._active_task["last_resume_gate"] = gate
+                self._active_task["last_resumed_at"] = datetime.now(UTC).isoformat()
+                self._interrupted_reason = None
+                return item is not None
+
             if sunrise is not None and sunrise <= now_local <= sunrise + timedelta(
                 hours=_SUNRISE_RESUME_WINDOW_HOURS
             ):
-                names = list(self._active_task.get("zone_names") or [])
                 content = "Resumed the unfinished mowing task after sunrise"
                 if names:
                     content += f" in {_zone_phrase(names)}"
-                content += "."
-                if self._active_task.get("origin") != "schedule":
-                    next_start = self._next_schedule_start_today(snapshot, now_local)
-                    if next_start:
-                        content += (
-                            " This is a continuation of the previous task; today's "
-                            f"scheduled mowing starts at {next_start}."
-                        )
-                    else:
-                        content += " This is a continuation of the previous task."
+                content += (
+                    ". This is a continuation of the retained task; the native "
+                    "mowing schedule does not gate this resume."
+                )
                 item = self._emit(
                     "NM1005",
                     "Unfinished mowing resumed after sunrise",
@@ -467,6 +516,7 @@ class NavimowerNotificationCenter:
                     confidence="inferred_from_retained_task_and_sunrise",
                     event_key=f"{self._task_token()}-{now_local.date().isoformat()}",
                 )
+                self._active_task["last_resume_gate"] = "sunrise"
                 self._active_task["last_resumed_at"] = datetime.now(UTC).isoformat()
                 self._interrupted_reason = None
                 return item is not None
@@ -643,12 +693,30 @@ class NavimowerNotificationCenter:
             schedule_end is None or night_candidate < schedule_end - timedelta(minutes=5)
         ):
             names = list((self._active_task or {}).get("zone_names") or [])
-            content = "The unfinished mowing task started returning to the charging station around sunset because Night mowing is disabled"
+            scheduled = (self._active_task or {}).get("origin") == "schedule"
+            content = (
+                "The unfinished scheduled mowing task started returning to the charging "
+                "station around sunset because Night mowing is disabled"
+                if scheduled
+                else "The unfinished mowing task started returning to the charging station "
+                "around sunset because Night mowing is disabled"
+            )
             if names:
                 content += f" while mowing {_zone_phrase(names)}"
             if progress is not None:
                 content += f" at {progress:g}% progress"
-            content += ". It may resume after sunrise when the mower retains the task and charging allows."
+            if scheduled:
+                content += (
+                    ". It can resume when a native mowing window is open and daylight "
+                    "is available; whichever condition becomes available later is the "
+                    "effective resume gate."
+                )
+            else:
+                content += (
+                    ". It may resume after sunrise when the mower retains the task and "
+                    "charging allows. The native mowing schedule does not gate this "
+                    "retained task."
+                )
             item = self._emit(
                 "NM1004",
                 "Mowing paused for night",
@@ -660,6 +728,9 @@ class NavimowerNotificationCenter:
             self._interrupted_reason = "night"
             if self._active_task is not None:
                 self._active_task["night_paused_at"] = datetime.now(UTC).isoformat()
+                self._active_task["night_pause_context"] = (
+                    "native_schedule" if scheduled else "retained_task"
+                )
             return item is not None
 
         if schedule_end is not None:
@@ -807,6 +878,28 @@ class NavimowerNotificationCenter:
                         "end_dt": day_start + timedelta(minutes=end_min),
                     }
         return None
+
+    def _scheduled_night_resume_gate(
+        self, snapshot: dict[str, Any], now_local: datetime
+    ) -> tuple[str, dict[str, Any]] | None:
+        """Resolve the last gate for a retained native-schedule night pause."""
+        period = self._schedule_period_containing_now(snapshot, now_local)
+        if period is None:
+            return None
+        if (snapshot.get("settings") or {}).get("night_mow") is not False:
+            return "schedule_window", period
+
+        sunrise = self._sun_event_local(SUN_EVENT_SUNRISE, now_local.date())
+        sunset = self._sun_event_local(SUN_EVENT_SUNSET, now_local.date())
+        if sunrise is not None and now_local < sunrise:
+            return None
+        if sunset is not None and now_local >= sunset:
+            return None
+
+        start_dt = period["start_dt"]
+        if sunrise is not None and start_dt < sunrise <= now_local:
+            return "sunrise", period
+        return "schedule_window", period
 
     def _next_schedule_start_today(
         self, snapshot: dict[str, Any], now_local: datetime

--- a/tests/test_v043_beta14.py
+++ b/tests/test_v043_beta14.py
@@ -6,8 +6,6 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 
 def test_beta14_identity():
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta14"
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta14.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta14")
 

--- a/tests/test_v043_beta15.py
+++ b/tests/test_v043_beta15.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta15_identity():
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta15"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta15.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta15")
+
+
+def test_scheduled_night_resume_resolves_schedule_and_daylight_gate():
+    source = (COMPONENT / "notification_center.py").read_text(encoding="utf-8")
+    assert "def _scheduled_night_resume_gate" in source
+    assert 'return "sunrise", period' in source
+    assert 'return "schedule_window", period' in source
+    assert 'start_dt < sunrise <= now_local' in source
+    assert 'now_local >= sunset' in source
+    assert 'kind="scheduled_night_resume"' in source
+    assert 'self._active_task["last_resume_gate"] = gate' in source
+
+
+def test_scheduled_resume_wording_uses_actual_last_gate():
+    source = (COMPONENT / "notification_center.py").read_text(encoding="utf-8")
+    assert '"Unfinished scheduled mowing resumed after sunrise"' in source
+    assert '"Unfinished scheduled mowing resumed"' in source
+    assert "daylight was the last remaining gate" in source
+    assert "when the scheduled mowing window opened at" in source
+
+
+def test_retained_non_schedule_task_is_not_gated_by_native_schedule():
+    source = (COMPONENT / "notification_center.py").read_text(encoding="utf-8")
+    assert "mowing schedule does not gate this resume." in source
+    assert "The native mowing schedule does not gate this " in source
+    assert "retained task." in source
+
+
+def test_night_pause_message_explains_native_schedule_gate():
+    source = (COMPONENT / "notification_center.py").read_text(encoding="utf-8")
+    assert "It can resume when a native mowing window is open and daylight" in source
+    assert "effective resume gate" in source
+    assert '"native_schedule" if scheduled else "retained_task"' in source


### PR DESCRIPTION
## What changed
- Distinguish native scheduled night resumes by the actual last gate: schedule window vs sunrise/daylight.
- Scheduled tasks paused by sunset now explain that both a native mowing window and daylight must allow continuation.
- Retained non-scheduled / one-time tasks keep sunrise continuation semantics and explicitly do not depend on the native schedule.
- Persist `last_resume_gate` / night-pause context in the retained task diagnostics.
- Convert the beta14 version assertion into a historical release-note identity check and add beta15 regression coverage.

## Why
A native scheduled task can stop at sunset because Night mowing is disabled, but the next continuation is not always caused by sunrise. If sunrise occurs before the next native schedule window, the mower waits for that window; if the schedule window is already open before sunrise, daylight is the final gate. One-time retained mowing behaves differently and can continue after sunrise independently of the native schedule.

## Validation
Remote builder completed successfully on `c9d2ea0d1266b5b04897b48fa176897229ea39ca`: full pytest suite, compileall, `git diff --check`, exact diff-scope validation and focused notification-gate smoke checks all passed.