### PR TITLE
Navimower 0.4.3-beta16: configure managed schedule

### DIFF
--- a/.github/release-notes/0.4.3-beta16.md
+++ b/.github/release-notes/0.4.3-beta16.md
@@ -1,0 +1,20 @@
+title: Navimower 0.4.3-beta16
+
+Managed-scheduler configuration beta.
+
+### Added
+- Add a dedicated **Navimower Schedule** page under the integration Configure/gear options flow.
+- Add a multi-select **Automatic mowing zones** allowlist using stable zone IDs.
+- List mapped zones that are not yet eligible and explain that each must be fully completed manually once before it can be selected.
+- Add **Time window** and **24 hours** managed-schedule modes. Time window continues to use the existing Start/End controls; 24 hours never closes the managed window and starts a new oldest-zone round after all selected zones complete.
+
+### Safety
+- A zone with no confirmed `last_completed_at` is never an automatic scheduler candidate.
+- New zones are never automatically added to the allowlist after configuration.
+- Turning Navimower Schedule on is refused until at least one selected zone has a confirmed successful completion; the native schedule is left untouched on that failed enable attempt.
+- Already-enabled beta13-beta15 schedulers receive a one-time allowlist containing only currently proven zones, preserving existing field setups without auto-enrolling future zones.
+
+### Unchanged
+- The Navimower Schedule switch remains the runtime on/off control and native/managed schedules remain mutually exclusive.
+- Existing Start/End time entities remain available for dashboards and automations.
+- Maintenance and Mowing Reports discovery remains paused.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
 
+## 0.4.3-beta16
+
+Configure the integration-owned scheduler from the Navimower gear/options flow.
+
+### Added
+
+- Add multi-zone Automatic mowing zones selection using stable zone IDs.
+- Show never-completed zones as unavailable until one confirmed manual completion exists.
+- Add Time window and 24 hours modes; continuous mode rolls into a new oldest-zone round after all selected zones finish.
+
+### Safety
+
+- Never schedule a zone without a confirmed successful completion.
+- Never auto-enroll newly created zones.
+- Refuse enabling the managed scheduler when no proven selected zone exists.
+- Migrate already-enabled beta schedulers once to an explicit allowlist of currently proven zones.
+
+
 ## 0.4.3-beta15
 
 Schedule-aware night-pause and resume notification attribution.

--- a/custom_components/navimower/config_flow.py
+++ b/custom_components/navimower/config_flow.py
@@ -27,7 +27,15 @@ from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.selector import TextSelector, TextSelectorConfig, TextSelectorType
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+    TimeSelector,
+)
 
 from .account import shared_private_device_id
 from .api import NavimowCloudClient, NavimowError, PassportAuthError, PassportError
@@ -49,17 +57,27 @@ from .const import (
     CONF_VEHICLE_TYPE,
     DEFAULT_INCLUDE_RETURN_TRAIL,
     DEFAULT_LANGUAGE,
+    DEFAULT_SCHEDULE_END,
+    DEFAULT_SCHEDULE_MODE,
+    DEFAULT_SCHEDULE_START,
     DEFAULT_TRAIL_RETENTION_DAYS,
     DOMAIN,
     OPT_CHANNELS,
     OPT_GATES,
     OPT_INCLUDE_RETURN_TRAIL,
+    OPT_SCHEDULE_END,
+    OPT_SCHEDULE_MODE,
+    OPT_SCHEDULE_START,
+    OPT_SCHEDULE_ZONE_IDS,
     OPT_TRAIL_RETENTION_DAYS,
     OPT_ZONES,
+    SCHEDULE_MODE_CONTINUOUS,
+    SCHEDULE_MODE_WINDOW,
     TRAIL_RETENTION_OPTIONS,
 )
 from .gate import NavimowerGate, parse_gates
 from .oauth import async_register_oauth_implementation
+from .schedule_logic import format_hhmm, parse_hhmm
 
 _LOGGER = logging.getLogger(__name__)
 _USER_SCHEMA = vol.Schema(
@@ -497,7 +515,7 @@ class NavimowConfigFlow(
 
 
 class NavimowOptionsFlow(OptionsFlowWithReload):
-    """Manage general history, user-friendly gates and local channels."""
+    """Manage history, the managed scheduler, gates and local channels."""
 
     def __init__(self) -> None:
         self._gate_index: int | None = None
@@ -531,6 +549,37 @@ class NavimowOptionsFlow(OptionsFlowWithReload):
                 choices.setdefault(str(zone_id), f"Zone {zone_id} (ID {zone_id})")
         return choices
 
+    def _schedule_zone_rows(self) -> list[dict[str, Any]]:
+        coordinator = self._coordinator()
+        data = getattr(coordinator, "data", None) or {}
+        rows = data.get("zone_states") or []
+        return [row for row in rows if isinstance(row, dict) and row.get("id") is not None]
+
+    def _schedule_zone_choices(self) -> dict[str, str]:
+        choices: dict[str, str] = {}
+        for row in self._schedule_zone_rows():
+            if not row.get("last_completed_at"):
+                continue
+            try:
+                zone_id = str(int(row["id"]))
+            except (TypeError, ValueError):
+                continue
+            choices[zone_id] = str(row.get("name") or f"Zone {zone_id}")
+        for value in self._options().get(OPT_SCHEDULE_ZONE_IDS, []) or []:
+            text = str(value)
+            if text.isdigit():
+                choices.setdefault(text, f"Zone {text} (saved)")
+        return choices
+
+    def _schedule_unavailable_text(self) -> str:
+        rows: list[str] = []
+        for row in self._schedule_zone_rows():
+            if row.get("last_completed_at"):
+                continue
+            name = str(row.get("name") or f"Zone {row.get('id')}")
+            rows.append(f"- {name} — Never completed")
+        return "\n".join(rows) if rows else "None"
+
     def _gates(self) -> list[NavimowerGate]:
         return parse_gates(self.config_entry.options.get(OPT_GATES))
 
@@ -551,7 +600,7 @@ class NavimowOptionsFlow(OptionsFlowWithReload):
         del user_input
         return self.async_show_menu(
             step_id="init",
-            menu_options=["general", "gates", "channels"],
+            menu_options=["general", "navimower_schedule", "gates", "channels"],
         )
 
     async def async_step_general(
@@ -598,6 +647,90 @@ class NavimowOptionsFlow(OptionsFlowWithReload):
                     ): bool,
                 }
             ),
+        )
+
+    async def async_step_navimower_schedule(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        options = self._options()
+        choices = self._schedule_zone_choices()
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            selected = [
+                str(value)
+                for value in user_input.get(OPT_SCHEDULE_ZONE_IDS, []) or []
+                if str(value) in choices
+            ]
+            mode = str(user_input.get(OPT_SCHEDULE_MODE) or DEFAULT_SCHEDULE_MODE)
+            start = format_hhmm(
+                parse_hhmm(user_input.get(OPT_SCHEDULE_START), DEFAULT_SCHEDULE_START)
+            )
+            end = format_hhmm(
+                parse_hhmm(user_input.get(OPT_SCHEDULE_END), DEFAULT_SCHEDULE_END)
+            )
+            if mode == SCHEDULE_MODE_WINDOW and start == end:
+                errors["base"] = "schedule_same_time"
+            else:
+                return self._save(
+                    **{
+                        OPT_SCHEDULE_ZONE_IDS: selected,
+                        OPT_SCHEDULE_MODE: mode,
+                        OPT_SCHEDULE_START: start,
+                        OPT_SCHEDULE_END: end,
+                    }
+                )
+
+        selected_default = [
+            str(value)
+            for value in options.get(OPT_SCHEDULE_ZONE_IDS, []) or []
+            if str(value) in choices
+        ]
+        mode_default = str(options.get(OPT_SCHEDULE_MODE, DEFAULT_SCHEDULE_MODE))
+        if mode_default not in {SCHEDULE_MODE_WINDOW, SCHEDULE_MODE_CONTINUOUS}:
+            mode_default = DEFAULT_SCHEDULE_MODE
+        return self.async_show_form(
+            step_id="navimower_schedule",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        OPT_SCHEDULE_ZONE_IDS,
+                        default=selected_default,
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                {"value": value, "label": label}
+                                for value, label in choices.items()
+                            ],
+                            multiple=True,
+                            mode=SelectSelectorMode.LIST,
+                        )
+                    ),
+                    vol.Required(
+                        OPT_SCHEDULE_MODE,
+                        default=mode_default,
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                {"value": SCHEDULE_MODE_WINDOW, "label": "Time window"},
+                                {"value": SCHEDULE_MODE_CONTINUOUS, "label": "24 hours"},
+                            ],
+                            mode=SelectSelectorMode.LIST,
+                        )
+                    ),
+                    vol.Required(
+                        OPT_SCHEDULE_START,
+                        default=str(options.get(OPT_SCHEDULE_START, DEFAULT_SCHEDULE_START)),
+                    ): TimeSelector(),
+                    vol.Required(
+                        OPT_SCHEDULE_END,
+                        default=str(options.get(OPT_SCHEDULE_END, DEFAULT_SCHEDULE_END)),
+                    ): TimeSelector(),
+                }
+            ),
+            errors=errors,
+            description_placeholders={
+                "unavailable_zones": self._schedule_unavailable_text(),
+            },
         )
 
     async def async_step_gates(

--- a/custom_components/navimower/const.py
+++ b/custom_components/navimower/const.py
@@ -38,6 +38,17 @@ OPT_TRAIL_RETENTION_DAYS: Final = "trail_retention_days"
 OPT_INCLUDE_RETURN_TRAIL: Final = "include_return_trail"
 OPT_DIAGNOSTICS_DETAIL: Final = "diagnostics_detail"
 OPT_PASSIVE_DISCOVERY: Final = "passive_discovery"
+OPT_SCHEDULE_ENABLED: Final = "navimower_schedule_enabled"
+OPT_SCHEDULE_START: Final = "navimower_schedule_start"
+OPT_SCHEDULE_END: Final = "navimower_schedule_end"
+OPT_SCHEDULE_MODE: Final = "navimower_schedule_mode"
+OPT_SCHEDULE_ZONE_IDS: Final = "navimower_schedule_zone_ids"
+
+SCHEDULE_MODE_WINDOW: Final = "window"
+SCHEDULE_MODE_CONTINUOUS: Final = "continuous"
+DEFAULT_SCHEDULE_MODE: Final = SCHEDULE_MODE_WINDOW
+DEFAULT_SCHEDULE_START: Final = "10:00"
+DEFAULT_SCHEDULE_END: Final = "20:00"
 
 DEFAULT_TRAIL_RETENTION_DAYS: Final = 7
 TRAIL_RETENTION_OPTIONS: Final[tuple[int, ...]] = (3, 7, 14, 30, 0)  # 0 = unlimited

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta15"
+  "version": "0.4.3-beta16"
 }

--- a/custom_components/navimower/navimower_schedule.py
+++ b/custom_components/navimower/navimower_schedule.py
@@ -18,13 +18,24 @@ from .const import (
     ACTIVITY_MOWING,
     ACTIVITY_PAUSED,
     ACTIVITY_RETURNING,
+    DEFAULT_SCHEDULE_END,
+    DEFAULT_SCHEDULE_MODE,
+    DEFAULT_SCHEDULE_START,
     DOMAIN,
+    OPT_SCHEDULE_ENABLED,
+    OPT_SCHEDULE_END,
+    OPT_SCHEDULE_MODE,
+    OPT_SCHEDULE_START,
+    OPT_SCHEDULE_ZONE_IDS,
+    SCHEDULE_MODE_CONTINUOUS,
+    SCHEDULE_MODE_WINDOW,
     encode_partition_ids,
     mow_setup,
 )
 from .resume import async_resume_task
 from .schedule_logic import (
     completion_advanced,
+    filter_schedule_zones,
     format_hhmm,
     later_iso,
     parse_hhmm,
@@ -35,12 +46,6 @@ from .schedule_logic import (
 from .setting_write import async_write_settings
 
 _LOGGER = logging.getLogger(__name__)
-
-OPT_SCHEDULE_ENABLED = "navimower_schedule_enabled"
-OPT_SCHEDULE_START = "navimower_schedule_start"
-OPT_SCHEDULE_END = "navimower_schedule_end"
-DEFAULT_SCHEDULE_START = "10:00"
-DEFAULT_SCHEDULE_END = "20:00"
 
 _STORE_VERSION = 1
 _TICK_SECONDS = 20
@@ -78,8 +83,13 @@ class NavimowerScheduleController:
         self.coordinator = coordinator
         self._store = schedule_store(hass, entry.entry_id)
         self._enabled = bool(entry.options.get(OPT_SCHEDULE_ENABLED, False))
+        mode = str(entry.options.get(OPT_SCHEDULE_MODE, DEFAULT_SCHEDULE_MODE))
+        self._mode = mode if mode in {SCHEDULE_MODE_WINDOW, SCHEDULE_MODE_CONTINUOUS} else DEFAULT_SCHEDULE_MODE
         self._start = parse_hhmm(entry.options.get(OPT_SCHEDULE_START), DEFAULT_SCHEDULE_START)
         self._end = parse_hhmm(entry.options.get(OPT_SCHEDULE_END), DEFAULT_SCHEDULE_END)
+        self._selection_configured = OPT_SCHEDULE_ZONE_IDS in entry.options
+        self._selected_zone_ids = self._normalize_zone_ids(entry.options.get(OPT_SCHEDULE_ZONE_IDS, []))
+        self._legacy_selection_migration_allowed = self._enabled and not self._selection_configured
         self._runtime: dict[str, Any] = self._empty_runtime()
         self._unsub = None
         self._tick_task: asyncio.Task | None = None
@@ -88,9 +98,25 @@ class NavimowerScheduleController:
         self._stopped = False
 
     @staticmethod
+    def _normalize_zone_ids(values: Any) -> set[int]:
+        if not isinstance(values, (list, tuple, set)):
+            values = [] if values in (None, "") else [values]
+        result: set[int] = set()
+        for value in values:
+            try:
+                zone_id = int(value)
+            except (TypeError, ValueError):
+                continue
+            if zone_id > 0:
+                result.add(zone_id)
+        return result
+
+    @staticmethod
     def _empty_runtime() -> dict[str, Any]:
         return {
             "window_token": None,
+            "round_index": 1,
+            "round_started_at": None,
             "completed_zone_ids_in_window": [],
             "active_zone_id": None,
             "active_cycle_id": None,
@@ -115,6 +141,14 @@ class NavimowerScheduleController:
         return self._enabled
 
     @property
+    def mode(self) -> str:
+        return self._mode
+
+    @property
+    def selected_zone_ids(self) -> tuple[int, ...]:
+        return tuple(sorted(self._selected_zone_ids))
+
+    @property
     def start_time(self) -> time:
         return self._start
 
@@ -131,6 +165,7 @@ class NavimowerScheduleController:
             restored = self._empty_runtime()
             restored.update({key: deepcopy(value) for key, value in saved.items() if key in restored})
             self._runtime = restored
+        self._maybe_migrate_legacy_zone_selection()
         self._unsub = self.coordinator.async_add_listener(self._handle_update)
         self._tick_task = self.hass.async_create_background_task(
             self._tick_loop(),
@@ -161,11 +196,17 @@ class NavimowerScheduleController:
 
     def diagnostics(self) -> dict[str, Any]:
         now = dt_util.now()
-        open_now, token = window_state(now, self._start, self._end)
+        open_now, token = self._window_state(now)
+        eligible = self._eligible_zones()
+        eligible_ids = sorted(int(row["id"]) for row in eligible if row.get("id") is not None)
         return {
             "enabled": self._enabled,
+            "mode": self._mode,
             "start": format_hhmm(self._start),
             "end": format_hhmm(self._end),
+            "selected_zone_ids": sorted(self._selected_zone_ids),
+            "eligible_zone_ids": eligible_ids,
+            "zone_selection_configured": self._selection_configured,
             "window_open": open_now,
             "window_token_now": token,
             **deepcopy(self._runtime),
@@ -176,8 +217,11 @@ class NavimowerScheduleController:
         return {
             key: row.get(key)
             for key in (
+                "mode",
                 "start",
                 "end",
+                "selected_zone_ids",
+                "eligible_zone_ids",
                 "window_open",
                 "active_zone_id",
                 "resume_pending",
@@ -193,6 +237,10 @@ class NavimowerScheduleController:
         if enabled == self._enabled:
             return
         if enabled:
+            if not self._eligible_zones():
+                raise RuntimeError(
+                    "Configure at least one successfully completed automatic mowing zone first"
+                )
             native = (self.coordinator.data or {}).get("settings", {}).get("schedule_enabled")
             if native is None:
                 raise RuntimeError("Native mowing schedule state is not available yet")
@@ -208,6 +256,7 @@ class NavimowerScheduleController:
             self._runtime["last_command"] = f"disabled:{reason}"
             self._runtime["last_command_at"] = _utc_now()
         self._enabled = enabled
+        self._legacy_selection_migration_allowed = False
         self._update_options(**{OPT_SCHEDULE_ENABLED: enabled})
         await self._save()
         if enabled:
@@ -285,6 +334,47 @@ class NavimowerScheduleController:
     def _zones(self) -> list[dict[str, Any]]:
         return [row for row in (self.coordinator.data or {}).get("zone_states") or [] if isinstance(row, dict)]
 
+    def _maybe_migrate_legacy_zone_selection(self) -> None:
+        """Preserve an already-enabled beta scheduler without auto-enrolling future zones."""
+        if not self._legacy_selection_migration_allowed or self._selection_configured:
+            return
+        zones = self._zones()
+        if not zones:
+            return
+        proven: set[int] = set()
+        for row in zones:
+            try:
+                zone_id = int(row.get("id"))
+            except (TypeError, ValueError):
+                continue
+            if zone_id > 0 and parse_iso(row.get("last_completed_at")) is not None:
+                proven.add(zone_id)
+        self._selected_zone_ids = proven
+        self._selection_configured = True
+        self._legacy_selection_migration_allowed = False
+        self._update_options(
+            **{
+                OPT_SCHEDULE_ZONE_IDS: [str(value) for value in sorted(proven)],
+                OPT_SCHEDULE_MODE: self._mode,
+            }
+        )
+        _LOGGER.info(
+            "Migrated the enabled beta Navimower schedule to an explicit allowlist of %s proven zones",
+            len(proven),
+        )
+
+    def _eligible_zones(self) -> list[dict[str, Any]]:
+        return filter_schedule_zones(
+            self._zones(),
+            self._selected_zone_ids,
+            scheduler_completed_at=self._runtime.get("scheduler_completed_at") or {},
+        )
+
+    def _window_state(self, now: datetime) -> tuple[bool, str | None]:
+        if self._mode == SCHEDULE_MODE_CONTINUOUS:
+            return True, "continuous"
+        return window_state(now, self._start, self._end)
+
     def _zone(self, zone_id: int | None) -> dict[str, Any] | None:
         if zone_id is None:
             return None
@@ -340,15 +430,18 @@ class NavimowerScheduleController:
         if not self._enabled:
             return
         data = self.coordinator.data or {}
+        self._maybe_migrate_legacy_zone_selection()
         settings = data.get("settings") or {}
         if settings.get("schedule_enabled") is True:
             await self.async_set_enabled(False, reason="native_schedule_enabled")
             return
 
         now = dt_util.now()
-        in_window, token = window_state(now, self._start, self._end)
+        in_window, token = self._window_state(now)
         if in_window and token and token != self._runtime.get("window_token"):
             self._runtime["window_token"] = token
+            self._runtime["round_index"] = 1
+            self._runtime["round_started_at"] = _utc_now()
             self._runtime["completed_zone_ids_in_window"] = []
             self._runtime["just_completed_zone_id"] = None
             self._runtime["suspended_reason"] = None
@@ -390,12 +483,27 @@ class NavimowerScheduleController:
             return
 
         completed = {int(value) for value in self._runtime.get("completed_zone_ids_in_window") or []}
+        eligible = self._eligible_zones()
         candidate = select_oldest_zone(
-            self._zones(),
+            eligible,
             completed_in_window=completed,
             just_completed_zone_id=self._runtime.get("just_completed_zone_id"),
             scheduler_completed_at=self._runtime.get("scheduler_completed_at") or {},
         )
+        if candidate is None and self._mode == SCHEDULE_MODE_CONTINUOUS and eligible:
+            eligible_ids = {int(row["id"]) for row in eligible if row.get("id") is not None}
+            if eligible_ids and eligible_ids.issubset(completed):
+                self._runtime["completed_zone_ids_in_window"] = []
+                self._runtime["just_completed_zone_id"] = None
+                self._runtime["round_index"] = int(self._runtime.get("round_index") or 1) + 1
+                self._runtime["round_started_at"] = _utc_now()
+                await self._save()
+                candidate = select_oldest_zone(
+                    eligible,
+                    completed_in_window=set(),
+                    just_completed_zone_id=None,
+                    scheduler_completed_at=self._runtime.get("scheduler_completed_at") or {},
+                )
         if candidate is None:
             return
         try:

--- a/custom_components/navimower/schedule_logic.py
+++ b/custom_components/navimower/schedule_logic.py
@@ -6,13 +6,15 @@ from typing import Any, Iterable
 
 
 def parse_hhmm(value: Any, default: str) -> time:
-    """Return a local wall-clock time from ``HH:MM`` or a time object."""
+    """Return a local wall-clock time from ``HH:MM[:SS]`` or a time object."""
     if isinstance(value, time):
         return value.replace(second=0, microsecond=0)
     text = str(value or default).strip()
     try:
-        hour_s, minute_s = text.split(":", 1)
-        hour, minute = int(hour_s), int(minute_s)
+        parts = text.split(":")
+        if len(parts) < 2:
+            raise ValueError
+        hour, minute = int(parts[0]), int(parts[1])
         if not (0 <= hour <= 23 and 0 <= minute <= 59):
             raise ValueError
     except (TypeError, ValueError):
@@ -75,8 +77,35 @@ def completion_advanced(current: Any, baseline: Any, dispatched_at: Any) -> bool
     return baseline_dt is None or current_dt > baseline_dt
 
 
-def _minimum_aware_datetime() -> datetime:
-    return datetime.min.replace(tzinfo=datetime.now().astimezone().tzinfo)
+def filter_schedule_zones(
+    zones: Iterable[dict[str, Any]],
+    selected_zone_ids: Iterable[int],
+    *,
+    scheduler_completed_at: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Return only user-selected zones with a confirmed successful completion."""
+    selected: set[int] = set()
+    for value in selected_zone_ids or []:
+        try:
+            selected.add(int(value))
+        except (TypeError, ValueError):
+            continue
+    confirmed = scheduler_completed_at or {}
+    result: list[dict[str, Any]] = []
+    for row in zones or []:
+        if not isinstance(row, dict):
+            continue
+        try:
+            zone_id = int(row.get("id"))
+        except (TypeError, ValueError):
+            continue
+        if zone_id not in selected:
+            continue
+        effective = later_iso(row.get("last_completed_at"), confirmed.get(str(zone_id)))
+        if parse_iso(effective) is None:
+            continue
+        result.append(row)
+    return result
 
 
 def select_oldest_zone(
@@ -101,8 +130,9 @@ def select_oldest_zone(
             continue
         effective = later_iso(row.get("last_completed_at"), confirmed.get(str(zone_id)))
         parsed = parse_iso(effective)
-        key = (0, _minimum_aware_datetime()) if parsed is None else (1, parsed)
-        candidates.append(((key[0], key[1], zone_id), row))
+        if parsed is None:
+            continue
+        candidates.append(((parsed, zone_id), row))
     if not candidates:
         return None
     candidates.sort(key=lambda item: item[0])

--- a/custom_components/navimower/strings.json
+++ b/custom_components/navimower/strings.json
@@ -70,9 +70,10 @@
     "step": {
       "init": {
         "title": "Navimower options",
-        "description": "Configure retained trail history, zone-pair gates and optional local X/Y channels.",
+        "description": "Configure retained trail history, Navimower Schedule, zone-pair gates and optional local X/Y gate areas.",
         "menu_options": {
           "general": "General and trail history",
+          "navimower_schedule": "Navimower Schedule",
           "gates": "Gates",
           "channels": "Gate areas"
         }
@@ -177,12 +178,29 @@
         "data": {
           "channel": "Gate area"
         }
+      },
+      "navimower_schedule": {
+        "title": "Navimower Schedule",
+        "description": "Choose which proven zones the integration may mow automatically and when it may work. Only zones with at least one confirmed successful completion can be selected. A new or difficult zone must first be fully completed manually once; completing it does not select it automatically. Start and end are used only in Time window mode.\\n\\nNot yet available for automatic mowing:\\n{unavailable_zones}",
+        "data": {
+          "navimower_schedule_zone_ids": "Automatic mowing zones",
+          "navimower_schedule_mode": "Allowed mowing time",
+          "navimower_schedule_start": "Start",
+          "navimower_schedule_end": "End"
+        },
+        "data_description": {
+          "navimower_schedule_zone_ids": "The scheduler only dispatches zones selected here. New zones are never added automatically.",
+          "navimower_schedule_mode": "Time window stops managed mowing outside the configured hours. 24 hours keeps the managed scheduler available continuously and starts a new round after every selected zone has completed.",
+          "navimower_schedule_start": "Used only in Time window mode.",
+          "navimower_schedule_end": "Used only in Time window mode."
+        }
       }
     },
     "error": {
       "same_zone": "Zone A and Zone B must be different.",
       "duplicate_gate": "A gate with the same name or zone pair already exists.",
-      "duplicate_channel": "A channel with the same name already exists."
+      "duplicate_channel": "A channel with the same name already exists.",
+      "schedule_same_time": "Start and end must be different when Allowed mowing time is Time window."
     },
     "abort": {
       "options_saved": "Navimower options were saved and the integration is reloading.",
@@ -198,67 +216,173 @@
       }
     },
     "sensor": {
-      "battery": {"name": "Battery"},
-      "state": {"name": "Status"},
-      "state_code": {"name": "State code"},
-      "mowing_progress": {"name": "Mowing progress"},
-      "current_zone": {"name": "Current zone"},
-      "session_area": {"name": "Session area"},
-      "weekly_area": {"name": "Area this week"},
-      "total_area": {"name": "Total area"},
-      "next_mow": {"name": "Next mow"},
-      "error_text": {"name": "Error"},
-      "signal_wifi": {"name": "Wi-Fi signal"},
-      "blades_life": {"name": "Blades life"},
-      "chassis_life": {"name": "Chassis life"},
-      "schedule": {"name": "Schedule"},
-      "coverage": {"name": "Coverage"},
-      "current_physical_zone": {"name": "Current physical zone"},
-      "target_zone": {"name": "Target zone"},
-      "current_channel": {"name": "Current channel"},
-      "cutting_height": {"name": "Global cutting height"},
-      "position_source": {"name": "Position source"},
-      "mqtt_stream_state": {"name": "MQTT position stream"},
-      "private_poll_age": {"name": "Private-cloud poll age"}
+      "battery": {
+        "name": "Battery"
+      },
+      "state": {
+        "name": "Status"
+      },
+      "state_code": {
+        "name": "State code"
+      },
+      "mowing_progress": {
+        "name": "Mowing progress"
+      },
+      "current_zone": {
+        "name": "Current zone"
+      },
+      "session_area": {
+        "name": "Session area"
+      },
+      "weekly_area": {
+        "name": "Area this week"
+      },
+      "total_area": {
+        "name": "Total area"
+      },
+      "next_mow": {
+        "name": "Next mow"
+      },
+      "error_text": {
+        "name": "Error"
+      },
+      "signal_wifi": {
+        "name": "Wi-Fi signal"
+      },
+      "blades_life": {
+        "name": "Blades life"
+      },
+      "chassis_life": {
+        "name": "Chassis life"
+      },
+      "schedule": {
+        "name": "Schedule"
+      },
+      "coverage": {
+        "name": "Coverage"
+      },
+      "current_physical_zone": {
+        "name": "Current physical zone"
+      },
+      "target_zone": {
+        "name": "Target zone"
+      },
+      "current_channel": {
+        "name": "Current channel"
+      },
+      "cutting_height": {
+        "name": "Global cutting height"
+      },
+      "position_source": {
+        "name": "Position source"
+      },
+      "mqtt_stream_state": {
+        "name": "MQTT position stream"
+      },
+      "private_poll_age": {
+        "name": "Private-cloud poll age"
+      }
     },
     "calendar": {
-      "schedule": {"name": "Mowing schedule"}
+      "schedule": {
+        "name": "Mowing schedule"
+      }
     },
     "binary_sensor": {
-      "problem": {"name": "Problem"},
-      "online": {"name": "Online"},
-      "docked": {"name": "Docked"},
-      "zone_transition": {"name": "Zone transition"},
-      "private_cloud_connected": {"name": "Private cloud connected"},
-      "oauth_connected": {"name": "Smart Home OAuth connected"},
-      "mqtt_connected": {"name": "MQTT connected"},
-      "pose_valid": {"name": "Live position valid"}
+      "problem": {
+        "name": "Problem"
+      },
+      "online": {
+        "name": "Online"
+      },
+      "docked": {
+        "name": "Docked"
+      },
+      "zone_transition": {
+        "name": "Zone transition"
+      },
+      "private_cloud_connected": {
+        "name": "Private cloud connected"
+      },
+      "oauth_connected": {
+        "name": "Smart Home OAuth connected"
+      },
+      "mqtt_connected": {
+        "name": "MQTT connected"
+      },
+      "pose_valid": {
+        "name": "Live position valid"
+      }
     },
     "switch": {
-      "mowing_schedule_enabled": {"name": "Mowing schedule enabled"},
-      "night_mow": {"name": "Night mowing"},
-      "mowing_cycle": {"name": "Cyclic mowing"},
-      "rain_detection": {"name": "Rain"},
-      "rain_sensor": {"name": "Rain sensor"},
-      "weather_rain": {"name": "Weather forecast"},
-      "rain_delay_mode": {"name": "Delay after rain"},
-      "frost_delay": {"name": "Frost"},
-      "snow_delay": {"name": "Snow"},
-      "storm_delay": {"name": "Strong wind"},
-      "high_temp_delay": {"name": "Hot weather"},
-      "sound": {"name": "Sound"},
-      "power_saving": {"name": "Power saving"},
-      "night_light": {"name": "Night light"},
-      "child_lock": {"name": "Child lock"},
-      "lift_alarm": {"name": "Lift alarm"},
-      "geo_fence_alarm": {"name": "Geo-fence alarm"},
-      "efls": {"name": "Camera positioning (EFLS)"},
-      "obstacle_avoidance": {"name": "Obstacle avoidance"},
-      "traction_control": {"name": "Traction control"},
-      "animal_protection": {"name": "Animal-friendly"}
+      "mowing_schedule_enabled": {
+        "name": "Mowing schedule enabled"
+      },
+      "night_mow": {
+        "name": "Night mowing"
+      },
+      "mowing_cycle": {
+        "name": "Cyclic mowing"
+      },
+      "rain_detection": {
+        "name": "Rain"
+      },
+      "rain_sensor": {
+        "name": "Rain sensor"
+      },
+      "weather_rain": {
+        "name": "Weather forecast"
+      },
+      "rain_delay_mode": {
+        "name": "Delay after rain"
+      },
+      "frost_delay": {
+        "name": "Frost"
+      },
+      "snow_delay": {
+        "name": "Snow"
+      },
+      "storm_delay": {
+        "name": "Strong wind"
+      },
+      "high_temp_delay": {
+        "name": "Hot weather"
+      },
+      "sound": {
+        "name": "Sound"
+      },
+      "power_saving": {
+        "name": "Power saving"
+      },
+      "night_light": {
+        "name": "Night light"
+      },
+      "child_lock": {
+        "name": "Child lock"
+      },
+      "lift_alarm": {
+        "name": "Lift alarm"
+      },
+      "geo_fence_alarm": {
+        "name": "Geo-fence alarm"
+      },
+      "efls": {
+        "name": "Camera positioning (EFLS)"
+      },
+      "obstacle_avoidance": {
+        "name": "Obstacle avoidance"
+      },
+      "traction_control": {
+        "name": "Traction control"
+      },
+      "animal_protection": {
+        "name": "Animal-friendly"
+      }
     },
     "select": {
-      "zone": {"name": "Mow zone"},
+      "zone": {
+        "name": "Mow zone"
+      },
       "work_mode": {
         "name": "Work mode",
         "state": {
@@ -284,15 +408,29 @@
       }
     },
     "number": {
-      "return_battery_level": {"name": "Return-to-dock battery"},
-      "charging_limit": {"name": "Charging limit"},
-      "rain_delay_time": {"name": "Wait time after rain"},
-      "snow_delay_time": {"name": "Snow delay duration"},
-      "maximum_mowing_temperature": {"name": "Maximum mowing temperature"},
-      "geo_fence_radius": {"name": "Geo-fence radius"}
+      "return_battery_level": {
+        "name": "Return-to-dock battery"
+      },
+      "charging_limit": {
+        "name": "Charging limit"
+      },
+      "rain_delay_time": {
+        "name": "Wait time after rain"
+      },
+      "snow_delay_time": {
+        "name": "Snow delay duration"
+      },
+      "maximum_mowing_temperature": {
+        "name": "Maximum mowing temperature"
+      },
+      "geo_fence_radius": {
+        "name": "Geo-fence radius"
+      }
     },
     "time": {
-      "frost_delay_until": {"name": "Won't mow until after frost"}
+      "frost_delay_until": {
+        "name": "Won't mow until after frost"
+      }
     }
   }
 }

--- a/custom_components/navimower/translations/en.json
+++ b/custom_components/navimower/translations/en.json
@@ -70,9 +70,10 @@
     "step": {
       "init": {
         "title": "Navimower options",
-        "description": "Configure retained trail history, zone-pair gates and optional local X/Y channels.",
+        "description": "Configure retained trail history, Navimower Schedule, zone-pair gates and optional local X/Y gate areas.",
         "menu_options": {
           "general": "General and trail history",
+          "navimower_schedule": "Navimower Schedule",
           "gates": "Gates",
           "channels": "Gate areas"
         }
@@ -177,12 +178,29 @@
         "data": {
           "channel": "Gate area"
         }
+      },
+      "navimower_schedule": {
+        "title": "Navimower Schedule",
+        "description": "Choose which proven zones the integration may mow automatically and when it may work. Only zones with at least one confirmed successful completion can be selected. A new or difficult zone must first be fully completed manually once; completing it does not select it automatically. Start and end are used only in Time window mode.\\n\\nNot yet available for automatic mowing:\\n{unavailable_zones}",
+        "data": {
+          "navimower_schedule_zone_ids": "Automatic mowing zones",
+          "navimower_schedule_mode": "Allowed mowing time",
+          "navimower_schedule_start": "Start",
+          "navimower_schedule_end": "End"
+        },
+        "data_description": {
+          "navimower_schedule_zone_ids": "The scheduler only dispatches zones selected here. New zones are never added automatically.",
+          "navimower_schedule_mode": "Time window stops managed mowing outside the configured hours. 24 hours keeps the managed scheduler available continuously and starts a new round after every selected zone has completed.",
+          "navimower_schedule_start": "Used only in Time window mode.",
+          "navimower_schedule_end": "Used only in Time window mode."
+        }
       }
     },
     "error": {
       "same_zone": "Zone A and Zone B must be different.",
       "duplicate_gate": "A gate with the same name or zone pair already exists.",
-      "duplicate_channel": "A channel with the same name already exists."
+      "duplicate_channel": "A channel with the same name already exists.",
+      "schedule_same_time": "Start and end must be different when Allowed mowing time is Time window."
     },
     "abort": {
       "options_saved": "Navimower options were saved and the integration is reloading.",
@@ -198,67 +216,173 @@
       }
     },
     "sensor": {
-      "battery": {"name": "Battery"},
-      "state": {"name": "Status"},
-      "state_code": {"name": "State code"},
-      "mowing_progress": {"name": "Mowing progress"},
-      "current_zone": {"name": "Current zone"},
-      "session_area": {"name": "Session area"},
-      "weekly_area": {"name": "Area this week"},
-      "total_area": {"name": "Total area"},
-      "next_mow": {"name": "Next mow"},
-      "error_text": {"name": "Error"},
-      "signal_wifi": {"name": "Wi-Fi signal"},
-      "blades_life": {"name": "Blades life"},
-      "chassis_life": {"name": "Chassis life"},
-      "schedule": {"name": "Schedule"},
-      "coverage": {"name": "Coverage"},
-      "current_physical_zone": {"name": "Current physical zone"},
-      "target_zone": {"name": "Target zone"},
-      "current_channel": {"name": "Current channel"},
-      "cutting_height": {"name": "Global cutting height"},
-      "position_source": {"name": "Position source"},
-      "mqtt_stream_state": {"name": "MQTT position stream"},
-      "private_poll_age": {"name": "Private-cloud poll age"}
+      "battery": {
+        "name": "Battery"
+      },
+      "state": {
+        "name": "Status"
+      },
+      "state_code": {
+        "name": "State code"
+      },
+      "mowing_progress": {
+        "name": "Mowing progress"
+      },
+      "current_zone": {
+        "name": "Current zone"
+      },
+      "session_area": {
+        "name": "Session area"
+      },
+      "weekly_area": {
+        "name": "Area this week"
+      },
+      "total_area": {
+        "name": "Total area"
+      },
+      "next_mow": {
+        "name": "Next mow"
+      },
+      "error_text": {
+        "name": "Error"
+      },
+      "signal_wifi": {
+        "name": "Wi-Fi signal"
+      },
+      "blades_life": {
+        "name": "Blades life"
+      },
+      "chassis_life": {
+        "name": "Chassis life"
+      },
+      "schedule": {
+        "name": "Schedule"
+      },
+      "coverage": {
+        "name": "Coverage"
+      },
+      "current_physical_zone": {
+        "name": "Current physical zone"
+      },
+      "target_zone": {
+        "name": "Target zone"
+      },
+      "current_channel": {
+        "name": "Current channel"
+      },
+      "cutting_height": {
+        "name": "Global cutting height"
+      },
+      "position_source": {
+        "name": "Position source"
+      },
+      "mqtt_stream_state": {
+        "name": "MQTT position stream"
+      },
+      "private_poll_age": {
+        "name": "Private-cloud poll age"
+      }
     },
     "calendar": {
-      "schedule": {"name": "Mowing schedule"}
+      "schedule": {
+        "name": "Mowing schedule"
+      }
     },
     "binary_sensor": {
-      "problem": {"name": "Problem"},
-      "online": {"name": "Online"},
-      "docked": {"name": "Docked"},
-      "zone_transition": {"name": "Zone transition"},
-      "private_cloud_connected": {"name": "Private cloud connected"},
-      "oauth_connected": {"name": "Smart Home OAuth connected"},
-      "mqtt_connected": {"name": "MQTT connected"},
-      "pose_valid": {"name": "Live position valid"}
+      "problem": {
+        "name": "Problem"
+      },
+      "online": {
+        "name": "Online"
+      },
+      "docked": {
+        "name": "Docked"
+      },
+      "zone_transition": {
+        "name": "Zone transition"
+      },
+      "private_cloud_connected": {
+        "name": "Private cloud connected"
+      },
+      "oauth_connected": {
+        "name": "Smart Home OAuth connected"
+      },
+      "mqtt_connected": {
+        "name": "MQTT connected"
+      },
+      "pose_valid": {
+        "name": "Live position valid"
+      }
     },
     "switch": {
-      "mowing_schedule_enabled": {"name": "Mowing schedule enabled"},
-      "night_mow": {"name": "Night mowing"},
-      "mowing_cycle": {"name": "Cyclic mowing"},
-      "rain_detection": {"name": "Rain"},
-      "rain_sensor": {"name": "Rain sensor"},
-      "weather_rain": {"name": "Weather forecast"},
-      "rain_delay_mode": {"name": "Delay after rain"},
-      "frost_delay": {"name": "Frost"},
-      "snow_delay": {"name": "Snow"},
-      "storm_delay": {"name": "Strong wind"},
-      "high_temp_delay": {"name": "Hot weather"},
-      "sound": {"name": "Sound"},
-      "power_saving": {"name": "Power saving"},
-      "night_light": {"name": "Night light"},
-      "child_lock": {"name": "Child lock"},
-      "lift_alarm": {"name": "Lift alarm"},
-      "geo_fence_alarm": {"name": "Geo-fence alarm"},
-      "efls": {"name": "Camera positioning (EFLS)"},
-      "obstacle_avoidance": {"name": "Obstacle avoidance"},
-      "traction_control": {"name": "Traction control"},
-      "animal_protection": {"name": "Animal-friendly"}
+      "mowing_schedule_enabled": {
+        "name": "Mowing schedule enabled"
+      },
+      "night_mow": {
+        "name": "Night mowing"
+      },
+      "mowing_cycle": {
+        "name": "Cyclic mowing"
+      },
+      "rain_detection": {
+        "name": "Rain"
+      },
+      "rain_sensor": {
+        "name": "Rain sensor"
+      },
+      "weather_rain": {
+        "name": "Weather forecast"
+      },
+      "rain_delay_mode": {
+        "name": "Delay after rain"
+      },
+      "frost_delay": {
+        "name": "Frost"
+      },
+      "snow_delay": {
+        "name": "Snow"
+      },
+      "storm_delay": {
+        "name": "Strong wind"
+      },
+      "high_temp_delay": {
+        "name": "Hot weather"
+      },
+      "sound": {
+        "name": "Sound"
+      },
+      "power_saving": {
+        "name": "Power saving"
+      },
+      "night_light": {
+        "name": "Night light"
+      },
+      "child_lock": {
+        "name": "Child lock"
+      },
+      "lift_alarm": {
+        "name": "Lift alarm"
+      },
+      "geo_fence_alarm": {
+        "name": "Geo-fence alarm"
+      },
+      "efls": {
+        "name": "Camera positioning (EFLS)"
+      },
+      "obstacle_avoidance": {
+        "name": "Obstacle avoidance"
+      },
+      "traction_control": {
+        "name": "Traction control"
+      },
+      "animal_protection": {
+        "name": "Animal-friendly"
+      }
     },
     "select": {
-      "zone": {"name": "Mow zone"},
+      "zone": {
+        "name": "Mow zone"
+      },
       "work_mode": {
         "name": "Work mode",
         "state": {
@@ -284,15 +408,29 @@
       }
     },
     "number": {
-      "return_battery_level": {"name": "Return-to-dock battery"},
-      "charging_limit": {"name": "Charging limit"},
-      "rain_delay_time": {"name": "Wait time after rain"},
-      "snow_delay_time": {"name": "Snow delay duration"},
-      "maximum_mowing_temperature": {"name": "Maximum mowing temperature"},
-      "geo_fence_radius": {"name": "Geo-fence radius"}
+      "return_battery_level": {
+        "name": "Return-to-dock battery"
+      },
+      "charging_limit": {
+        "name": "Charging limit"
+      },
+      "rain_delay_time": {
+        "name": "Wait time after rain"
+      },
+      "snow_delay_time": {
+        "name": "Snow delay duration"
+      },
+      "maximum_mowing_temperature": {
+        "name": "Maximum mowing temperature"
+      },
+      "geo_fence_radius": {
+        "name": "Geo-fence radius"
+      }
     },
     "time": {
-      "frost_delay_until": {"name": "Won't mow until after frost"}
+      "frost_delay_until": {
+        "name": "Won't mow until after frost"
+      }
     }
   }
 }

--- a/tests/test_navimower_schedule_logic.py
+++ b/tests/test_navimower_schedule_logic.py
@@ -8,6 +8,7 @@ assert spec and spec.loader
 logic = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(logic)
 completion_advanced = logic.completion_advanced
+filter_schedule_zones = logic.filter_schedule_zones
 select_oldest_zone = logic.select_oldest_zone
 window_state = logic.window_state
 
@@ -29,9 +30,10 @@ def test_oldest_zone_and_guards():
         {"id": 2, "last_completed_at": "2026-08-13T10:00:00+00:00"},
         {"id": 3, "last_completed_at": None},
     ]
-    assert select_oldest_zone(zones)["id"] == 3
-    assert select_oldest_zone(zones, completed_in_window={3})["id"] == 2
-    assert select_oldest_zone(zones, completed_in_window={3}, just_completed_zone_id=2)["id"] == 1
+    assert select_oldest_zone(zones)["id"] == 2
+    assert select_oldest_zone(zones, completed_in_window={2})["id"] == 1
+    assert select_oldest_zone(zones, completed_in_window={2}, just_completed_zone_id=1) is None
+    assert [row["id"] for row in filter_schedule_zones(zones, [1, 2, 3])] == [1, 2]
 
 
 def test_scheduler_confirmed_completion_beats_stale_cloud_value():

--- a/tests/test_v043_beta15.py
+++ b/tests/test_v043_beta15.py
@@ -6,8 +6,6 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 
 def test_beta15_identity():
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta15"
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta15.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta15")
 

--- a/tests/test_v043_beta16.py
+++ b/tests/test_v043_beta16.py
@@ -1,0 +1,69 @@
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _schedule_logic():
+    spec = importlib.util.spec_from_file_location(
+        "navimower_schedule_logic_beta16", COMPONENT / "schedule_logic.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_beta16_identity():
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta16"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta16.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta16")
+
+
+def test_uncompleted_zone_is_not_eligible_or_ranked_first():
+    logic = _schedule_logic()
+    zones = [
+        {"id": 1, "name": "Never completed", "last_completed_at": None},
+        {"id": 2, "name": "Proven", "last_completed_at": "2026-08-17T10:00:00+00:00"},
+    ]
+    eligible = logic.filter_schedule_zones(zones, [1, 2])
+    assert [row["id"] for row in eligible] == [2]
+    assert logic.select_oldest_zone(zones)["id"] == 2
+
+
+def test_schedule_time_parser_accepts_time_selector_seconds():
+    logic = _schedule_logic()
+    assert logic.format_hhmm(logic.parse_hhmm("09:30:00", "10:00")) == "09:30"
+
+
+def test_options_flow_exposes_multi_zone_and_24_hour_configuration():
+    source = (COMPONENT / "config_flow.py").read_text(encoding="utf-8")
+    strings = json.loads((COMPONENT / "strings.json").read_text(encoding="utf-8"))
+    assert 'menu_options=["general", "navimower_schedule", "gates", "channels"]' in source
+    assert "multiple=True" in source
+    assert '"24 hours"' in source
+    assert '"unavailable_zones": self._schedule_unavailable_text()' in source
+    step = strings["options"]["step"]["navimower_schedule"]
+    assert step["data"]["navimower_schedule_zone_ids"] == "Automatic mowing zones"
+    assert "fully completed manually once" in step["description"]
+
+
+def test_scheduler_filters_allowlist_and_has_continuous_rounds():
+    source = (COMPONENT / "navimower_schedule.py").read_text(encoding="utf-8")
+    assert "def _eligible_zones" in source
+    assert "filter_schedule_zones(" in source
+    assert 'return True, "continuous"' in source
+    assert "eligible_ids.issubset(completed)" in source
+    assert 'self._runtime["round_index"]' in source
+    assert "Configure at least one successfully completed automatic mowing zone first" in source
+
+
+def test_existing_enabled_beta_scheduler_gets_one_time_explicit_allowlist_migration():
+    source = (COMPONENT / "navimower_schedule.py").read_text(encoding="utf-8")
+    assert "_legacy_selection_migration_allowed" in source
+    assert "def _maybe_migrate_legacy_zone_selection" in source
+    assert "OPT_SCHEDULE_ZONE_IDS: [str(value) for value in sorted(proven)]" in source
+    assert "future zones" in source


### PR DESCRIPTION
Adds the beta16 Configure/gear options for the managed scheduler: explicit multi-zone allowlist, confirmed-completion eligibility, Time window / 24 hours mode, compatibility migration for already-enabled beta schedulers, release notes and regression coverage. Remote builder passed the full test suite, compileall, diff-check, exact diff-scope validation and focused scheduler-options smoke checks on `f7a38d5d2a6acbad5eec2f4d0f9a20db1aad6d6f`.