### PR TITLE
Navimower 0.4.3-beta17: dock and scheduler options polish

### DIFF
--- a/.github/release-notes/0.4.3-beta17.md
+++ b/.github/release-notes/0.4.3-beta17.md
@@ -1,0 +1,16 @@
+title: Navimower 0.4.3-beta17
+
+Scheduler options polish and docked physical-area stabilization.
+
+### Fixed
+- A mower that is confirmed Docked/Charging now reports the virtual **Dock** physical area even when MQTT/private-cloud pose is stale, unavailable or falls outside the mowing polygons.
+- **24 hours** mode no longer shows irrelevant Start/End controls; selecting **Time window** opens a dedicated second step for those times.
+- The unavailable-zone explanation now uses real line breaks and disappears when there are no unavailable zones.
+
+### Safety
+- Dock is display/presence context only: it has no mowing-zone ID and does not affect zone progress or completion.
+- A pending mower activity command suppresses the dock override so dispatch away from the station is not hidden by a stale docked flag.
+
+### Unchanged
+- Automatic mowing still requires both an explicit user-selected zone and a confirmed prior successful completion.
+- Maintenance / Mowing Reports and Clear and resume / Reboot command discovery remain paused/read-only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
 
+## 0.4.3-beta17
+
+Scheduler options polish and docked physical-area stabilization.
+
+### Fixed
+
+- Show a confirmed docked or charging mower as the virtual `Dock` physical area instead of a stale lawn zone or `Outside mapped zones`.
+- Hide Start/End controls completely in 24-hour Navimower Schedule mode by moving Time window clocks to a dedicated second step.
+- Render the scheduler availability note with real line breaks and omit the `None` placeholder when every mapped zone is already eligible.
+
+### Safety
+
+- The Dock display override is suppressed while a local activity command is pending so a stale docked flag cannot mask a mower that has just been dispatched.
+- Dock remains a virtual physical area only (`zone_id: null`) and never participates in mowing progress or zone completion.
+
+
 ## 0.4.3-beta16
 
 Configure the integration-owned scheduler from the Navimower gear/options flow.

--- a/custom_components/navimower/config_flow.py
+++ b/custom_components/navimower/config_flow.py
@@ -520,6 +520,7 @@ class NavimowOptionsFlow(OptionsFlowWithReload):
     def __init__(self) -> None:
         self._gate_index: int | None = None
         self._channel_index: int | None = None
+        self._schedule_pending_zone_ids: list[str] | None = None
 
     def _options(self) -> dict[str, Any]:
         return dict(self.config_entry.options)
@@ -578,7 +579,13 @@ class NavimowOptionsFlow(OptionsFlowWithReload):
                 continue
             name = str(row.get("name") or f"Zone {row.get('id')}")
             rows.append(f"- {name} — Never completed")
-        return "\n".join(rows) if rows else "None"
+        if not rows:
+            return ""
+        return (
+            "Not yet available for automatic mowing:\n"
+            "These zones must be fully completed manually once before they can be selected:\n"
+            + "\n".join(rows)
+        )
 
     def _gates(self) -> list[NavimowerGate]:
         return parse_gates(self.config_entry.options.get(OPT_GATES))
@@ -654,7 +661,6 @@ class NavimowOptionsFlow(OptionsFlowWithReload):
     ) -> ConfigFlowResult:
         options = self._options()
         choices = self._schedule_zone_choices()
-        errors: dict[str, str] = {}
         if user_input is not None:
             selected = [
                 str(value)
@@ -662,23 +668,16 @@ class NavimowOptionsFlow(OptionsFlowWithReload):
                 if str(value) in choices
             ]
             mode = str(user_input.get(OPT_SCHEDULE_MODE) or DEFAULT_SCHEDULE_MODE)
-            start = format_hhmm(
-                parse_hhmm(user_input.get(OPT_SCHEDULE_START), DEFAULT_SCHEDULE_START)
-            )
-            end = format_hhmm(
-                parse_hhmm(user_input.get(OPT_SCHEDULE_END), DEFAULT_SCHEDULE_END)
-            )
-            if mode == SCHEDULE_MODE_WINDOW and start == end:
-                errors["base"] = "schedule_same_time"
-            else:
+            if mode == SCHEDULE_MODE_CONTINUOUS:
+                self._schedule_pending_zone_ids = None
                 return self._save(
                     **{
                         OPT_SCHEDULE_ZONE_IDS: selected,
-                        OPT_SCHEDULE_MODE: mode,
-                        OPT_SCHEDULE_START: start,
-                        OPT_SCHEDULE_END: end,
+                        OPT_SCHEDULE_MODE: SCHEDULE_MODE_CONTINUOUS,
                     }
                 )
+            self._schedule_pending_zone_ids = selected
+            return await self.async_step_navimower_schedule_window()
 
         selected_default = [
             str(value)
@@ -717,6 +716,50 @@ class NavimowOptionsFlow(OptionsFlowWithReload):
                             mode=SelectSelectorMode.LIST,
                         )
                     ),
+                }
+            ),
+            description_placeholders={
+                "unavailable_note": self._schedule_unavailable_text(),
+            },
+        )
+
+    async def async_step_navimower_schedule_window(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        options = self._options()
+        errors: dict[str, str] = {}
+        selected = self._schedule_pending_zone_ids
+        if selected is None:
+            choices = self._schedule_zone_choices()
+            selected = [
+                str(value)
+                for value in options.get(OPT_SCHEDULE_ZONE_IDS, []) or []
+                if str(value) in choices
+            ]
+        if user_input is not None:
+            start = format_hhmm(
+                parse_hhmm(user_input.get(OPT_SCHEDULE_START), DEFAULT_SCHEDULE_START)
+            )
+            end = format_hhmm(
+                parse_hhmm(user_input.get(OPT_SCHEDULE_END), DEFAULT_SCHEDULE_END)
+            )
+            if start == end:
+                errors["base"] = "schedule_same_time"
+            else:
+                self._schedule_pending_zone_ids = None
+                return self._save(
+                    **{
+                        OPT_SCHEDULE_ZONE_IDS: selected,
+                        OPT_SCHEDULE_MODE: SCHEDULE_MODE_WINDOW,
+                        OPT_SCHEDULE_START: start,
+                        OPT_SCHEDULE_END: end,
+                    }
+                )
+
+        return self.async_show_form(
+            step_id="navimower_schedule_window",
+            data_schema=vol.Schema(
+                {
                     vol.Required(
                         OPT_SCHEDULE_START,
                         default=str(options.get(OPT_SCHEDULE_START, DEFAULT_SCHEDULE_START)),
@@ -728,9 +771,6 @@ class NavimowOptionsFlow(OptionsFlowWithReload):
                 }
             ),
             errors=errors,
-            description_placeholders={
-                "unavailable_zones": self._schedule_unavailable_text(),
-            },
         )
 
     async def async_step_gates(

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta16"
+  "version": "0.4.3-beta17"
 }

--- a/custom_components/navimower/navigation_fallback.py
+++ b/custom_components/navimower/navigation_fallback.py
@@ -15,7 +15,7 @@ from dataclasses import replace
 from typing import Any
 
 from . import coordinator as _coordinator
-from .position_fallback import choose_position
+from .position_fallback import apply_docked_display_override, choose_position
 
 
 class _NavigationProxy:
@@ -133,6 +133,26 @@ def _decorate_navigation_result(
     age = context.get("age")
     stale = bool(context.get("stale"))
     position = context.get("position")
+
+    # Charging/docked state is authoritative for the virtual physical Dock area.
+    # Do this before pose decoration so an unavailable, stale or edge-flapping
+    # coordinate can never display a stationary docked mower as a lawn zone or
+    # Outside mapped zones. A pending command suppresses the override while a
+    # mower is being dispatched away from the station.
+    if apply_docked_display_override(
+        result,
+        docked=snapshot.get("docked") is True,
+        pending_activity=coordinator._pending_activity_value(),  # noqa: SLF001
+    ):
+        for state in (result.get("gate_states") or {}).values():
+            if not isinstance(state, dict):
+                continue
+            state["position_source"] = "state"
+            state["position_age"] = None
+            state["position_stale"] = False
+            state["mqtt_pose_valid"] = coordinator._fresh_mqtt_position() is not None  # noqa: SLF001
+            state["cloud_fallback"] = False
+        return result
 
     # Display follows the best available position independently from gate safety.
     # This also means the first cloud arrival sample may update the visible zone

--- a/custom_components/navimower/position_fallback.py
+++ b/custom_components/navimower/position_fallback.py
@@ -70,3 +70,40 @@ def choose_position(
         "stale": True,
         "gate_usable": False,
     }
+
+
+def apply_docked_display_override(
+    result: dict[str, Any],
+    *,
+    docked: bool,
+    pending_activity: Any,
+) -> bool:
+    """Expose a confirmed docked mower as the virtual Dock physical area.
+
+    Dock/charging state is stronger evidence for physical-area display than a
+    stale, unavailable or boundary-flapping pose. A pending local mowing,
+    pause or return command suppresses the override so the old docked flag
+    cannot mask a mower that has just been dispatched.
+    """
+    if not docked or pending_activity is not None:
+        return False
+
+    result.update(
+        {
+            "current_physical_zone": "Dock",
+            "current_physical_zone_id": None,
+            "current_physical_zone_source": "docked_state",
+            "current_physical_zone_position_source": "state",
+            "current_physical_zone_position_age": None,
+            "current_physical_zone_stale": False,
+            "current_channel": "Not in channel",
+            "current_channel_id": None,
+            "current_channel_connection": [],
+            "current_channel_distance": None,
+            "current_channel_source": "docked_state",
+            "current_channel_pose_age": None,
+            "current_channel_stale": False,
+            "current_channel_pose_valid": False,
+        }
+    )
+    return True

--- a/custom_components/navimower/strings.json
+++ b/custom_components/navimower/strings.json
@@ -181,18 +181,26 @@
       },
       "navimower_schedule": {
         "title": "Navimower Schedule",
-        "description": "Choose which proven zones the integration may mow automatically and when it may work. Only zones with at least one confirmed successful completion can be selected. A new or difficult zone must first be fully completed manually once; completing it does not select it automatically. Start and end are used only in Time window mode.\\n\\nNot yet available for automatic mowing:\\n{unavailable_zones}",
+        "description": "Choose which proven zones the integration may mow automatically and when it may work. Only zones with at least one confirmed successful completion can be selected. A new or difficult zone must first be fully completed manually once; completing it does not select it automatically.\n\n{unavailable_note}",
         "data": {
           "navimower_schedule_zone_ids": "Automatic mowing zones",
-          "navimower_schedule_mode": "Allowed mowing time",
+          "navimower_schedule_mode": "Allowed mowing time"
+        },
+        "data_description": {
+          "navimower_schedule_zone_ids": "The scheduler only dispatches zones selected here. New zones are never added automatically.",
+          "navimower_schedule_mode": "Time window asks for daily start and end times on the next screen. 24 hours keeps the managed scheduler available continuously and starts a new round after every selected zone has completed."
+        }
+      },
+      "navimower_schedule_window": {
+        "title": "Navimower Schedule — Time window",
+        "description": "Set the daily time window during which Navimower Schedule may mow. Outside this window the managed scheduler returns the mower home and preserves unfinished work for the next window.",
+        "data": {
           "navimower_schedule_start": "Start",
           "navimower_schedule_end": "End"
         },
         "data_description": {
-          "navimower_schedule_zone_ids": "The scheduler only dispatches zones selected here. New zones are never added automatically.",
-          "navimower_schedule_mode": "Time window stops managed mowing outside the configured hours. 24 hours keeps the managed scheduler available continuously and starts a new round after every selected zone has completed.",
-          "navimower_schedule_start": "Used only in Time window mode.",
-          "navimower_schedule_end": "Used only in Time window mode."
+          "navimower_schedule_start": "Daily managed mowing start time.",
+          "navimower_schedule_end": "Daily managed mowing end time."
         }
       }
     },

--- a/custom_components/navimower/translations/en.json
+++ b/custom_components/navimower/translations/en.json
@@ -181,18 +181,26 @@
       },
       "navimower_schedule": {
         "title": "Navimower Schedule",
-        "description": "Choose which proven zones the integration may mow automatically and when it may work. Only zones with at least one confirmed successful completion can be selected. A new or difficult zone must first be fully completed manually once; completing it does not select it automatically. Start and end are used only in Time window mode.\\n\\nNot yet available for automatic mowing:\\n{unavailable_zones}",
+        "description": "Choose which proven zones the integration may mow automatically and when it may work. Only zones with at least one confirmed successful completion can be selected. A new or difficult zone must first be fully completed manually once; completing it does not select it automatically.\n\n{unavailable_note}",
         "data": {
           "navimower_schedule_zone_ids": "Automatic mowing zones",
-          "navimower_schedule_mode": "Allowed mowing time",
+          "navimower_schedule_mode": "Allowed mowing time"
+        },
+        "data_description": {
+          "navimower_schedule_zone_ids": "The scheduler only dispatches zones selected here. New zones are never added automatically.",
+          "navimower_schedule_mode": "Time window asks for daily start and end times on the next screen. 24 hours keeps the managed scheduler available continuously and starts a new round after every selected zone has completed."
+        }
+      },
+      "navimower_schedule_window": {
+        "title": "Navimower Schedule — Time window",
+        "description": "Set the daily time window during which Navimower Schedule may mow. Outside this window the managed scheduler returns the mower home and preserves unfinished work for the next window.",
+        "data": {
           "navimower_schedule_start": "Start",
           "navimower_schedule_end": "End"
         },
         "data_description": {
-          "navimower_schedule_zone_ids": "The scheduler only dispatches zones selected here. New zones are never added automatically.",
-          "navimower_schedule_mode": "Time window stops managed mowing outside the configured hours. 24 hours keeps the managed scheduler available continuously and starts a new round after every selected zone has completed.",
-          "navimower_schedule_start": "Used only in Time window mode.",
-          "navimower_schedule_end": "Used only in Time window mode."
+          "navimower_schedule_start": "Daily managed mowing start time.",
+          "navimower_schedule_end": "Daily managed mowing end time."
         }
       }
     },

--- a/tests/test_v043_beta16.py
+++ b/tests/test_v043_beta16.py
@@ -45,7 +45,7 @@ def test_options_flow_exposes_multi_zone_and_24_hour_configuration():
     assert 'menu_options=["general", "navimower_schedule", "gates", "channels"]' in source
     assert "multiple=True" in source
     assert '"24 hours"' in source
-    assert '"unavailable_zones": self._schedule_unavailable_text()' in source
+    assert '"unavailable_note": self._schedule_unavailable_text()' in source
     step = strings["options"]["step"]["navimower_schedule"]
     assert step["data"]["navimower_schedule_zone_ids"] == "Automatic mowing zones"
     assert "fully completed manually once" in step["description"]

--- a/tests/test_v043_beta16.py
+++ b/tests/test_v043_beta16.py
@@ -16,9 +16,7 @@ def _schedule_logic():
     return module
 
 
-def test_beta16_identity():
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta16"
+def test_beta16_release_notes_remain_available():
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta16.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta16")
 

--- a/tests/test_v043_beta17.py
+++ b/tests/test_v043_beta17.py
@@ -1,0 +1,74 @@
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _position_fallback():
+    spec = importlib.util.spec_from_file_location(
+        "navimower_position_fallback_beta17", COMPONENT / "position_fallback.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_beta17_identity():
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta17"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta17.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta17")
+
+
+def test_docked_display_is_virtual_dock_even_from_outside_state():
+    helper = _position_fallback().apply_docked_display_override
+    result = {
+        "current_physical_zone": "Outside mapped zones",
+        "current_physical_zone_id": None,
+        "current_physical_zone_source": "pose_unavailable",
+        "current_physical_zone_stale": True,
+    }
+    assert helper(result, docked=True, pending_activity=None) is True
+    assert result["current_physical_zone"] == "Dock"
+    assert result["current_physical_zone_id"] is None
+    assert result["current_physical_zone_source"] == "docked_state"
+    assert result["current_physical_zone_position_source"] == "state"
+    assert result["current_physical_zone_stale"] is False
+    assert result["current_channel"] == "Not in channel"
+
+
+def test_pending_activity_suppresses_stale_dock_override():
+    helper = _position_fallback().apply_docked_display_override
+    result = {"current_physical_zone": "Yard"}
+    assert helper(result, docked=True, pending_activity="mowing") is False
+    assert result["current_physical_zone"] == "Yard"
+
+
+def test_24_hour_schedule_form_has_no_time_selectors():
+    source = (COMPONENT / "config_flow.py").read_text(encoding="utf-8")
+    first = source.index("    async def async_step_navimower_schedule(\n")
+    second = source.index("    async def async_step_navimower_schedule_window(\n", first)
+    main_step = source[first:second]
+    window_step = source[second:source.index("    async def async_step_gates(\n", second)]
+    assert "TimeSelector()" not in main_step
+    assert "SCHEDULE_MODE_CONTINUOUS" in main_step
+    assert "TimeSelector()" in window_step
+
+
+def test_scheduler_description_has_no_literal_backslash_newlines_or_none():
+    strings = json.loads((COMPONENT / "strings.json").read_text(encoding="utf-8"))
+    step = strings["options"]["step"]["navimower_schedule"]
+    assert "\\n" not in step["description"]
+    source = (COMPONENT / "config_flow.py").read_text(encoding="utf-8")
+    assert 'if not rows:\n            return ""' in source
+    assert '"unavailable_note": self._schedule_unavailable_text()' in source
+
+
+def test_navigation_fallback_uses_dock_override_before_pose_decoration():
+    source = (COMPONENT / "navigation_fallback.py").read_text(encoding="utf-8")
+    assert "apply_docked_display_override" in source
+    assert 'docked=snapshot.get("docked") is True' in source
+    assert 'state["position_source"] = "state"' in source


### PR DESCRIPTION
Finalizes the beta16 follow-up fixes without rewriting the published beta16 tag. Adds a virtual Dock physical-area override for confirmed Docked/Charging mowers so stale/unavailable/boundary poses cannot show a lawn zone or Outside mapped zones; the override keeps zone_id null and is suppressed while a local activity command is pending. Polishes Navimower Schedule options so 24-hour mode has no Start/End controls, Time window uses a dedicated second step, and the unavailable-zone note renders with real line breaks and disappears when empty. Remote beta build passed 188 tests, compileall, diff-check, exact diff-scope and focused scheduler/dock smoke checks at `f3f23deee468d7afdfd166e9e36a021303b9d965`.