### PR TITLE
Navimower 0.4.3-beta18: confirmed zone completion

### DIFF
--- a/.github/release-notes/0.4.3-beta18.md
+++ b/.github/release-notes/0.4.3-beta18.md
@@ -1,0 +1,17 @@
+title: Navimower 0.4.3-beta18
+
+Confirmed per-zone completion tracking.
+
+### Fixed
+- Zone **Last completed** no longer advances when a new task inherits stale high/100% progress and then immediately fails or returns to the dock.
+- A vendor progress reset/new-cycle start is only a cycle boundary; its start timestamp is no longer written as the previous cycle's completion.
+- Private-cloud `end_time + >=95%` remains diagnostic evidence but is no longer authoritative by itself.
+- On load, beta-era completion timestamps are removed when they were unverified vendor values or matched a recorded reset boundary.
+
+### Safety
+- Completion requires current-cycle evidence: Navimower must first observe the zone below the completion threshold and later at or above the existing **95%** threshold.
+- Error/failed returns cannot make an unconfirmed zone eligible for **Navimower Schedule**.
+
+### Unchanged
+- Navimower Schedule still requires explicit user selection and a confirmed successful completion before automatic mowing.
+- Maintenance / Mowing Reports and Clear and resume / Reboot command discovery remain unchanged/read-only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
 
+## 0.4.3-beta18
+
+Confirmed per-zone completion tracking.
+
+### Fixed
+
+- Do not advance zone `last_completed` when a task starts with stale high progress and then immediately fails/returns to the dock.
+- Do not stamp `last_completed` at a vendor progress-reset/new-cycle boundary; that timestamp is the next cycle start, not the previous cycle completion.
+- Stop treating private-cloud `end_time + >=95%` as authoritative completion evidence.
+- Repair persisted beta-era completion timestamps that were unverified vendor values or matched a recorded reset boundary.
+
+### Safety
+
+- Completion requires current-cycle evidence: the zone must first be observed below the completion threshold and later at or above the existing 95% threshold.
+- Failed/error returns can close the route session without making an unconfirmed zone eligible for Navimower Schedule.
+
+
 ## 0.4.3-beta17
 
 Scheduler options polish and docked physical-area stabilization.

--- a/custom_components/navimower/coordinator.py
+++ b/custom_components/navimower/coordinator.py
@@ -1472,43 +1472,22 @@ class NavimowCoordinator(DataUpdateCoordinator[dict]):
         snapshot["active_cycle_id"] = (self.history.active_session or {}).get("id")
 
     def _session_completed(self, snapshot: dict[str, Any]) -> bool | None:
+        """Return success only for zones confirmed inside this observed cycle."""
+        del snapshot
         active = self.history.active_session
         if not active:
             return None
         selected = {
-            parsed
-            for value in active.get("zone_ids") or []
-            if (parsed := _as_int(value)) is not None
+            value for raw in active.get("zone_ids") or []
+            if (value := _as_int(raw)) is not None
         }
-        task_progress = active.get("task_zone_progress") or {}
-        if selected and task_progress:
-            values = [_progress_percent(task_progress.get(str(zone_id))) for zone_id in selected]
-            known = [value for value in values if value is not None]
-            if len(known) == len(selected):
-                return all(value >= VENDOR_COMPLETION_PROGRESS_MIN for value in known)
-        percentages = {
-            _as_int(item.get("id")): _progress_percent(
-                item.get("progress")
-                if item.get("progress") is not None
-                else item.get("percentage")
-            )
-            for item in snapshot.get("zone_details") or []
-            if isinstance(item, dict) and _as_int(item.get("id")) is not None
+        if not selected:
+            return None
+        confirmed = {
+            value for raw in active.get("task_zone_completion_confirmed") or []
+            if (value := _as_int(raw)) is not None
         }
-        for item in (snapshot.get("coverage") or {}).get("zones") or []:
-            if not isinstance(item, dict):
-                continue
-            zone_id = _as_int(item.get("id"))
-            if zone_id is None or percentages.get(zone_id) is not None:
-                continue
-            percentages[zone_id] = _progress_percent(item.get("pct"))
-        relevant = (
-            [percentages.get(zone_id) for zone_id in selected]
-            if selected
-            else list(percentages.values())
-        )
-        known = [value for value in relevant if value is not None]
-        return all(value >= VENDOR_COMPLETION_PROGRESS_MIN for value in known) if known else None
+        return selected.issubset(confirmed)
 
     def _active_cutting_height(self, snapshot: dict[str, Any]) -> int | None:
         if snapshot.get("cutting_height_supported") is False:
@@ -2031,12 +2010,15 @@ class NavimowCoordinator(DataUpdateCoordinator[dict]):
                         if (end_time or start_time)
                         else None
                     ),
-                    "last_completed_at": (
+                    "vendor_start_time": start_time,
+                    "vendor_end_time": end_time,
+                    "vendor_completed_at": (
                         dt_util.utc_from_timestamp(end_time).isoformat()
                         if end_time
                         and (percentage or 0) >= VENDOR_COMPLETION_PROGRESS_MIN
                         else None
                     ),
+                    "last_completed_at": None,
                     "cutting_height_supported": cutting_height_supported,
                     "configured_height_raw": raw_height,
                     "configured_height_mm": configured_height,

--- a/custom_components/navimower/history.py
+++ b/custom_components/navimower/history.py
@@ -116,6 +116,18 @@ def _iso(ms: int | None) -> str | None:
         return None
 
 
+def _iso_ms(value: Any) -> int | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return int(parsed.timestamp() * 1000)
+    except (TypeError, ValueError, OverflowError, OSError):
+        return None
+
+
 def _metadata(session: dict[str, Any]) -> dict[str, Any]:
     return {
         "id": session.get("id"),
@@ -305,6 +317,15 @@ def _merge_session_records(
         previous.get("cycle_reset_zone_ids"),
         continuation.get("cycle_reset_zone_ids"),
     )
+    task_progress = dict(previous.get("task_zone_progress") or {})
+    task_progress.update(continuation.get("task_zone_progress") or {})
+    merged["task_zone_progress"] = task_progress
+    merged["task_zone_seen_incomplete"] = _unique_ints(
+        previous.get("task_zone_seen_incomplete"), continuation.get("task_zone_seen_incomplete")
+    )
+    merged["task_zone_completion_confirmed"] = _unique_ints(
+        previous.get("task_zone_completion_confirmed"), continuation.get("task_zone_completion_confirmed")
+    )
     merged["zone_cycle_boundaries"] = sorted(
         [dict(item) for item in [
             *(previous.get("zone_cycle_boundaries") or []),
@@ -466,6 +487,7 @@ class NavimowerHistory:
                 await self._index_store.async_save(self._index_data())
 
         await self._async_merge_adjacent_sessions()
+        await self._async_repair_unverified_zone_completions()
         await self._async_remove_empty_completed_sessions()
         await self._async_migrate_legacy_store()
         with self._lock:
@@ -598,6 +620,41 @@ class NavimowerHistory:
             self._session_stores.pop(session_id, None)
         await self._index_store.async_save(self._index_data())
         _LOGGER.info("Removed %d empty Navimower session stub(s)", len(removable))
+
+    async def _async_repair_unverified_zone_completions(self) -> None:
+        """Remove beta-era raw-vendor/reset-boundary completion timestamps."""
+        repaired = 0
+        with self._lock:
+            reset_boundaries: dict[int, list[int]] = {}
+            for session in self._cache.values():
+                for item in (session or {}).get("zone_cycle_boundaries") or []:
+                    if not isinstance(item, dict):
+                        continue
+                    zone_id, at_ms = _as_int(item.get("zone_id")), _as_int(item.get("at_ms"))
+                    if zone_id is not None and at_ms is not None:
+                        reset_boundaries.setdefault(zone_id, []).append(at_ms)
+            for key, original in list(self._zone_history.items()):
+                record = dict(original)
+                completed_ms = _iso_ms(record.get("last_completed_at"))
+                if completed_ms is None:
+                    continue
+                zone_id = _as_int(record.get("id")) or _as_int(key)
+                unverified = _as_int(record.get("last_completed_progress")) is None
+                reset_stamp = bool(
+                    zone_id is not None and any(
+                        abs(completed_ms - boundary) <= 60_000
+                        for boundary in reset_boundaries.get(zone_id, [])
+                    )
+                )
+                if not (unverified or reset_stamp):
+                    continue
+                record.pop("last_completed_at", None)
+                record.pop("last_completed_progress", None)
+                self._zone_history[str(key)] = record
+                repaired += 1
+        if repaired:
+            await self._index_store.async_save(self._index_data())
+            _LOGGER.info("Removed %d unverified Navimower zone completion timestamp(s)", repaired)
 
     async def _async_migrate_legacy_store(self) -> None:
         if self._sessions or self._active_id:
@@ -785,6 +842,10 @@ class NavimowerHistory:
             if mode and not active.get("mode"):
                 active["mode"] = mode
             if completed is not None:
+                if completed is True:
+                    selected = set(_unique_ints(active.get("zone_ids")))
+                    confirmed = set(_unique_ints(active.get("task_zone_completion_confirmed")))
+                    completed = bool(selected) and selected.issubset(confirmed)
                 active["completed"] = completed
 
             # Once a mowing session exists, preserve transit and pause positions.
@@ -884,6 +945,8 @@ class NavimowerHistory:
             "cycle_reset_zone_ids": cycle_reset_zone_ids,
             "visited_zone_ids": [],
             "task_zone_progress": {str(value): 0 for value in zone_ids},
+            "task_zone_seen_incomplete": [],
+            "task_zone_completion_confirmed": [],
             "segment_starts_ms": [start_ms],
             "points": [],
         }
@@ -926,6 +989,8 @@ class NavimowerHistory:
         previous["final_progress"] = {}
         previous.setdefault("visited_zone_ids", [])
         previous.setdefault("task_zone_progress", {})
+        previous.setdefault("task_zone_seen_incomplete", [])
+        previous.setdefault("task_zone_completion_confirmed", [])
         previous["zone_ids"] = _unique_ints(
             previous.get("zone_ids"), zone_ids
         )
@@ -1137,7 +1202,6 @@ class NavimowerHistory:
             active_zones = _unique_ints((active or {}).get("zone_ids") or [])
             relevant = active_zones or requested
             final_progress: dict[str, int] = {}
-            known_progress: list[int] = []
             for zone_id in relevant:
                 state = self._zone_progress_state.get(str(zone_id)) or {}
                 progress = _as_int(state.get("peak_progress"))
@@ -1145,10 +1209,8 @@ class NavimowerHistory:
                     progress = _as_int(state.get("progress"))
                 if progress is not None:
                     final_progress[str(zone_id)] = progress
-                    known_progress.append(progress)
-            completed = bool(known_progress) and all(
-                value >= VENDOR_COMPLETION_PROGRESS_MIN for value in known_progress
-            )
+            confirmed = set(_unique_ints((active or {}).get("task_zone_completion_confirmed")))
+            completed = bool(relevant) and set(relevant).issubset(confirmed)
             if active is not None:
                 completed = bool(active.get("completed") is True or completed)
                 active["completed"] = completed
@@ -1159,17 +1221,6 @@ class NavimowerHistory:
                     self._discard_active_locked()
                 else:
                     self._finish_active_locked(boundary_ms)
-            if completed:
-                for zone_id in relevant:
-                    progress = final_progress.get(str(zone_id))
-                    record = dict(self._zone_history.get(str(zone_id)) or {})
-                    record.update({
-                        "id": zone_id,
-                        "name": record.get("name") or f"Zone {zone_id}",
-                        "last_completed_at": _iso(boundary_ms),
-                        "last_completed_progress": progress,
-                    })
-                    self._zone_history[str(zone_id)] = record
             self._force_new_session_once = True
             self._force_new_cycle_zone_ids = list(relevant)
             self._last_cycle_event = {
@@ -1227,6 +1278,7 @@ class NavimowerHistory:
                 final_progress: dict[str, int] = {}
                 completed_flags: list[bool] = []
                 boundaries = active.setdefault("zone_cycle_boundaries", [])
+                confirmed_before = set(_unique_ints(active.get("task_zone_completion_confirmed")))
                 for _previous, row, previous_peak in reset_rows:
                     zone_id = _as_int(row.get("id"))
                     if zone_id is None:
@@ -1238,12 +1290,24 @@ class NavimowerHistory:
                         boundaries.append({"zone_id": zone_id, "at_ms": at_ms, "at": _iso(at_ms), "reason": "vendor_progress_reset", "previous_peak": previous_peak})
                     reset_zone_ids.append(zone_id)
                     final_progress[str(zone_id)] = previous_peak
-                    completed_zone = previous_peak >= VENDOR_COMPLETION_PROGRESS_MIN
+                    completed_zone = zone_id in confirmed_before
                     completed_flags.append(completed_zone)
-                    if completed_zone:
-                        record = dict(self._zone_history.get(str(zone_id)) or {})
-                        record.update({"id": zone_id, "name": row.get("name") or record.get("name") or f"Zone {zone_id}", "last_completed_at": _iso(at_ms), "last_completed_progress": previous_peak})
-                        self._zone_history[str(zone_id)] = record
+                reset_set = set(reset_zone_ids)
+                active["task_zone_seen_incomplete"] = [
+                    value for value in _unique_ints(active.get("task_zone_seen_incomplete"))
+                    if value not in reset_set
+                ]
+                active["task_zone_completion_confirmed"] = [
+                    value for value in _unique_ints(active.get("task_zone_completion_confirmed"))
+                    if value not in reset_set
+                ]
+                task_progress = active.setdefault("task_zone_progress", {})
+                for zone_id in reset_set:
+                    task_progress[str(zone_id)] = 0
+                if active.get("completion_reason") == "vendor_progress":
+                    active["completed"] = None
+                    active["completion_reason"] = None
+                    active["final_progress"] = {}
                 self._update_active_metadata_locked(active)
                 self._last_cycle_event = {"reason": "vendor_zone_cycle_reset", "at_ms": boundary_ms, "at": _iso(boundary_ms), "zone_ids": _unique_ints(reset_zone_ids), "completed": bool(completed_flags) and all(completed_flags), "final_progress": final_progress, "source": "vendor_progress"}
                 self._trail_revision += 1
@@ -1327,7 +1391,6 @@ class NavimowerHistory:
                 for key in (
                     "last_started_at",
                     "last_mowed_at",
-                    "last_completed_at",
                 ):
                     value = detail.get(key)
                     if value:
@@ -1346,6 +1409,8 @@ class NavimowerHistory:
                 task_progress = active.setdefault("task_zone_progress", {})
                 for zone_id in active.get("zone_ids") or []:
                     task_progress.setdefault(str(zone_id), 0)
+                seen_incomplete = set(_unique_ints(active.get("task_zone_seen_incomplete")))
+                completion_confirmed = set(_unique_ints(active.get("task_zone_completion_confirmed")))
                 active_zone_id = _as_int(active_progress_zone_id)
                 if active_zone_id is not None:
                     active_detail = next(
@@ -1369,6 +1434,11 @@ class NavimowerHistory:
                                 else active_detail.get("percentage")
                             )
                         if progress is not None:
+                            if progress < VENDOR_COMPLETION_PROGRESS_MIN:
+                                seen_incomplete.add(active_zone_id)
+                                completion_confirmed.discard(active_zone_id)
+                            elif active_zone_id in seen_incomplete:
+                                completion_confirmed.add(active_zone_id)
                             previous_progress = _as_int(
                                 task_progress.get(str(active_zone_id))
                             )
@@ -1398,6 +1468,8 @@ class NavimowerHistory:
                                 task_progress[str(active_zone_id)] = max(
                                     previous_progress or 0, progress
                                 )
+                active["task_zone_seen_incomplete"] = sorted(seen_incomplete)
+                active["task_zone_completion_confirmed"] = sorted(completion_confirmed)
                 if active.get("cutting_height_mm") is None:
                     target_ids = set(active.get("zone_ids") or [])
                     candidates = [
@@ -1408,15 +1480,10 @@ class NavimowerHistory:
                     known = [value for value in candidates if value is not None]
                     if len(set(known)) == 1:
                         active["cutting_height_mm"] = known[0]
-                percentages = [
-                    _as_int(task_progress.get(str(zone_id)))
-                    for zone_id in active.get("zone_ids") or []
-                    if _as_int(task_progress.get(str(zone_id))) is not None
-                ]
+                selected_zone_ids = _unique_ints(active.get("zone_ids"))
                 if (
-                    percentages
-                    and len(percentages) == len(active.get("zone_ids") or [])
-                    and all(value >= VENDOR_COMPLETION_PROGRESS_MIN for value in percentages)
+                    selected_zone_ids
+                    and set(selected_zone_ids).issubset(completion_confirmed)
                 ):
                     active["completed"] = True
                     active["completion_reason"] = (

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta17"
+  "version": "0.4.3-beta18"
 }

--- a/tests/test_history_merge.py
+++ b/tests/test_history_merge.py
@@ -358,9 +358,9 @@ async def cycle_reset_split_test() -> None:
     assert len(boundaries) == 1
     assert boundaries[0]["zone_id"] == 24
     assert boundaries[0]["previous_peak"] == 98
-    zone_history = manager.zone_history()["24"]
-    assert zone_history["last_completed_progress"] == 98
-    assert zone_history["last_completed_at"]
+    zone_history = manager.zone_history().get("24", {})
+    assert "last_completed_progress" not in zone_history
+    assert "last_completed_at" not in zone_history
 
     if hass.tasks:
         await asyncio.gather(*hass.tasks)
@@ -435,6 +435,12 @@ def practical_completion_threshold_test() -> None:
         physical_zone_id=13,
     )
     manager.update_zone_history(
+        {"zones": [{"id": 13, "pct": 40}]},
+        [{"id": 13, "name": "Street", "percentage": 40}],
+        active_zone_progress=40,
+        active_progress_zone_id=13,
+    )
+    manager.update_zone_history(
         {"zones": [{"id": 13, "pct": 97}]},
         [{"id": 13, "name": "Street", "percentage": 97}],
         active_zone_progress=97,
@@ -464,6 +470,12 @@ async def dock_completion_history_test() -> None:
         returning=False,
         zone_ids=[24],
         physical_zone_id=24,
+    )
+    manager.update_zone_history(
+        {"zones": [{"id": 24, "pct": 23}]},
+        [{"id": 24, "name": "Yard", "progress": 23, "percentage": 23}],
+        active_zone_progress=23,
+        active_progress_zone_id=24,
     )
     manager.update_zone_history(
         {"zones": [{"id": 24, "pct": 97}]},
@@ -624,3 +636,55 @@ async def vendor_partial_reset_test() -> None:
 
 asyncio.run(vendor_partial_reset_test())
 print("explicit and vendor partial reset tests passed")
+
+
+async def beta18_stale_high_error_return_test() -> None:
+    Store.values.clear()
+    hass = FakeHass()
+    manager = history.NavimowerHistory(hass, "entry-beta18-error", "TEST")
+    manager.process_pose(position={"x": 5.0, "y": 5.0}, pose_time=2_700_000_000, heading=0.0,
+        activity="mowing", cutting=True, docked=False, returning=False, zone_ids=[24], physical_zone_id=24)
+    manager.update_zone_history(
+        {"zones": [{"id": 24, "pct": 98}]},
+        [{"id": 24, "name": "Yard", "progress": 98, "percentage": 98,
+          "last_completed_at": history._iso(2_700_000_010_000)}],
+        active_zone_progress=98, active_progress_zone_id=24)
+    active = manager.active_session
+    assert active and active["completed"] is not True
+    assert active["task_zone_completion_confirmed"] == []
+    assert "last_completed_at" not in manager.zone_history()["24"]
+    manager.process_pose(position={"x": 5.1, "y": 5.1}, pose_time=2_700_000_020, heading=0.0,
+        activity="docked", cutting=False, docked=True, returning=False, zone_ids=[24], completed=True)
+    assert "last_completed_at" not in manager.zone_history()["24"]
+    assert manager.session_summaries(include_points=True)[-1]["completed"] is False
+    if hass.tasks:
+        await asyncio.gather(*hass.tasks)
+
+asyncio.run(beta18_stale_high_error_return_test())
+
+async def beta18_persisted_false_completion_repair_test() -> None:
+    Store.values.clear()
+    reset_ms = 2_800_000_020_000
+    reset_session = session("1", 2_800_000_000_000, 2_800_000_030_000)
+    reset_session["zone_ids"] = [24]
+    reset_session["zone_cycle_boundaries"] = [{"zone_id": 24, "at_ms": reset_ms, "reason": "vendor_progress_reset"}]
+    Store.values["navimower_sessions_entry-beta18-repair"] = {
+        "sn": "TEST", "sequence": 1, "active_id": None,
+        "sessions": [history._metadata(reset_session)],
+        "zone_history": {
+            "13": {"id": 13, "last_completed_at": history._iso(2_800_000_010_000)},
+            "24": {"id": 24, "last_completed_at": history._iso(reset_ms), "last_completed_progress": 98},
+            "42": {"id": 42, "last_completed_at": history._iso(2_799_000_000_000), "last_completed_progress": 97},
+        },
+    }
+    Store.values["navimower_session_entry-beta18-repair_1"] = reset_session
+    manager = history.NavimowerHistory(FakeHass(), "entry-beta18-repair", "TEST")
+    await manager.async_load()
+    repaired = manager.zone_history()
+    assert "last_completed_at" not in repaired["13"]
+    assert "last_completed_at" not in repaired["24"]
+    assert repaired["42"]["last_completed_progress"] == 97
+    assert repaired["42"]["last_completed_at"]
+
+asyncio.run(beta18_persisted_false_completion_repair_test())
+print("beta18 completion safety tests passed")

--- a/tests/test_v043_beta17.py
+++ b/tests/test_v043_beta17.py
@@ -16,9 +16,7 @@ def _position_fallback():
     return module
 
 
-def test_beta17_identity():
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta17"
+def test_beta17_release_notes_remain_available():
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta17.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta17")
 

--- a/tests/test_v043_beta18.py
+++ b/tests/test_v043_beta18.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta18_identity():
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta18"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta18.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta18")
+
+
+def test_completion_is_current_cycle_confirmed():
+    coordinator = (COMPONENT / "coordinator.py").read_text(encoding="utf-8")
+    history = (COMPONENT / "history.py").read_text(encoding="utf-8")
+    assert '"vendor_completed_at": (' in coordinator
+    assert '"last_completed_at": None' in coordinator
+    assert '"task_zone_seen_incomplete"' in history
+    assert '"task_zone_completion_confirmed"' in history
+    assert "_async_repair_unverified_zone_completions" in history
+    start = history.index("    def prepare_cycle(\n")
+    end = history.index("    def cycle_diagnostics", start)
+    assert '"last_completed_at"' not in history[start:end]


### PR DESCRIPTION
## Summary

Fixes the false per-zone `last_completed` updates reported during failed/error starts and stale high-progress transitions.

- Require current-cycle completion evidence: a zone must be observed below the existing 95% threshold and later at/above 95% before it is confirmed complete.
- Stop treating private-cloud `end_time + >=95%` as authoritative completion by itself; retain it as diagnostic evidence only.
- Treat vendor progress resets/new-cycle timestamps strictly as cycle boundaries, not previous-cycle completion timestamps.
- Prevent an error/failed return to dock from making an unconfirmed zone complete or eligible for Navimower Schedule.
- Repair beta-era persisted completion timestamps that were unverified raw-vendor values or matched a recorded reset boundary.
- Keep the existing 95% completion threshold and unrelated 0.4.3 behavior unchanged.

## Validation

Remote beta builder passed the full pytest suite, compileall, `git diff --check`, exact diff-scope validation and focused completion-safety checks before publishing `release/0.4.3-beta18` at `8259fb8aaefb3a3aebaa56dcba760fa5a0393ecc`.

The initial build attempts failed safely before publishing the release branch and were used to correct validation-only regressions; no prerelease/tag was created from those failed attempts.