### PR TITLE
Navimower 0.4.3-beta19: schedule window/restart hardening

### DIFF
--- a/.github/release-notes/0.4.3-beta19.md
+++ b/.github/release-notes/0.4.3-beta19.md
@@ -1,0 +1,17 @@
+title: Navimower 0.4.3-beta19
+
+Navimower Schedule window/restart hardening.
+
+### Fixed
+- A stale unconfirmed new-zone start can no longer block **Navimower Schedule** indefinitely after a Home Assistant restart or a lost immediate state transition.
+- If a new-zone `mow` command is still unconfirmed after **120 seconds**, Navimower clears that stale pending command and suspends the scheduler instead of automatically repeating a `reset=true` start.
+- If the mower later reports Mowing for the retained active zone, the scheduler clears that safety suspension and resumes normal tracking automatically.
+
+### Safety
+- **Time window** remains the hard outer gate. If the mower is observed Mowing or Paused outside the configured window, Navimower sends Dock/Home and retains the interrupted zone/progress for the next allowed resume.
+- **24 hours** mode deliberately does not inspect or override **Night mowing**. With Night mowing off, the mower may pause around sunset and resume according to its own retained-task/daylight logic; with it on, mowing can continue overnight.
+- Home Assistant restart restores the saved scheduler runtime. Already-confirmed active mowing is not restarted and no new cycle is created just because Home Assistant restarted.
+
+### Unchanged
+- Low-battery charging, sunset/night pauses and other mower-internal pauses remain controlled by the mower while the Navimower window is open.
+- Interrupted-task recovery still prefers the vendor Resume command and then `mow(reset=false)`; automatic reset fallback remains refused.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
 
+## 0.4.3-beta19
+
+Navimower Schedule window/restart hardening.
+
+### Fixed
+
+- Prevent a stale unconfirmed new-zone `mow` command from blocking Navimower Schedule forever after Home Assistant restarts or loses the immediate state transition.
+- After 120 seconds without a confirmed Mowing state, clear the stale pending command and suspend safely instead of automatically repeating a `reset=true` start.
+- Recover automatically if the mower later confirms that same active-zone mowing start.
+
+### Safety
+
+- Keep Time window as the hard outer gate: an observed Mowing/Paused state outside the window is sent Dock/Home while the interrupted zone and progress are retained for resume.
+- Keep 24 hours mode independent from the mower's Night mowing setting; sunset/sunrise pauses remain the mower/user setting's responsibility.
+- A Home Assistant restart during already-confirmed mowing restores scheduler runtime without starting a new mowing cycle.
+
+
 ## 0.4.3-beta18
 
 Confirmed per-zone completion tracking.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta18"
+  "version": "0.4.3-beta19"
 }

--- a/custom_components/navimower/navimower_schedule.py
+++ b/custom_components/navimower/navimower_schedule.py
@@ -51,6 +51,7 @@ _STORE_VERSION = 1
 _TICK_SECONDS = 20
 _RESUME_CONFIRM_SECONDS = 90
 _CONTINUE_CONFIRM_SECONDS = 120
+_MOW_CONFIRM_SECONDS = 120
 _DOCK_RETRY_SECONDS = 60
 _RETRY_NEW_MOW_SECONDS = 30
 
@@ -408,6 +409,35 @@ class NavimowerScheduleController:
         pending = self._runtime.get("pending_command")
         return _age_seconds(pending.get("sent_at")) if isinstance(pending, dict) else None
 
+    async def _reconcile_unconfirmed_mow_start(self, activity: Any) -> None:
+        """Recover safely when a new-zone start confirmation is lost across restart."""
+        pending = self._runtime.get("pending_command")
+        if isinstance(pending, dict) and pending.get("kind") == "mow":
+            age = self._pending_age()
+            if age is not None and age >= _MOW_CONFIRM_SECONDS and activity != ACTIVITY_MOWING:
+                zone_id = pending.get("zone_id") or self._runtime.get("active_zone_id")
+                self._runtime["pending_command"] = None
+                self._runtime["suspended_reason"] = "mow_start_not_confirmed"
+                self._runtime["last_error"] = (
+                    "New-zone mowing start was not confirmed; automatic reset retry was refused"
+                )
+                self._runtime["last_command"] = f"mow_start_unconfirmed:{zone_id}"
+                self._runtime["last_command_at"] = _utc_now()
+                await self._save()
+                return
+
+        if (
+            self._runtime.get("suspended_reason") == "mow_start_not_confirmed"
+            and activity == ACTIVITY_MOWING
+            and self._runtime.get("active_zone_id") is not None
+        ):
+            zone_id = self._runtime.get("active_zone_id")
+            self._runtime["suspended_reason"] = None
+            self._runtime["last_error"] = None
+            self._runtime["last_command"] = f"late_mow_confirmed:{zone_id}"
+            self._runtime["last_command_at"] = _utc_now()
+            await self._save()
+
     def _retry_ready(self) -> bool:
         stamp = self._runtime.get("retry_not_before")
         parsed = parse_iso(stamp)
@@ -451,6 +481,7 @@ class NavimowerScheduleController:
         completed_now = await self._confirm_active_completion()
         activity = data.get("activity")
         await self._confirm_pending(activity)
+        await self._reconcile_unconfirmed_mow_start(activity)
 
         if not in_window:
             await self._enforce_closed_window(activity)

--- a/tests/test_v043_beta18.py
+++ b/tests/test_v043_beta18.py
@@ -1,13 +1,10 @@
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta18_identity():
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta18"
+def test_beta18_release_notes_remain_available():
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta18.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta18")
 

--- a/tests/test_v043_beta19.py
+++ b/tests/test_v043_beta19.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta19_identity():
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta19"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta19.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta19")
+
+
+def test_24_hour_mode_leaves_night_mowing_to_the_mower():
+    source = (COMPONENT / "navimower_schedule.py").read_text(encoding="utf-8")
+    start = source.index("    def _window_state(self, now: datetime)")
+    end = source.index("    def _zone(self, zone_id", start)
+    resolver = source[start:end]
+    assert 'return True, "continuous"' in resolver
+    assert "night_mow" not in source
+    assert "sunrise" not in resolver.lower()
+    assert "sunset" not in resolver.lower()
+
+
+def test_closed_window_is_a_hard_outer_gate_even_when_scheduler_is_suspended():
+    source = (COMPONENT / "navimower_schedule.py").read_text(encoding="utf-8")
+    evaluate = source[source.index("    async def _evaluate_locked"):]
+    closed = evaluate.index("        if not in_window:")
+    suspended = evaluate.index('        if self._runtime.get("suspended_reason"):', closed)
+    assert closed < suspended
+    enforce_start = source.index("    async def _enforce_closed_window")
+    enforce_end = source.index("    async def _continue_interrupted_task", enforce_start)
+    enforce = source[enforce_start:enforce_end]
+    assert "ACTIVITY_MOWING, ACTIVITY_PAUSED" in enforce
+    assert 'await self._async_send_dock("navimower_schedule_window_closed")' in enforce
+    assert 'self._runtime["resume_pending"] = True' in enforce
+    assert 'self._runtime["progress_before_interrupt"]' in enforce
+
+
+def test_restart_restores_runtime_and_reconciles_stale_new_zone_start():
+    source = (COMPONENT / "navimower_schedule.py").read_text(encoding="utf-8")
+    assert "restored.update" in source
+    assert "self._runtime = restored" in source
+    assert "self._queue_evaluation()" in source
+    assert "_MOW_CONFIRM_SECONDS = 120" in source
+    assert "_reconcile_unconfirmed_mow_start" in source
+    assert '"mow_start_not_confirmed"' in source
+    assert "automatic reset retry was refused" in source
+    assert '"late_mow_confirmed:' in source
+
+
+def test_restart_reconciliation_runs_before_window_and_suspend_guards():
+    source = (COMPONENT / "navimower_schedule.py").read_text(encoding="utf-8")
+    evaluate_start = source.index("    async def _evaluate_locked")
+    evaluate_end = source.index("    async def _confirm_active_completion", evaluate_start)
+    evaluate = source[evaluate_start:evaluate_end]
+    reconcile = evaluate.index("await self._reconcile_unconfirmed_mow_start(activity)")
+    closed = evaluate.index("if not in_window:")
+    suspended = evaluate.index('if self._runtime.get("suspended_reason"):')
+    assert reconcile < closed < suspended
+    assert "reset=True" not in source[source.index("    async def _reconcile_unconfirmed_mow_start"):source.index("    def _retry_ready")]


### PR DESCRIPTION
## Summary

Prepare Navimower 0.4.3-beta19 with focused Navimower Schedule hardening.

## What changed

- keep 24-hour mode neutral to the mower's own Night mowing setting
- retain the existing closed Time window hard gate that sends Dock/Home when Mowing or Paused is observed outside the window
- reconcile a stale unconfirmed new-zone `mow` command after Home Assistant restart/state loss
- after 120 seconds without confirmation, suspend safely instead of automatically repeating `reset=true`
- recover automatically if the same active zone later confirms Mowing
- add beta19 regression checks for saved runtime restore, closed-window ordering, continuous-mode Night mowing neutrality and no reset fallback

## Safety

Already-confirmed mowing is not restarted merely because Home Assistant restarted. Interrupted-task recovery remains Resume first, then `mow(reset=false)`; automatic reset fallback remains refused.

Remote builder completed the full test suite, compileall, diff-check, exact diff-scope and focused scheduler/restart checks before publishing this branch.