### PR TITLE
Navimower 0.4.3-beta21 coverage completion

### DIFF
--- a/.github/release-notes/0.4.3-beta21.md
+++ b/.github/release-notes/0.4.3-beta21.md
@@ -1,0 +1,21 @@
+title: Navimower 0.4.3-beta21
+
+Per-zone `Last completed` is now driven by vendor zone coverage instead of live work/task counters.
+
+### Fixed
+- Fresh private-cloud **per-zone coverage at 100%** is the only telemetry allowed to write `last_completed`.
+- MQTT/private `mapWorkPosition`, route progress and whole-task percentage remain useful live progress sources, but cannot directly mark a zone complete.
+- A zone that was observed below 100% stays armed after the mower changes to another target. This allows both single-zone schedulers and native multi-zone tasks to confirm the previous zone when cloud coverage settles to 100%.
+- Stale 100% rows from a previous cycle are ignored until there is current-cycle evidence. This specifically prevents a rain/charging resume from immediately completing a still-partial zone because `mapWorkPosition` temporarily retained 100%.
+
+### Safety
+- Vendor `endTime` is timestamp metadata only. It can timestamp an already-confirmed 100% completion, but never proves completion by itself.
+- Very small zones that can move from start to 100% between polls have a bounded recent-cycle fallback using vendor start/end timestamps, and the vendor end must be newer than the previously persisted completion.
+- Dock/Charging still only closes the route/session history; it does not write `Last completed`.
+
+### Compatibility
+- The same `last_completed` sensor remains the contract for Navimower Schedule and external integrations such as `navimower-zone-scheduler`.
+- The completion resolver is scheduler-independent and works with one-zone commands as well as native multi-zone mowing.
+
+### Diagnostics
+- Active completion diagnostics now include zones seen as current targets and retained per-zone vendor coverage state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
 
+## 0.4.3-beta21
+
+Vendor per-zone coverage becomes the sole authority for `Last completed`.
+
+### Fixed
+
+- Stop allowing MQTT/private `mapWorkPosition`, route progress or whole-task percentage to write `last_completed`; these remain display/progress signals only.
+- Confirm a zone only when fresh private-cloud per-zone coverage for a currently observed target/physical zone reaches 100% in the current work cycle.
+- Keep an incomplete zone armed after the mower changes target, so multi-zone tasks can confirm the previous zone when its vendor coverage settles to 100%.
+- Ignore stale historical 100% rows until the zone has current-cycle evidence; this prevents rain/charging resumes from completing a still-partial zone.
+
+### Safety
+
+- `endTime` is never completion proof by itself. It is used only as the timestamp after coverage has already reached authoritative 100%.
+- A small-zone fallback accepts a directly observed recent 100% vendor cycle only when its start/end timestamps are new relative to the previously persisted completion.
+- Docking still only finalizes route/session history and does not create zone completion.
+
+### Diagnostics
+
+- Expose zones seen as current targets plus retained vendor coverage state in active completion diagnostics.
+
+
 ## 0.4.3-beta20
 
 Fresh current-cycle per-zone completion arbitration.

--- a/custom_components/navimower/history.py
+++ b/custom_components/navimower/history.py
@@ -37,23 +37,12 @@ _INDEX_VERSION = 1
 _SESSION_VERSION = 1
 _LEGACY_TRAIL_VERSION = 1
 
-# Completion is deliberately stricter than display telemetry. Last-known values
-# can keep sensors stable but can never create a completion event. Fresh MQTT or
-# private-cloud evidence must belong to the current zone/cycle.
+# Completion is stricter than display telemetry. Live work/task counters are
+# useful progress signals, but only fresh vendor per-zone coverage is allowed to
+# advance ``last_completed_at``. This avoids stale mapWorkPosition/task values
+# falsely completing a zone after rain, charging or another interruption.
 _COMPLETION_EVIDENCE_MAX_AGE_SECONDS = 30.0
-_COMPLETION_SAMPLE_ADVANCE_MS = 1000
-_COMPLETION_JUMP_GUARD_PERCENT = 25
-_COMPLETION_CYCLE_START_TOLERANCE_MS = 30_000
-_ACTIVE_ZONE_COMPLETION_SOURCES = frozenset(
-    {
-        "mqtt_map_work_position",
-        "mqtt_route_progress",
-        "private_map_work_position",
-    }
-)
-_SINGLE_ZONE_TASK_COMPLETION_SOURCES = frozenset(
-    {"mqtt_task_percentage", "private_task_percentage"}
-)
+_COMPLETION_VENDOR_EVENT_TOLERANCE_MS = 120_000
 
 SESSION_DETAIL_POINT_FORMAT = [
     "timestamp_ms",
@@ -342,6 +331,12 @@ def _merge_session_records(
     merged["task_zone_seen_incomplete"] = _unique_ints(
         previous.get("task_zone_seen_incomplete"), continuation.get("task_zone_seen_incomplete")
     )
+    merged["task_zone_seen_target"] = _unique_ints(
+        previous.get("task_zone_seen_target"), continuation.get("task_zone_seen_target")
+    )
+    coverage_state = dict(previous.get("task_zone_coverage_state") or {})
+    coverage_state.update(continuation.get("task_zone_coverage_state") or {})
+    merged["task_zone_coverage_state"] = coverage_state
     merged["task_zone_completion_confirmed"] = _unique_ints(
         previous.get("task_zone_completion_confirmed"), continuation.get("task_zone_completion_confirmed")
     )
@@ -942,6 +937,8 @@ class NavimowerHistory:
             "visited_zone_ids": [],
             "task_zone_progress": {str(value): 0 for value in zone_ids},
             "task_zone_seen_incomplete": [],
+            "task_zone_seen_target": [],
+            "task_zone_coverage_state": {},
             "task_zone_completion_confirmed": [],
             "task_zone_last_evidence": {},
             "task_zone_completion_candidates": {},
@@ -989,6 +986,8 @@ class NavimowerHistory:
         previous.setdefault("visited_zone_ids", [])
         previous.setdefault("task_zone_progress", {})
         previous.setdefault("task_zone_seen_incomplete", [])
+        previous.setdefault("task_zone_seen_target", [])
+        previous.setdefault("task_zone_coverage_state", {})
         previous.setdefault("task_zone_completion_confirmed", [])
         previous.setdefault("task_zone_last_evidence", {})
         previous.setdefault("task_zone_completion_candidates", {})
@@ -1305,12 +1304,14 @@ class NavimowerHistory:
                 ]
                 task_progress = active.setdefault("task_zone_progress", {})
                 last_evidence = active.setdefault("task_zone_last_evidence", {})
+                coverage_state = active.setdefault("task_zone_coverage_state", {})
                 completion_candidates = active.setdefault(
                     "task_zone_completion_candidates", {}
                 )
                 for zone_id in reset_set:
                     task_progress[str(zone_id)] = 0
                     last_evidence.pop(str(zone_id), None)
+                    coverage_state.pop(str(zone_id), None)
                     completion_candidates.pop(str(zone_id), None)
                 if active.get("completion_reason") == "vendor_progress":
                     active["completed"] = None
@@ -1336,8 +1337,222 @@ class NavimowerHistory:
                     known = [value for value in (previous_peak, progress) if value is not None]
                     peak = max(known) if known else None
                 self._zone_progress_state[str(zone_id)] = {"progress": progress, "peak_progress": peak, "start_time": _as_int(row.get("start_time")), "end_time": _as_int(row.get("end_time")), "observed_at_ms": _timestamp_ms(pose_time)}
+            self._confirm_coverage_completions_locked(snapshot, pose_time)
         self._schedule_index_save()
         return bool(reset_rows)
+
+    def _confirm_coverage_completions_locked(
+        self, snapshot: dict[str, Any], pose_time: Any
+    ) -> None:
+        """Confirm per-zone completion only from fresh vendor coverage reaching 100%."""
+        active = self._cache.get(self._active_id or "")
+        if active is None:
+            return
+
+        coverage_age = _as_float(snapshot.get("coverage_source_age"))
+        if (
+            coverage_age is None
+            or coverage_age < 0
+            or coverage_age > _COMPLETION_EVIDENCE_MAX_AGE_SECONDS
+        ):
+            return
+
+        coverage_rows = {
+            _as_int(item.get("id")): item
+            for item in (snapshot.get("coverage") or {}).get("zones") or []
+            if isinstance(item, dict) and _as_int(item.get("id")) is not None
+        }
+        if not coverage_rows:
+            return
+
+        now_ms = _timestamp_ms(pose_time)
+        current_target = _as_int(snapshot.get("active_zone_progress_zone_id"))
+        physical_zone = _as_int(snapshot.get("current_physical_zone_id"))
+        activity_name = str(snapshot.get("activity") or "").lower()
+
+        seen_target = set(_unique_ints(active.get("task_zone_seen_target")))
+        if current_target is not None:
+            seen_target.add(current_target)
+        if activity_name == "mowing" and physical_zone is not None:
+            seen_target.add(physical_zone)
+
+        seen_incomplete = set(
+            _unique_ints(active.get("task_zone_seen_incomplete"))
+        )
+        confirmed = set(
+            _unique_ints(active.get("task_zone_completion_confirmed"))
+        )
+        coverage_state = active.setdefault("task_zone_coverage_state", {})
+        last_evidence = active.setdefault("task_zone_last_evidence", {})
+        completion_candidates = active.setdefault(
+            "task_zone_completion_candidates", {}
+        )
+
+        relevant = sorted(seen_target | seen_incomplete)
+        for zone_id in relevant:
+            row = coverage_rows.get(zone_id)
+            if not isinstance(row, dict):
+                continue
+            progress = _as_int(row.get("pct"))
+            if progress is None or progress < 0 or progress > 100:
+                continue
+
+            zone_key = str(zone_id)
+            previous = dict(coverage_state.get(zone_key) or {})
+            previous_progress = _as_int(previous.get("progress"))
+            previous_start = _as_int(previous.get("start_time"))
+            previous_end = _as_int(previous.get("end_time"))
+            vendor_start = _as_int(row.get("start_time"))
+            vendor_end = _as_int(row.get("end_time"))
+            vendor_start_ms = _timestamp_ms(vendor_start) if vendor_start else None
+            vendor_end_ms = _timestamp_ms(vendor_end) if vendor_end else None
+            sample_ms = now_ms - int(max(0.0, coverage_age) * 1000)
+            evidence = {
+                "progress": progress,
+                "source": "private_zone_coverage",
+                "source_age_s": round(coverage_age, 3),
+                "sample_ms": sample_ms,
+                "observed_at": _iso(now_ms),
+                "start_time": vendor_start,
+                "end_time": vendor_end,
+            }
+
+            if progress < 100:
+                seen_incomplete.add(zone_id)
+                completion_candidates.pop(zone_key, None)
+                active["last_completion_rejection"] = None
+                last_evidence[zone_key] = evidence
+                coverage_state[zone_key] = {
+                    "progress": progress,
+                    "start_time": vendor_start,
+                    "end_time": vendor_end,
+                    "observed_at_ms": now_ms,
+                }
+                continue
+
+            if zone_id in confirmed:
+                coverage_state[zone_key] = {
+                    "progress": progress,
+                    "start_time": vendor_start,
+                    "end_time": vendor_end,
+                    "observed_at_ms": now_ms,
+                }
+                last_evidence[zone_key] = evidence
+                continue
+
+            transitioned_to_100 = bool(
+                previous_progress is not None and previous_progress < 100
+            )
+            vendor_cycle_changed = bool(
+                (
+                    vendor_start is not None
+                    and previous_start is not None
+                    and vendor_start > previous_start
+                )
+                or (
+                    vendor_end is not None
+                    and previous_end is not None
+                    and vendor_end > previous_end
+                    and previous_progress is not None
+                    and previous_progress < 100
+                )
+            )
+
+            zone_record = dict(self._zone_history.get(zone_key) or {})
+            previous_completed_ms = _iso_ms(zone_record.get("last_completed_at"))
+            recent_vendor_cycle = bool(
+                zone_id in seen_target
+                and vendor_start_ms is not None
+                and vendor_end_ms is not None
+                and vendor_end_ms >= vendor_start_ms
+                and vendor_start_ms
+                >= now_ms - _COMPLETION_VENDOR_EVENT_TOLERANCE_MS
+                and vendor_end_ms
+                <= now_ms + _COMPLETION_VENDOR_EVENT_TOLERANCE_MS
+                and (
+                    previous_completed_ms is None
+                    or vendor_end_ms > previous_completed_ms + 1000
+                )
+            )
+
+            if zone_id in seen_incomplete:
+                confirmation = "coverage_100_after_incomplete"
+            elif transitioned_to_100 or vendor_cycle_changed:
+                confirmation = "coverage_100_transition"
+            elif recent_vendor_cycle:
+                confirmation = "coverage_100_recent_vendor_cycle"
+            else:
+                completion_candidates[zone_key] = {
+                    **evidence,
+                    "zone_id": zone_id,
+                    "reason": "coverage_100_without_current_cycle_evidence",
+                }
+                active["last_completion_rejection"] = dict(
+                    completion_candidates[zone_key]
+                )
+                coverage_state[zone_key] = {
+                    "progress": progress,
+                    "start_time": vendor_start,
+                    "end_time": vendor_end,
+                    "observed_at_ms": now_ms,
+                }
+                last_evidence[zone_key] = evidence
+                continue
+
+            completion_ms = now_ms
+            armed_sample_ms = _as_int(
+                (last_evidence.get(zone_key) or {}).get("sample_ms")
+            )
+            if (
+                vendor_end_ms is not None
+                and vendor_end_ms
+                <= now_ms + _COMPLETION_VENDOR_EVENT_TOLERANCE_MS
+                and (
+                    armed_sample_ms is None
+                    or vendor_end_ms
+                    >= armed_sample_ms - _COMPLETION_VENDOR_EVENT_TOLERANCE_MS
+                )
+            ):
+                completion_ms = vendor_end_ms
+
+            confirmed.add(zone_id)
+            completion_candidates.pop(zone_key, None)
+            active["last_completion_rejection"] = None
+            zone_record.update(
+                {
+                    "id": zone_id,
+                    "name": zone_record.get("name")
+                    or row.get("name")
+                    or f"Zone {zone_id}",
+                    "last_completed_at": _iso(completion_ms),
+                    "last_completed_progress": 100,
+                    "last_completed_source": "private_zone_coverage",
+                    "last_completed_confirmation": confirmation,
+                    "last_completed_cycle_id": active.get("id"),
+                }
+            )
+            self._zone_history[zone_key] = zone_record
+            active.setdefault("final_progress", {})[zone_key] = 100
+            coverage_state[zone_key] = {
+                "progress": progress,
+                "start_time": vendor_start,
+                "end_time": vendor_end,
+                "observed_at_ms": now_ms,
+            }
+            last_evidence[zone_key] = evidence
+
+        active["task_zone_seen_target"] = sorted(seen_target)
+        active["task_zone_seen_incomplete"] = sorted(seen_incomplete)
+        active["task_zone_completion_confirmed"] = sorted(confirmed)
+        selected = _unique_ints(active.get("zone_ids"))
+        if selected and set(selected).issubset(confirmed):
+            active["completed"] = True
+            active["completion_reason"] = "vendor_coverage"
+        elif active.get("completion_reason") == "vendor_coverage":
+            active["completed"] = None
+            active["completion_reason"] = None
+        self._update_active_metadata_locked(active)
+        self._schedule_active_save()
 
     def cycle_diagnostics(self) -> dict[str, Any]:
         """Return non-sensitive cycle and completion-arbitration state."""
@@ -1350,6 +1565,12 @@ class NavimowerHistory:
                     "zone_ids": _unique_ints(active.get("zone_ids")),
                     "seen_incomplete": _unique_ints(
                         active.get("task_zone_seen_incomplete")
+                    ),
+                    "seen_target": _unique_ints(
+                        active.get("task_zone_seen_target")
+                    ),
+                    "coverage_state": deepcopy(
+                        active.get("task_zone_coverage_state") or {}
                     ),
                     "confirmed": _unique_ints(
                         active.get("task_zone_completion_confirmed")
@@ -1392,28 +1613,13 @@ class NavimowerHistory:
         cycle_reset_pending: bool = False,
         observed_at: Any = None,
     ) -> None:
-        """Persist zone state and confirm completion from fresh current-cycle evidence.
-
-        Display telemetry may retain a last-known value through a source outage.
-        Completion is intentionally fail-closed: only fresh MQTT/private-cloud
-        counters tied to the active zone/cycle may advance ``last_completed_at``.
-        """
+        """Persist display state; completion is owned by vendor coverage arbitration."""
         coverage_by_id = {
             _as_int(item.get("id")): item
             for item in (coverage or {}).get("zones") or []
             if isinstance(item, dict) and _as_int(item.get("id")) is not None
         }
         changed = False
-        now_ms = _timestamp_ms(observed_at)
-
-        def fresh_age(value: Any) -> tuple[bool, float | None]:
-            age = _as_float(value)
-            return (
-                age is not None
-                and 0 <= age <= _COMPLETION_EVIDENCE_MAX_AGE_SECONDS,
-                age,
-            )
-
         with self._lock:
             for detail in zone_details:
                 if not isinstance(detail, dict):
@@ -1461,311 +1667,6 @@ class NavimowerHistory:
 
             active = self._cache.get(self._active_id or "")
             if active is not None:
-                progress_state = active.setdefault("task_zone_progress", {})
-                for zone_id in active.get("zone_ids") or []:
-                    progress_state.setdefault(str(zone_id), 0)
-                seen_incomplete = set(
-                    _unique_ints(active.get("task_zone_seen_incomplete"))
-                )
-                completion_confirmed = set(
-                    _unique_ints(active.get("task_zone_completion_confirmed"))
-                )
-                last_evidence = active.setdefault("task_zone_last_evidence", {})
-                completion_candidates = active.setdefault(
-                    "task_zone_completion_candidates", {}
-                )
-                active_zone_id = _as_int(active_progress_zone_id)
-
-                if active_zone_id is not None:
-                    active_detail = next(
-                        (
-                            item
-                            for item in zone_details
-                            if _as_int(item.get("id")) == active_zone_id
-                        ),
-                        None,
-                    )
-                    if active_detail is not None:
-                        zone_key = str(active_zone_id)
-                        zone_record = dict(
-                            self._zone_history.get(zone_key) or {}
-                        )
-                        target_ids = _unique_ints(target_zone_ids)
-                        single_zone_task = bool(
-                            len(target_ids) == 1
-                            and target_ids[0] == active_zone_id
-                        )
-                        physical_id = _as_int(physical_zone_id)
-
-                        # Private-cloud coverage is usable as a fallback only when
-                        # its start timestamp proves the row belongs to this cycle.
-                        vendor_progress = _as_int(
-                            active_detail.get("vendor_percentage")
-                            if active_detail.get("vendor_percentage") is not None
-                            else active_detail.get("percentage")
-                        )
-                        vendor_start = _as_int(
-                            active_detail.get("vendor_start_time")
-                        )
-                        vendor_end = _as_int(active_detail.get("vendor_end_time"))
-                        cloud_fresh, cloud_age = fresh_age(coverage_source_age)
-                        cycle_start_ms = _as_int(active.get("started_at_ms")) or now_ms
-                        for boundary in active.get("zone_cycle_boundaries") or []:
-                            if not isinstance(boundary, dict):
-                                continue
-                            if _as_int(boundary.get("zone_id")) != active_zone_id:
-                                continue
-                            boundary_ms = _as_int(boundary.get("at_ms"))
-                            if boundary_ms is not None:
-                                cycle_start_ms = max(cycle_start_ms, boundary_ms)
-                        vendor_start_ms = (
-                            _timestamp_ms(vendor_start) if vendor_start else None
-                        )
-                        vendor_end_ms = _timestamp_ms(vendor_end) if vendor_end else None
-                        cloud_current_cycle = bool(
-                            cloud_fresh
-                            and vendor_progress is not None
-                            and vendor_start_ms is not None
-                            and vendor_start_ms
-                            >= cycle_start_ms - _COMPLETION_CYCLE_START_TOLERANCE_MS
-                            and vendor_start_ms
-                            <= now_ms + _COMPLETION_CYCLE_START_TOLERANCE_MS
-                        )
-                        cloud_end_current_cycle = bool(
-                            cloud_current_cycle
-                            and vendor_end_ms is not None
-                            and vendor_end_ms >= cycle_start_ms
-                            and vendor_end_ms
-                            <= now_ms + _COMPLETION_CYCLE_START_TOLERANCE_MS
-                            and (vendor_progress or 0)
-                            >= VENDOR_COMPLETION_PROGRESS_MIN
-                        )
-
-                        source = str(active_zone_progress_source or "")
-                        source_fresh, source_age = fresh_age(
-                            active_zone_progress_source_age
-                        )
-                        progress = _as_int(active_zone_progress)
-                        route_zone_matches = not (
-                            source == "mqtt_route_progress"
-                            and physical_id is not None
-                            and physical_id != active_zone_id
-                        )
-
-                        task_source = str(task_progress_source or "")
-                        task_fresh, task_age = fresh_age(task_progress_source_age)
-                        task_value = _as_int(task_progress)
-                        task_evidence_fresh = bool(
-                            single_zone_task
-                            and task_source in _SINGLE_ZONE_TASK_COMPLETION_SOURCES
-                            and task_fresh
-                            and task_value is not None
-                        )
-
-                        evidence_progress = None
-                        evidence_source = None
-                        evidence_age = None
-                        if (
-                            source in _ACTIVE_ZONE_COMPLETION_SOURCES
-                            and source_fresh
-                            and progress is not None
-                            and route_zone_matches
-                        ):
-                            evidence_progress = progress
-                            evidence_source = source
-                            evidence_age = source_age
-                        elif task_evidence_fresh:
-                            evidence_progress = task_value
-                            evidence_source = f"{task_source}_single_zone"
-                            evidence_age = task_age
-                        elif cloud_current_cycle:
-                            evidence_progress = vendor_progress
-                            evidence_source = "private_zone_coverage"
-                            evidence_age = cloud_age
-
-                        if evidence_progress is not None and evidence_source:
-                            previous_progress = _as_int(progress_state.get(zone_key))
-                            same_cycle_persisted = (
-                                zone_record.get("last_completed_cycle_id")
-                                == active.get("id")
-                            )
-                            sample_ms = now_ms - int(
-                                max(0.0, float(evidence_age or 0.0)) * 1000
-                            )
-                            evidence_snapshot = {
-                                "progress": evidence_progress,
-                                "source": evidence_source,
-                                "source_age_s": (
-                                    round(float(evidence_age), 3)
-                                    if evidence_age is not None
-                                    else None
-                                ),
-                                "sample_ms": sample_ms,
-                                "observed_at": _iso(now_ms),
-                            }
-
-                            if evidence_progress < VENDOR_COMPLETION_PROGRESS_MIN:
-                                seen_incomplete.add(active_zone_id)
-                                completion_candidates.pop(zone_key, None)
-                                # Heal older optimistic in-memory state, but never
-                                # retract a beta20 completion already persisted for
-                                # this exact cycle because small vendor regressions
-                                # around 95% are legitimate.
-                                if (
-                                    active_zone_id in completion_confirmed
-                                    and not same_cycle_persisted
-                                ):
-                                    completion_confirmed.discard(active_zone_id)
-                                if (
-                                    previous_progress is not None
-                                    and previous_progress
-                                    >= VENDOR_COMPLETION_PROGRESS_MIN
-                                    and not same_cycle_persisted
-                                ):
-                                    progress_state[zone_key] = evidence_progress
-                                    if active.get("completion_reason") == "vendor_progress":
-                                        active["completed"] = None
-                                        active["completion_reason"] = None
-                                        active["final_progress"] = {}
-                                else:
-                                    progress_state[zone_key] = max(
-                                        previous_progress or 0, evidence_progress
-                                    )
-                                active["last_completion_rejection"] = None
-                            else:
-                                progress_state[zone_key] = max(
-                                    previous_progress or 0, evidence_progress
-                                )
-                                activity_name = str(activity or "").lower()
-                                finish_signals: list[str] = []
-                                if evidence_progress >= 100:
-                                    finish_signals.append("progress_100")
-                                if cloud_end_current_cycle:
-                                    finish_signals.append("current_cycle_cloud_end")
-                                if task_evidence_fresh and (task_value or 0) >= 100:
-                                    finish_signals.append("single_zone_task_100")
-
-                                if activity_name == ACTIVITY_ERROR:
-                                    active["last_completion_rejection"] = {
-                                        **evidence_snapshot,
-                                        "zone_id": active_zone_id,
-                                        "reason": "error_state",
-                                    }
-                                elif active_zone_id not in seen_incomplete:
-                                    active["last_completion_rejection"] = {
-                                        **evidence_snapshot,
-                                        "zone_id": active_zone_id,
-                                        "reason": "high_before_current_cycle_low",
-                                    }
-                                elif not finish_signals:
-                                    active["last_completion_rejection"] = {
-                                        **evidence_snapshot,
-                                        "zone_id": active_zone_id,
-                                        "reason": "awaiting_finish_signal",
-                                    }
-                                elif active_zone_id not in completion_confirmed:
-                                    previous_evidence = last_evidence.get(zone_key)
-                                    previous_evidence_progress = _as_int(
-                                        (previous_evidence or {}).get("progress")
-                                    )
-                                    sudden_jump = bool(
-                                        previous_evidence_progress is None
-                                        or evidence_progress
-                                        - previous_evidence_progress
-                                        > _COMPLETION_JUMP_GUARD_PERCENT
-                                    )
-                                    candidate = completion_candidates.get(zone_key)
-                                    candidate_sample = _as_int(
-                                        (candidate or {}).get("sample_ms")
-                                    )
-                                    second_fresh_sample = bool(
-                                        candidate_sample is not None
-                                        and sample_ms
-                                        >= candidate_sample
-                                        + _COMPLETION_SAMPLE_ADVANCE_MS
-                                    )
-                                    corroborated = bool(
-                                        cloud_end_current_cycle
-                                        or (
-                                            task_evidence_fresh
-                                            and (task_value or 0) >= 100
-                                            and not evidence_source.endswith(
-                                                "_single_zone"
-                                            )
-                                        )
-                                    )
-                                    if not corroborated and candidate is None:
-                                        completion_candidates[zone_key] = {
-                                            **evidence_snapshot,
-                                            "zone_id": active_zone_id,
-                                            "finish_signals": list(finish_signals),
-                                        }
-                                        active["last_completion_rejection"] = {
-                                            **evidence_snapshot,
-                                            "zone_id": active_zone_id,
-                                            "reason": (
-                                                "guarded_large_progress_jump"
-                                                if sudden_jump
-                                                else "awaiting_second_fresh_sample"
-                                            ),
-                                        }
-                                    elif (
-                                        candidate is not None
-                                        and not second_fresh_sample
-                                        and not corroborated
-                                    ):
-                                        active["last_completion_rejection"] = {
-                                            **evidence_snapshot,
-                                            "zone_id": active_zone_id,
-                                            "reason": "waiting_for_second_fresh_sample",
-                                        }
-                                    else:
-                                        confirmation = (
-                                            "current_cycle_cloud_end"
-                                            if cloud_end_current_cycle
-                                            else "single_zone_task_100"
-                                            if task_evidence_fresh
-                                            and (task_value or 0) >= 100
-                                            and not evidence_source.endswith("_single_zone")
-                                            else "second_fresh_sample"
-                                            if candidate is not None
-                                            else finish_signals[0]
-                                        )
-                                        completion_confirmed.add(active_zone_id)
-                                        completion_candidates.pop(zone_key, None)
-                                        active["last_completion_rejection"] = None
-                                        if not same_cycle_persisted:
-                                            completion_ms = (
-                                                vendor_end_ms
-                                                if cloud_end_current_cycle
-                                                and vendor_end_ms is not None
-                                                else now_ms
-                                            )
-                                            zone_record.update(
-                                                {
-                                                    "id": active_zone_id,
-                                                    "name": zone_record.get("name")
-                                                    or active_detail.get("name")
-                                                    or f"Zone {active_zone_id}",
-                                                    "last_completed_at": _iso(completion_ms),
-                                                    "last_completed_progress": evidence_progress,
-                                                    "last_completed_source": evidence_source,
-                                                    "last_completed_confirmation": confirmation,
-                                                    "last_completed_cycle_id": active.get("id"),
-                                                }
-                                            )
-                                            self._zone_history[zone_key] = zone_record
-                                        final_progress = active.setdefault(
-                                            "final_progress", {}
-                                        )
-                                        final_progress[zone_key] = evidence_progress
-
-                            last_evidence[zone_key] = evidence_snapshot
-
-                active["task_zone_seen_incomplete"] = sorted(seen_incomplete)
-                active["task_zone_completion_confirmed"] = sorted(
-                    completion_confirmed
-                )
                 if active.get("cutting_height_mm") is None:
                     target_ids = set(active.get("zone_ids") or [])
                     candidates = [
@@ -1776,19 +1677,6 @@ class NavimowerHistory:
                     known = [value for value in candidates if value is not None]
                     if len(set(known)) == 1:
                         active["cutting_height_mm"] = known[0]
-                selected_zone_ids = _unique_ints(active.get("zone_ids"))
-                if (
-                    selected_zone_ids
-                    and set(selected_zone_ids).issubset(completion_confirmed)
-                ):
-                    active["completed"] = True
-                    active["completion_reason"] = (
-                        active.get("completion_reason") or "vendor_progress"
-                    )
-                elif active.get("completion_reason") == "vendor_progress":
-                    active["completed"] = None
-                    active["completion_reason"] = None
-                    active["final_progress"] = {}
                 self._update_active_metadata_locked(active)
                 changed = True
 

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta20"
+  "version": "0.4.3-beta21"
 }

--- a/tests/test_history_merge.py
+++ b/tests/test_history_merge.py
@@ -420,249 +420,182 @@ async def provisional_cycle_reset_stub_test() -> None:
 asyncio.run(provisional_cycle_reset_stub_test())
 
 
-def practical_completion_threshold_test() -> None:
+
+def _coverage_snapshot(zone_rows, *, target, physical, activity="mowing", age=0):
+    return {
+        "coverage": {"zones": zone_rows},
+        "zone_details": [
+            {
+                "id": row["id"],
+                "name": row.get("name", f"Zone {row['id']}"),
+                "percentage": row.get("pct"),
+                "vendor_percentage": row.get("pct"),
+                "vendor_start_time": row.get("start_time"),
+                "vendor_end_time": row.get("end_time"),
+            }
+            for row in zone_rows
+        ],
+        "coverage_source_age": age,
+        "active_zone_progress_zone_id": target,
+        "current_physical_zone_id": physical,
+        "activity": activity,
+    }
+
+
+def vendor_coverage_completion_test() -> None:
     Store.values.clear()
-    manager = history.NavimowerHistory(FakeHass(), "entry-threshold", "TEST")
+    manager = history.NavimowerHistory(FakeHass(), "entry-coverage", "TEST")
     manager.process_pose(
-        position={"x": 0.0, "y": 0.0},
-        pose_time=2_300_000_000,
-        heading=0.0,
-        activity="mowing",
-        cutting=True,
-        docked=False,
-        returning=False,
-        zone_ids=[13],
-        physical_zone_id=13,
+        position={"x": 0.0, "y": 0.0}, pose_time=2_300_000_000,
+        heading=0.0, activity="mowing", cutting=True, docked=False,
+        returning=False, zone_ids=[13], physical_zone_id=13,
     )
-    manager.update_zone_history(
-        {"zones": [{"id": 13, "pct": 90}]},
-        [{"id": 13, "name": "Street", "percentage": 90}],
-        active_zone_progress=90,
-        active_progress_zone_id=13,
-        active_zone_progress_source="mqtt_map_work_position",
-        active_zone_progress_source_age=0,
-        target_zone_ids=[13],
-        physical_zone_id=13,
-        activity="mowing",
-        observed_at=2_300_000_010,
+    low = _coverage_snapshot(
+        [{"id": 13, "name": "Street", "pct": 90,
+          "start_time": 2_300_000_000, "end_time": 2_300_000_010}],
+        target=13, physical=13,
     )
-    manager.update_zone_history(
-        {"zones": [{"id": 13, "pct": 100}]},
-        [{"id": 13, "name": "Street", "percentage": 100}],
-        active_zone_progress=100,
-        active_progress_zone_id=13,
-        active_zone_progress_source="mqtt_map_work_position",
-        active_zone_progress_source_age=0,
-        target_zone_ids=[13],
-        physical_zone_id=13,
-        activity="mowing",
-        observed_at=2_300_000_020,
-    )
+    manager.prepare_cycle(low, pose_time=2_300_000_010)
+    manager.update_from_snapshot(low)
     assert "last_completed_at" not in manager.zone_history()["13"]
-    manager.update_zone_history(
-        {"zones": [{"id": 13, "pct": 100}]},
-        [{"id": 13, "name": "Street", "percentage": 100}],
-        active_zone_progress=100,
-        active_progress_zone_id=13,
-        active_zone_progress_source="mqtt_map_work_position",
-        active_zone_progress_source_age=0,
-        target_zone_ids=[13],
-        physical_zone_id=13,
-        activity="mowing",
-        observed_at=2_300_000_030,
+
+    done = _coverage_snapshot(
+        [{"id": 13, "name": "Street", "pct": 100,
+          "start_time": 2_300_000_000, "end_time": 2_300_000_020}],
+        target=13, physical=13,
     )
+    manager.prepare_cycle(done, pose_time=2_300_000_020)
+    manager.update_from_snapshot(done)
     active = manager.active_session
     assert active is not None
     assert active["completed"] is True
-    assert active["completion_reason"] == "vendor_progress"
+    assert active["completion_reason"] == "vendor_coverage"
     zone = manager.zone_history()["13"]
     assert zone["last_completed_progress"] == 100
-    assert zone["last_completed_source"] == "mqtt_map_work_position"
-    assert zone["last_completed_confirmation"] == "second_fresh_sample"
+    assert zone["last_completed_source"] == "private_zone_coverage"
+    assert zone["last_completed_confirmation"] == "coverage_100_after_incomplete"
 
 
-practical_completion_threshold_test()
-print("cycle tracking tests passed")
+vendor_coverage_completion_test()
 
 
-async def live_completion_before_dock_test() -> None:
+def private_live_100_never_completes_test() -> None:
     Store.values.clear()
-    hass = FakeHass()
-    manager = history.NavimowerHistory(hass, "entry-live-complete", "TEST")
-    manager.process_pose(
-        position={"x": 0.0, "y": 0.0}, pose_time=2_400_000_000,
-        heading=0.0, activity="mowing", cutting=True, docked=False,
-        returning=False, zone_ids=[24], physical_zone_id=24,
-    )
-    manager.update_zone_history(
-        {"zones": [{"id": 24, "pct": 91}]},
-        [{"id": 24, "name": "Yard", "progress": 91, "percentage": 91}],
-        active_zone_progress=91, active_progress_zone_id=24,
-        active_zone_progress_source="mqtt_map_work_position",
-        active_zone_progress_source_age=0, target_zone_ids=[24],
-        physical_zone_id=24, activity="mowing", observed_at=2_400_000_010,
-    )
-    manager.update_zone_history(
-        {"zones": [{"id": 24, "pct": 100}]},
-        [{"id": 24, "name": "Yard", "progress": 100, "percentage": 91}],
-        active_zone_progress=100, active_progress_zone_id=24,
-        active_zone_progress_source="mqtt_map_work_position",
-        active_zone_progress_source_age=0, target_zone_ids=[24],
-        physical_zone_id=24, activity="mowing", observed_at=2_400_000_020,
-    )
-    assert "last_completed_at" not in manager.zone_history()["24"]
-    manager.update_zone_history(
-        {"zones": [{"id": 24, "pct": 100}]},
-        [{"id": 24, "name": "Yard", "progress": 100, "percentage": 91}],
-        active_zone_progress=100, active_progress_zone_id=24,
-        active_zone_progress_source="mqtt_map_work_position",
-        active_zone_progress_source_age=0, target_zone_ids=[24],
-        physical_zone_id=24, activity="mowing", observed_at=2_400_000_030,
-    )
-    zone_before_dock = manager.zone_history()["24"]
-    completed_at = zone_before_dock["last_completed_at"]
-    assert zone_before_dock["last_completed_progress"] == 100
-    assert manager.active_session["task_zone_completion_confirmed"] == [24]
-
-    manager.process_pose(
-        position={"x": 0.1, "y": 0.1}, pose_time=2_400_000_040,
-        heading=0.0, activity="docked", cutting=False, docked=True,
-        returning=False, zone_ids=[24], completed=None,
-    )
-    assert manager.zone_history()["24"]["last_completed_at"] == completed_at
-    assert manager._active_id is None
-    if hass.tasks:
-        await asyncio.gather(*hass.tasks)
-
-
-asyncio.run(live_completion_before_dock_test())
-
-
-def guarded_source_jump_test() -> None:
-    Store.values.clear()
-    manager = history.NavimowerHistory(FakeHass(), "entry-source-jump", "TEST")
+    manager = history.NavimowerHistory(FakeHass(), "entry-live-private", "TEST")
     manager.process_pose(
         position={"x": 1.0, "y": 1.0}, pose_time=2_410_000_000,
         heading=0.0, activity="mowing", cutting=True, docked=False,
         returning=False, zone_ids=[24], physical_zone_id=24,
     )
-    manager.update_zone_history(
-        {"zones": [{"id": 24, "pct": 25}]},
-        [{"id": 24, "name": "Yard", "percentage": 25}],
-        active_zone_progress=25, active_progress_zone_id=24,
-        active_zone_progress_source="mqtt_map_work_position",
-        active_zone_progress_source_age=0, target_zone_ids=[24],
-        physical_zone_id=24, activity="mowing", observed_at=2_410_000_010,
+    partial = _coverage_snapshot(
+        [{"id": 24, "name": "Yard", "pct": 25,
+          "start_time": 2_410_000_000, "end_time": 2_410_000_010}],
+        target=24, physical=24,
     )
-    # A sudden fresh 100 from another source becomes a candidate, not completion.
+    manager.prepare_cycle(partial, pose_time=2_410_000_010)
+    manager.update_from_snapshot(partial)
     manager.update_zone_history(
-        {"zones": [{"id": 24, "pct": 25}]},
-        [{"id": 24, "name": "Yard", "percentage": 25}],
+        partial["coverage"], partial["zone_details"],
         active_zone_progress=100, active_progress_zone_id=24,
         active_zone_progress_source="private_map_work_position",
-        active_zone_progress_source_age=0, target_zone_ids=[24],
-        physical_zone_id=24, activity="mowing", observed_at=2_410_000_020,
-    )
-    assert "last_completed_at" not in manager.zone_history()["24"]
-    diag = manager.cycle_diagnostics()["active_completion"]
-    assert diag["candidates"]["24"]["progress"] == 100
-
-    # Re-reading the same cached private sample must still not complete it.
-    manager.update_zone_history(
-        {"zones": [{"id": 24, "pct": 25}]},
-        [{"id": 24, "name": "Yard", "percentage": 25}],
-        active_zone_progress=100, active_progress_zone_id=24,
-        active_zone_progress_source="private_map_work_position",
-        active_zone_progress_source_age=5, target_zone_ids=[24],
-        physical_zone_id=24, activity="mowing", observed_at=2_410_000_025,
+        active_zone_progress_source_age=0,
+        task_progress=100, task_progress_source="mqtt_task_percentage",
+        task_progress_source_age=0, target_zone_ids=[24],
+        physical_zone_id=24, coverage_source_age=0,
+        activity="mowing", observed_at=2_410_000_020,
     )
     assert "last_completed_at" not in manager.zone_history()["24"]
 
-    # A genuinely newer high sample confirms the guarded candidate.
-    manager.update_zone_history(
-        {"zones": [{"id": 24, "pct": 25}]},
-        [{"id": 24, "name": "Yard", "percentage": 25}],
-        active_zone_progress=100, active_progress_zone_id=24,
-        active_zone_progress_source="private_map_work_position",
-        active_zone_progress_source_age=0, target_zone_ids=[24],
-        physical_zone_id=24, activity="mowing", observed_at=2_410_000_030,
-    )
-    zone = manager.zone_history()["24"]
-    assert zone["last_completed_source"] == "private_map_work_position"
-    assert zone["last_completed_confirmation"] == "second_fresh_sample"
+
+private_live_100_never_completes_test()
 
 
-guarded_source_jump_test()
-
-
-def stale_last_known_never_completes_test() -> None:
+def stale_coverage_100_never_completes_test() -> None:
     Store.values.clear()
-    manager = history.NavimowerHistory(FakeHass(), "entry-last-known", "TEST")
+    manager = history.NavimowerHistory(FakeHass(), "entry-stale-coverage", "TEST")
     manager.process_pose(
         position={"x": 2.0, "y": 2.0}, pose_time=2_420_000_000,
         heading=0.0, activity="mowing", cutting=True, docked=False,
         returning=False, zone_ids=[13], physical_zone_id=13,
     )
-    manager.update_zone_history(
-        {"zones": [{"id": 13, "pct": 50}]},
-        [{"id": 13, "name": "Street", "percentage": 50}],
-        active_zone_progress=50, active_progress_zone_id=13,
-        active_zone_progress_source="mqtt_map_work_position",
-        active_zone_progress_source_age=0, target_zone_ids=[13],
-        physical_zone_id=13, activity="mowing", observed_at=2_420_000_010,
+    stale = _coverage_snapshot(
+        [{"id": 13, "name": "Street", "pct": 100,
+          "start_time": 2_200_000_000, "end_time": 2_200_000_100}],
+        target=13, physical=13,
     )
-    manager.update_zone_history(
-        {"zones": [{"id": 13, "pct": 50}]},
-        [{"id": 13, "name": "Street", "percentage": 50}],
-        active_zone_progress=100, active_progress_zone_id=13,
-        active_zone_progress_source="last_known_zone",
-        active_zone_progress_source_age=None,
-        task_progress=100, task_progress_source="last_known",
-        task_progress_source_age=None, target_zone_ids=[13],
-        physical_zone_id=13, activity="returning", observed_at=2_420_000_020,
-    )
+    manager.prepare_cycle(stale, pose_time=2_420_000_010)
+    manager.update_from_snapshot(stale)
     assert "last_completed_at" not in manager.zone_history()["13"]
+    diag = manager.cycle_diagnostics()["active_completion"]
+    assert diag["candidates"]["13"]["reason"] == "coverage_100_without_current_cycle_evidence"
 
 
-stale_last_known_never_completes_test()
+stale_coverage_100_never_completes_test()
 
 
-def current_cycle_cloud_fallback_test() -> None:
+def multi_zone_target_transition_completion_test() -> None:
     Store.values.clear()
-    manager = history.NavimowerHistory(FakeHass(), "entry-cloud-fallback", "TEST")
+    manager = history.NavimowerHistory(FakeHass(), "entry-multi-zone", "TEST")
     manager.process_pose(
         position={"x": 3.0, "y": 3.0}, pose_time=2_430_000_000,
         heading=0.0, activity="mowing", cutting=True, docked=False,
+        returning=False, zone_ids=[24, 13], physical_zone_id=24,
+    )
+    first = _coverage_snapshot(
+        [
+            {"id": 24, "name": "Yard", "pct": 97,
+             "start_time": 2_430_000_000, "end_time": 2_430_000_010},
+            {"id": 13, "name": "Street", "pct": 0,
+             "start_time": 2_430_000_000, "end_time": 0},
+        ],
+        target=24, physical=24,
+    )
+    manager.prepare_cycle(first, pose_time=2_430_000_010)
+    manager.update_from_snapshot(first)
+    assert "last_completed_at" not in manager.zone_history()["24"]
+
+    second = _coverage_snapshot(
+        [
+            {"id": 24, "name": "Yard", "pct": 100,
+             "start_time": 2_430_000_000, "end_time": 2_430_000_020},
+            {"id": 13, "name": "Street", "pct": 20,
+             "start_time": 2_430_000_015, "end_time": 2_430_000_020},
+        ],
+        target=13, physical=13,
+    )
+    manager.prepare_cycle(second, pose_time=2_430_000_020)
+    manager.update_from_snapshot(second)
+    zone = manager.zone_history()["24"]
+    assert zone["last_completed_progress"] == 100
+    assert zone["last_completed_source"] == "private_zone_coverage"
+    diag = manager.cycle_diagnostics()["active_completion"]
+    assert 24 in diag["confirmed"]
+    assert 13 in diag["seen_incomplete"]
+
+
+multi_zone_target_transition_completion_test()
+
+
+def end_time_below_100_never_completes_test() -> None:
+    Store.values.clear()
+    manager = history.NavimowerHistory(FakeHass(), "entry-end-time", "TEST")
+    manager.process_pose(
+        position={"x": 4.0, "y": 4.0}, pose_time=2_440_000_000,
+        heading=0.0, activity="mowing", cutting=True, docked=False,
         returning=False, zone_ids=[13], physical_zone_id=13,
     )
-    start = 2_430_000_000
-    manager.update_zone_history(
-        {"zones": [{"id": 13, "pct": 40, "start_time": start}]},
-        [{"id": 13, "name": "Street", "percentage": 40,
-          "vendor_start_time": start, "vendor_end_time": None}],
-        active_zone_progress=None, active_progress_zone_id=13,
-        target_zone_ids=[13], physical_zone_id=13,
-        coverage_source_age=0, activity="mowing", observed_at=2_430_000_010,
+    partial = _coverage_snapshot(
+        [{"id": 13, "name": "Street", "pct": 97,
+          "start_time": 2_440_000_000, "end_time": 2_440_000_020}],
+        target=13, physical=13, activity="returning",
     )
-    manager.update_zone_history(
-        {"zones": [{"id": 13, "pct": 97, "start_time": start,
-                    "end_time": 2_430_000_020}]},
-        [{"id": 13, "name": "Street", "percentage": 97,
-          "vendor_start_time": start, "vendor_end_time": 2_430_000_020}],
-        active_zone_progress=None, active_progress_zone_id=13,
-        target_zone_ids=[13], physical_zone_id=13,
-        coverage_source_age=0, activity="returning", observed_at=2_430_000_021,
-    )
-    zone = manager.zone_history()["13"]
-    assert zone["last_completed_progress"] == 97
-    assert zone["last_completed_source"] == "private_zone_coverage"
-    assert zone["last_completed_confirmation"] == "current_cycle_cloud_end"
+    manager.prepare_cycle(partial, pose_time=2_440_000_021)
+    manager.update_from_snapshot(partial)
+    assert "last_completed_at" not in manager.zone_history()["13"]
 
 
-current_cycle_cloud_fallback_test()
-print("beta20 completion arbitration tests passed")
-
-
+end_time_below_100_never_completes_test()
+print("beta21 coverage completion tests passed")
 
 
 async def explicit_partial_reset_test() -> None:

--- a/tests/test_v043_beta18.py
+++ b/tests/test_v043_beta18.py
@@ -17,6 +17,9 @@ def test_completion_is_current_cycle_confirmed():
     assert '"task_zone_seen_incomplete"' in history
     assert '"task_zone_completion_confirmed"' in history
     assert "_async_repair_unverified_zone_completions" in history
-    start = history.index("    def prepare_cycle(\n")
+    start = history.index("    def _confirm_coverage_completions_locked")
     end = history.index("    def cycle_diagnostics", start)
-    assert '"last_completed_at"' not in history[start:end]
+    completion = history[start:end]
+    assert '"private_zone_coverage"' in completion
+    assert '"coverage_100_without_current_cycle_evidence"' in completion
+    assert "current_cycle_cloud_end" not in completion

--- a/tests/test_v043_beta20.py
+++ b/tests/test_v043_beta20.py
@@ -1,13 +1,10 @@
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta20_identity():
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta20"
+def test_beta20_release_notes_remain_available():
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta20.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta20")
 
@@ -29,32 +26,11 @@ def test_docking_only_finalizes_history():
     dock = history[dock_start:dock_end]
     assert "_finish_active_locked" in dock
     assert "last_completed_at" not in dock
-    assert "last_completed_progress" not in dock
     assert "completed=self._session_completed(snapshot) if docked else None" not in coordinator
     assert "completed=None" in coordinator
 
 
-def test_completion_is_fresh_current_cycle_and_fail_closed():
-    history = (COMPONENT / "history.py").read_text(encoding="utf-8")
-    coordinator = (COMPONENT / "coordinator.py").read_text(encoding="utf-8")
-    assert "_COMPLETION_EVIDENCE_MAX_AGE_SECONDS = 30.0" in history
-    assert '"last_known_zone"' not in history[history.index("_ACTIVE_ZONE_COMPLETION_SOURCES"):history.index("SESSION_DETAIL_POINT_FORMAT")]
-    assert '"private_zone_coverage"' in history
-    assert '"guarded_large_progress_jump"' in history
-    assert '"waiting_for_second_fresh_sample"' in history
-    assert '"awaiting_second_fresh_sample"' in history
-    assert '"returning_after_95"' not in history
-    assert "vendor_end_ms >= cycle_start_ms" in history
-    assert '"last_completed_source"' in history
-    assert '"last_completed_confirmation"' in history
-    assert 'self._private_endpoint_age("path_info_time")' in coordinator
-    assert "_mqtt_route_progress_last_update" in coordinator
-    assert "_mqtt_work_progress_last_update" in coordinator
-    assert "_mqtt_task_progress_last_update" in coordinator
-    assert 'snapshot.get("work_progress_source_age")' in coordinator
-
-
-def test_completion_diagnostics_expose_source_and_freshness():
+def test_completion_metadata_and_freshness_diagnostics_remain_exposed():
     diagnostics = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
     zone_state = (COMPONENT / "zone_state.py").read_text(encoding="utf-8")
     history = (COMPONENT / "history.py").read_text(encoding="utf-8")

--- a/tests/test_v043_beta21.py
+++ b/tests/test_v043_beta21.py
@@ -1,0 +1,69 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta21_identity():
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta21"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta21.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta21")
+
+
+def test_last_completed_is_vendor_zone_coverage_authoritative():
+    history = (COMPONENT / "history.py").read_text(encoding="utf-8")
+    start = history.index("    def _confirm_coverage_completions_locked")
+    end = history.index("    def cycle_diagnostics", start)
+    completion = history[start:end]
+    assert 'row.get("pct")' in completion
+    assert '"private_zone_coverage"' in completion
+    assert 'if progress < 100:' in completion
+    assert '"coverage_100_after_incomplete"' in completion
+    assert '"coverage_100_transition"' in completion
+    assert '"coverage_100_recent_vendor_cycle"' in completion
+    assert '"coverage_100_without_current_cycle_evidence"' in completion
+    assert '"last_completed_progress": 100' in completion
+    assert '"last_completed_cycle_id": active.get("id")' in completion
+    assert "mqtt_map_work_position" not in completion
+    assert "mqtt_task_percentage" not in completion
+    assert "current_cycle_cloud_end" not in history
+    assert "waiting_for_second_fresh_sample" not in history
+
+
+def test_target_transition_keeps_previous_zone_armed_until_coverage_100():
+    history = (COMPONENT / "history.py").read_text(encoding="utf-8")
+    start = history.index("    def _confirm_coverage_completions_locked")
+    end = history.index("    def cycle_diagnostics", start)
+    completion = history[start:end]
+    assert 'seen_target.add(current_target)' in completion
+    assert 'seen_target.add(physical_zone)' in completion
+    assert 'relevant = sorted(seen_target | seen_incomplete)' in completion
+    assert 'seen_incomplete.add(zone_id)' in completion
+    assert 'active["task_zone_seen_target"] = sorted(seen_target)' in completion
+    assert 'active["task_zone_seen_incomplete"] = sorted(seen_incomplete)' in completion
+
+
+def test_private_live_100_and_task_100_cannot_directly_complete():
+    history = (COMPONENT / "history.py").read_text(encoding="utf-8")
+    update_start = history.index("    def update_zone_history")
+    update_end = history.index("    def update_from_snapshot", update_start)
+    update = history[update_start:update_end]
+    assert "last_completed_at" not in update
+    assert "active_zone_progress_source" in update
+    assert "task_progress_source" in update
+    assert "completion is owned by vendor coverage arbitration" in update
+
+
+def test_cloud_end_time_is_timestamp_only_after_coverage_100():
+    history = (COMPONENT / "history.py").read_text(encoding="utf-8")
+    start = history.index("    def _confirm_coverage_completions_locked")
+    end = history.index("    def cycle_diagnostics", start)
+    completion = history[start:end]
+    progress_gate = completion.index("if progress < 100:")
+    completion_write = completion.index('"last_completed_at"')
+    end_time_use = completion.index("vendor_end_ms")
+    assert progress_gate < completion_write
+    assert end_time_use < completion_write
+    assert "end_time + >=95" not in completion


### PR DESCRIPTION
## Summary

Make fresh vendor per-zone coverage the sole authority for advancing `Last completed`.

### Changes
- Only fresh private-cloud per-zone coverage reaching 100% can write `last_completed`.
- MQTT/private `mapWorkPosition`, route progress and whole-task percentage remain live progress sources only.
- `endTime` is timestamp metadata only and never completion proof by itself.
- Zones observed incomplete remain armed across target-zone transitions, so native multi-zone tasks can confirm the previous zone when its coverage settles to 100%.
- Stale historical 100% rows are rejected unless there is current-cycle evidence.
- Small zones get a bounded recent vendor-cycle fallback using start/end timestamps.
- Docking still only closes route/session history.
- Completion diagnostics expose seen targets and retained coverage state.

### Compatibility
The `Last completed` sensor contract is unchanged for both the built-in Navimower Schedule and external consumers such as `navimower-zone-scheduler`.

### Validation
Remote beta build passed the full pytest suite, compileall, `git diff --check`, exact diff-scope checks, and focused coverage-authority/runtime regression tests.