### PR TITLE
Navimower 0.4.3-beta22 progress projection fix

### DIFF
--- a/.github/release-notes/0.4.3-beta22.md
+++ b/.github/release-notes/0.4.3-beta22.md
@@ -1,0 +1,19 @@
+title: Navimower 0.4.3-beta22
+
+Restore live per-zone progress projection while keeping the beta21 completion contract unchanged.
+
+### Fixed
+- Active zone **Progress** no longer stays at 0% after a new vendor zone cycle resets the session cache.
+- A low current-cycle live value can refill that reset cache once both live progress and vendor coverage show the zone is genuinely incomplete.
+- Fresh vendor per-zone coverage continuously refills the session display cache; fresh MQTT work/route progress supplies denser active-zone updates between cloud polls.
+- A confirmed vendor coverage completion also settles the session display cache to 100%.
+
+### Safety
+- Existing stale-high recovery is retained: an old cached 100% still yields to fresh low live + vendor progress.
+- Existing completed-100 monotonic behavior is retained: a vendor-completed 100% zone is not pulled backward by a lower live counter.
+- `task_zone_progress` remains display/session state only. It has no path to `last_completed_at`.
+- Private `mapWorkPosition` is not persisted as dense display-cache evidence because a successful HTTP poll can still carry an old progress value after an interruption.
+- **Last completed remains beta21 behavior:** only fresh current-cycle vendor per-zone coverage reaching 100% can advance the sensor.
+
+### Verified regression
+- Covers the observed Street case where Navimow advanced 0 -> 33 -> 100 while Home Assistant stayed at 0% because the reset-time session cache was never repopulated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
 
+## 0.4.3-beta22
+
+Restore live per-zone progress projection without weakening beta21 completion safety.
+
+### Fixed
+
+- Fix active zone Progress being pinned to 0% after a confirmed vendor cycle reset even while MQTT and cloud coverage continue to advance.
+- Let low current-cycle active progress refill a reset-time session cache while retaining the existing stale-high recovery and completed-100 monotonic guards.
+- Refill the per-zone session display cache from fresh vendor coverage, with fresh MQTT work/route progress providing dense active-zone updates between cloud polls.
+- Set the display cache to 100% when the beta21 coverage completion resolver confirms the zone.
+
+### Safety
+
+- `task_zone_progress` is display/session state only and cannot write `Last completed`.
+- Private `mapWorkPosition` is deliberately not persisted into the dense display cache because a fresh HTTP poll can still carry an old semantic value after rain/charging interruptions.
+- `Last completed` remains exclusively owned by fresh current-cycle vendor per-zone coverage reaching 100%.
+
+
 ## 0.4.3-beta21
 
 Vendor per-zone coverage becomes the sole authority for `Last completed`.

--- a/custom_components/navimower/history.py
+++ b/custom_components/navimower/history.py
@@ -1418,6 +1418,10 @@ class NavimowerHistory:
             }
 
             if progress < 100:
+                # Keep the per-zone session display cache aligned with fresh
+                # authoritative coverage. This cache is display state only; it
+                # never writes Last completed.
+                active.setdefault("task_zone_progress", {})[zone_key] = progress
                 seen_incomplete.add(zone_id)
                 completion_candidates.pop(zone_key, None)
                 active["last_completion_rejection"] = None
@@ -1431,6 +1435,7 @@ class NavimowerHistory:
                 continue
 
             if zone_id in confirmed:
+                active.setdefault("task_zone_progress", {})[zone_key] = 100
                 coverage_state[zone_key] = {
                     "progress": progress,
                     "start_time": vendor_start,
@@ -1533,6 +1538,7 @@ class NavimowerHistory:
             )
             self._zone_history[zone_key] = zone_record
             active.setdefault("final_progress", {})[zone_key] = 100
+            active.setdefault("task_zone_progress", {})[zone_key] = 100
             coverage_state[zone_key] = {
                 "progress": progress,
                 "start_time": vendor_start,
@@ -1667,6 +1673,32 @@ class NavimowerHistory:
 
             active = self._cache.get(self._active_id or "")
             if active is not None:
+                # Restore the dense per-zone display cache removed by beta21.
+                # Only truly fresh MQTT work/route counters are persisted here;
+                # private mapWorkPosition is intentionally excluded because a
+                # fresh HTTP poll can still carry an old semantic value after an
+                # interruption. Completion remains coverage-only above.
+                live_zone_id = _as_int(active_progress_zone_id)
+                live_progress = _as_int(active_zone_progress)
+                live_source = str(active_zone_progress_source or "")
+                live_age = _as_float(active_zone_progress_source_age)
+                fresh_live_zone_progress = bool(
+                    str(activity or "").lower() == "mowing"
+                    and live_source in {
+                        "mqtt_map_work_position",
+                        "mqtt_route_progress",
+                    }
+                    and live_zone_id is not None
+                    and live_progress is not None
+                    and 0 <= live_progress <= 100
+                    and live_age is not None
+                    and 0 <= live_age <= _COMPLETION_EVIDENCE_MAX_AGE_SECONDS
+                )
+                if fresh_live_zone_progress:
+                    active.setdefault("task_zone_progress", {})[
+                        str(live_zone_id)
+                    ] = live_progress
+
                 if active.get("cutting_height_mm") is None:
                     target_ids = set(active.get("zone_ids") or [])
                     candidates = [

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta21"
+  "version": "0.4.3-beta22"
 }

--- a/custom_components/navimower/zone_state.py
+++ b/custom_components/navimower/zone_state.py
@@ -193,8 +193,24 @@ def build_zone_model(
         )
         live_display_pct = display_pct
         current_task_pct = clamp_pct(task_progress.get(str(zone_id)))
+        # A newly reset session cache can legitimately be 0 while the active
+        # MQTT counter and fresh vendor coverage are already advancing. Let that
+        # low current-cycle live value refill the projection, but keep the older
+        # stale-high recovery and completed-100 monotonic guards intact.
+        active_live_progress = bool(
+            zone_id == active_zone_id
+            and current_task_pct is not None
+            and current_task_pct < COMPLETION_THRESHOLD
+            and live_display_pct is not None
+            and live_display_pct > current_task_pct
+            and vendor_pct is not None
+            and vendor_pct < COMPLETION_THRESHOLD
+        )
+        if active_live_progress:
+            current_task_pct = live_display_pct
         task_override = (
-            cycle_id is not None
+            not active_live_progress
+            and cycle_id is not None
             and zone_id in visited_zone_ids
             and current_task_pct is not None
         )

--- a/tests/test_v043_beta21.py
+++ b/tests/test_v043_beta21.py
@@ -1,13 +1,10 @@
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta21_identity():
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta21"
+def test_beta21_release_notes_remain_available():
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta21.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta21")
 

--- a/tests/test_v043_beta22.py
+++ b/tests/test_v043_beta22.py
@@ -1,0 +1,81 @@
+import json
+from pathlib import Path
+
+from custom_components.navimower.zone_state import build_zone_model
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta22_identity():
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta22"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta22.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta22")
+
+
+def test_active_zone_live_progress_wins_over_reset_zero_cache():
+    rows, totals = build_zone_model(
+        map_zones=[{"id": 24, "name": "Street", "area": 82.0}],
+        zone_details=[{
+            "id": 24,
+            "name": "Street",
+            "area_m2": 82.0,
+            "progress": 33,
+            "vendor_percentage": 32,
+            "progress_source": "mqtt_map_work_position",
+        }],
+        coverage={"zones": [{
+            "id": 24,
+            "name": "Street",
+            "area": 82.0,
+            "finished": 26.24,
+            "pct": 32,
+        }]},
+        zone_history={},
+        active_session={
+            "id": "cycle-1",
+            "zone_ids": [24],
+            "visited_zone_ids": [24],
+            "task_zone_progress": {"24": 0},
+        },
+        active_zone_id=24,
+        task_progress_pct=33,
+        task_mowed_area_m2=27.06,
+        task_progress_source="mqtt_task_percentage",
+        task_area_source="mqtt_location",
+    )
+    street = rows[0]
+    assert street["coverage_pct"] == 33.0
+    assert street["task_progress_pct"] == 33.0
+    assert street["mowed_area_m2"] == 27.06
+    assert street["progress_source"] == "mqtt_map_work_position"
+    assert totals["task_progress_pct"] == 33.0
+
+
+def test_session_display_cache_tracks_coverage_and_fresh_mqtt_only():
+    history = (COMPONENT / "history.py").read_text(encoding="utf-8")
+    completion_start = history.index("    def _confirm_coverage_completions_locked")
+    completion_end = history.index("    def cycle_diagnostics", completion_start)
+    completion = history[completion_start:completion_end]
+    assert 'active.setdefault("task_zone_progress", {})[zone_key] = progress' in completion
+    assert 'active.setdefault("task_zone_progress", {})[zone_key] = 100' in completion
+
+    update_start = history.index("    def update_zone_history")
+    update_end = history.index("    def update_from_snapshot", update_start)
+    update = history[update_start:update_end]
+    assert '"mqtt_map_work_position"' in update
+    assert '"mqtt_route_progress"' in update
+    assert 'live_source in {' in update
+    assert 'str(live_zone_id)' in update
+    assert '"private_map_work_position"' not in update
+    assert "last_completed_at" not in update
+
+
+def test_active_zone_projection_preserves_existing_safety_guards():
+    source = (COMPONENT / "zone_state.py").read_text(encoding="utf-8")
+    assert "active_live_progress = bool(" in source
+    assert "current_task_pct < COMPLETION_THRESHOLD" in source
+    assert "vendor_pct < COMPLETION_THRESHOLD" in source
+    assert "not active_live_progress" in source
+    assert 'progress_source = "active_live_recovery"' in source


### PR DESCRIPTION
## What changed

- Restores the active-zone progress projection that beta21 accidentally left pinned at the reset-time session-cache value.
- Refills `task_zone_progress` from fresh vendor coverage and fresh MQTT work/route progress.
- Preserves the existing stale-high recovery and completed-100 monotonic guards.
- Keeps private `mapWorkPosition` out of the dense persisted display cache because a fresh HTTP poll can still carry a semantically stale value after interruptions.
- Keeps beta21 `Last completed` authority unchanged: only fresh current-cycle vendor per-zone coverage reaching 100% can advance completion.

## Root cause

After a confirmed zone-cycle reset, history reset `task_zone_progress[zone]` to 0. Beta21 removed the old live-progress arbitration that also repopulated that display/session cache. `zone_state.py` then preferred the cached 0 over otherwise-correct live MQTT/cloud progress, so the Street zone stayed at 0% in Home Assistant while Navimow advanced normally.

## Validation

Remote beta build passed the full pytest suite (208 tests), `compileall`, `git diff --check`, exact diff-scope validation, and the existing stale-high/completed-100/new-cycle progress regressions. A dedicated beta22 regression reproduces the observed Street 0 -> 33 case.