### PR TITLE
Navimower 0.4.3-beta24 release candidate cleanup

### DIFF
--- a/.github/release-notes/0.4.3-beta24.md
+++ b/.github/release-notes/0.4.3-beta24.md
@@ -1,0 +1,25 @@
+title: Navimower 0.4.3-beta24
+
+Release-candidate cleanup for Navimower Schedule, notifications and README structure.
+
+### Navimower Schedule UI
+- The **Navimower schedule** switch and its time entities are now created only after Schedule setup has been saved for that mower.
+- Entries that never completed Schedule setup no longer show unused Schedule controls; stale registry rows created by earlier betas are removed on reload.
+- A configured Schedule remains visible when its switch is turned off. Configuration and enabled state are intentionally separate.
+
+### Notification timeline
+- A mowing start that this Home Assistant instance cannot tie to a fresh local Mow/Resume command is now labelled neutrally as **Mowing task started** with observed-source context. It is no longer called **External mowing task started**, because the command may come from another Navimower HA instance, the mower/app or another control path.
+- Low-battery return no longer creates a duplicate Navimower-local **Mowing paused for charging** row beside the vendor Device notification. The vendor row remains the user-facing charging-pause event for both Schedule and non-Schedule users.
+- Navimower still retains the unfinished task/progress context and can emit **Mowing resumed after charging** when confirmed cutting resumes.
+
+### Scheduler diagnostics fix
+- A new `reset=true` Schedule dispatch no longer copies the old zone model's `cycle_id` into scheduler runtime.
+- `active_cycle_id` is attached only after the actual new history session for the active zone exists. This corrects diagnostics/state context without changing `Last completed` or zone-completion arbitration.
+
+### Documentation
+- README now presents **Installation**, account arrangement and setup before feature details.
+- Embedded beta development, upgrade summaries and old release-history blocks were removed from README; release history remains in **CHANGELOG.md**.
+- Notification and diagnostics documentation now describes current behavior instead of old beta-specific behavior.
+
+### Release-candidate status
+- This beta is intended as the next release-candidate baseline. The ongoing 24-hour Navimower Schedule field run remains on beta22 until its first full round rolls into round 2, so that rollover can be validated without changing the test environment mid-run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.4.3-beta24
+
+Release-candidate cleanup for Navimower Schedule, notifications and documentation.
+
+### Changed
+
+- Expose Navimower Schedule switch/time entities only after the user has saved Schedule setup for that mower; remove stale pre-setup registry entities created by earlier betas.
+- Rename un-attributed mowing starts to the neutral `Mowing task started` wording instead of claiming an `External` source when this Home Assistant instance has no fresh local command trace.
+- Use the vendor Device-feed low-battery return as the single visible charging-pause notification while retaining local task context for `Mowing resumed after charging`.
+- Reorder README into installation/setup first and current functionality second; remove embedded beta/upgrade history and keep release history in `CHANGELOG.md`.
+
+### Fixed
+
+- Stop copying a stale pre-reset zone `cycle_id` into Navimower Schedule runtime. A new dispatch now leaves `active_cycle_id` empty until the newly-created history session for that active zone is observed, then synchronizes the real session ID.
+
+### Unchanged
+
+- Navimower Schedule completion remains based on fresh `Last completed` advancement and is not changed by the cycle-ID diagnostics fix.
+- Charging/rain/night behavior remains mower-owned in 24-hour mode; charging resume attribution remains available without duplicating the vendor low-battery notification.
+
+
 ## 0.4.3-beta23
 
 Separate authoritative vendor cycle detection from dense live zone-progress projection and document Navimower Schedule.

--- a/README.md
+++ b/README.md
@@ -19,18 +19,17 @@ Navimower does **not** require the older NavimowHA integration.
 > machine with a cutting blade; verify commands and physical-gate automations in
 > a safe environment.
 
-## Project origins
+## Installation
 
-The private-cloud foundation used by Navimower was created by **Roberto
-Gualandris** in [ilguala/navimow_pro](https://github.com/ilguala/navimow_pro).
-That project reverse-engineered the Navimow mobile application's private-cloud
-communication and implemented the authentication, encrypted protocol, map
-handling and control foundation on which this integration builds.
+### HACS custom repository
 
-Navimower extends that foundation with official Smart Home OAuth/MQTT live data,
-persistent mowing history, physical-zone and gate logic, richer Home Assistant
-entities, and a separately maintained
-[Navimower Map Card](https://github.com/vahesoo/navimower-map-card).
+1. Open **HACS -> Integrations -> three-dot menu -> Custom repositories**.
+2. Add `https://github.com/vahesoo/NaviMower` as category **Integration**.
+3. Install Navimower and restart Home Assistant.
+4. Open **Settings -> Devices & services -> Add integration -> Navimower**.
+
+Manual installation is also possible by copying `custom_components/navimower`
+into `/config/custom_components/` and restarting Home Assistant.
 
 ## Recommended account arrangement
 
@@ -55,6 +54,19 @@ long as both can access the same mower.
 > account**. Add each mower as its own Navimower config entry. Entries using the
 > same account share one stable app/device identity at private-cloud account
 > scope while keeping separate entities, maps and histories.
+
+## Setup flow
+
+1. Enter the email and password of the dedicated private-cloud account.
+2. Select the mower, or enter its serial when a shared mower is not returned by
+   the normal mower list.
+3. Continue to official Smart Home OAuth.
+4. Sign in with an account that can access the same mower.
+5. Home Assistant stores both connection branches in one Navimower config entry.
+
+The two branches degrade independently: cached/private-cloud functionality may
+remain usable during an OAuth/MQTT outage, and live MQTT/history may remain
+useful during a temporary private-cloud outage.
 
 ## Main features
 
@@ -143,43 +155,36 @@ code is exposed only when the vendor actually reports one.
 
 ### Latest notification
 
-Navimower exposes the Navimow app's main **Notification -> Device** feed as the
-**Latest notification** sensor.
+Navimower exposes one merged **Latest notification** timeline. It combines the
+Navimow app's Device feed with Home Assistant-side context that Navimower can
+prove from confirmed mower state and fresh local command traces.
 
-- state: newest vendor notification title;
-- attributes: content, timestamp, read state, level/type/style and vendor code;
-- `recent`: up to five newest normalized messages;
-- poll interval: at most once per minute during normal background polling;
-- transient failures retain the last successful snapshot;
-- vendor notification codes are kept as strings, including alphanumeric values
-  such as `150A`;
-- vendor-native app jump URLs are deliberately not retained or exposed.
+- up to **10 vendor** Device notifications are retained with `origin: vendor`;
+- up to **20 Navimower** context rows are retained with `origin: navimower`;
+- vendor rows keep their original title, content, timestamp, read state and code;
+- Navimower rows explain confirmed Home Assistant starts, Resume/Dock actions,
+  night interruptions and retained-task resumes without inventing vendor codes;
+- a mowing start with no fresh command trace in this Home Assistant instance is
+  shown neutrally as **Mowing task started** / observed start. It is not labelled
+  as an app or "external" command because another HA instance, the mower itself
+  or another control path may have issued it;
+- low-battery return uses the vendor Device notification as the single visible
+  charging-pause row. Navimower still retains the unfinished task context and can
+  add **Mowing resumed after charging** when cutting really resumes;
+- local activity rows are created only after confirmed vendor activity, not from
+  an optimistic button state.
 
-Field testing with a mower shared to multiple Navimow accounts confirmed that the
-vendor `read` state is **account-specific**: reading notifications under the same
-Navimow account used by the HA private-cloud integration changes the feed entries
-from `read: false` to `read: true` on a later refresh.
+`navimower.mark_notification_read` marks the selected row using the correct
+origin-specific path: local rows stay local, while vendor rows use the vendor
+message flow. `navimower.mark_all_notifications_read` handles both retained local
+rows and the vendor Device feed.
 
-0.4.2-beta2 adds two explicit Home Assistant actions:
-
-- **`navimower.mark_notification_read`** accepts a Device notification
-  `message_id` and opens the same encrypted message-detail route used by the
-  official app. The integration does not optimistically change the cached read
-  flag; it immediately reloads the Device feed and accepts only the vendor's
-  returned state. This single-message path remains field-validation behavior in
-  beta2 until a live unread row is confirmed to become `read: true`.
-- **`navimower.mark_all_notifications_read`** uses the recovered official
-  `clearBatchMessageRead` Mark-all request and then immediately reloads the
-  Device feed.
-
-Both actions operate in the private-cloud Navimow account used by the selected
-config entry. They do not mark notifications read for other Navimow accounts to
-which the mower may also be shared.
+Vendor notification read state remains account-specific. These actions operate
+on the private-cloud Navimow account used by that config entry and do not mark
+messages read in other shared accounts.
 
 Notification history is user-facing event information and does not replace the
-live Problem/Error state model. Field testing also confirmed that mower
-fault/safety events can appear in the Device feed, but the notification code and
-live mower Error/Problem state remain separate vendor concepts.
+live Problem/Error state model.
 
 ### Settings and controls
 
@@ -201,27 +206,23 @@ Depending on mower model and firmware, Navimower can expose:
 
 **Night mowing, Rain and Rain sensor** use a robot-first plus cloud-persist write
 path. This prevents the mower's onboard copy from later restoring an older value
-to the cloud. All three were field-tested bidirectionally on H215 during the
-0.4.1 beta cycle.
+to the cloud. All three have been field-tested bidirectionally on H215.
 
 Unknown encoded cutting-height markers are not converted into invented
 millimetre values.
 
 ### i2 AWD experimental support
 
-0.4.1 introduced an initial capability profile derived from an i208 AWD
-diagnostic and the i2 documentation. It may expose settings such as Eco mode,
-Narrow zone adapt, Advanced slope mode, Grass pattern enhancement, Progress
-retention, Mowing cycle interval, Headlight, Night animal protection, Terrain
-adapt, Edge sense, TCS, positioning controls and Global cutting height when
-corresponding vendor fields are present.
+Initial i2 AWD support is capability-driven and may expose settings such as Eco
+mode, Narrow zone adapt, Advanced slope mode, Grass pattern enhancement,
+Progress retention, Mowing cycle interval, Headlight, Night animal protection,
+Terrain adapt, Edge sense, TCS, positioning controls and Global cutting height
+when the corresponding vendor fields are present.
 
 > [!CAUTION]
-> **i2 AWD support is experimental and has not yet been field-tested on a live
-> i2 AWD mower through Navimower.** The controls remain included so owners can
-> test and report behavior, but availability, labels and write semantics may vary
-> by firmware. H215 is the primary field-tested model and X390 provides secondary
-> model validation.
+> **i2 AWD controls remain experimental.** Diagnostics have provided useful
+> capability evidence, but not every control/write path has been field-validated
+> across i2 AWD models and firmware. Availability and write semantics can vary.
 
 Default battery-setting ranges are 5–20% for return-to-dock and 70–100% for the
 charging limit unless the mower reports its own supported min/max limits.
@@ -240,31 +241,6 @@ cutting height. Entities are exposed only when the model/capability mapping and
 reported vendor settings support them.
 
 The private and OAuth endpoints currently target the European/FRA service.
-
-## Installation
-
-### HACS custom repository
-
-1. Open **HACS -> Integrations -> three-dot menu -> Custom repositories**.
-2. Add `https://github.com/vahesoo/NaviMower` as category **Integration**.
-3. Install Navimower and restart Home Assistant.
-4. Open **Settings -> Devices & services -> Add integration -> Navimower**.
-
-Manual installation is also possible by copying `custom_components/navimower`
-into `/config/custom_components/` and restarting Home Assistant.
-
-## Setup flow
-
-1. Enter the email and password of the dedicated private-cloud account.
-2. Select the mower, or enter its serial when a shared mower is not returned by
-   the normal mower list.
-3. Continue to official Smart Home OAuth.
-4. Sign in with an account that can access the same mower.
-5. Home Assistant stores both connection branches in one Navimower config entry.
-
-The two branches degrade independently: cached/private-cloud functionality may
-remain usable during an OAuth/MQTT outage, and live MQTT/history may remain
-useful during a temporary private-cloud outage.
 
 ## Navimower Schedule
 
@@ -299,6 +275,11 @@ schedule** and:
 
 Only the explicitly selected zones are enrolled. Adding another zone to the map
 does not automatically add it to the scheduler.
+
+Before this setup is saved, Navimower Schedule switch/time entities are intentionally
+not created on the mower device. Saving the setup reloads the config entry and
+exposes the controls for that mower. Turning the Schedule switch off later does
+not remove the configured controls.
 
 ### How zone selection works
 
@@ -428,16 +409,12 @@ entity: lawn_mower.tont
 The integration itself provides authenticated local APIs for map data, session
 indexes, exact route details and completed-session render archives.
 
-### Built-in Map Camera removal
+### Legacy Map Camera
 
-The old SVG **Legacy Map Camera** was deprecated in 0.4.1 and is **removed from
-0.4.2-beta1 onward**. The camera platform, renderer and camera entity translation
-are no longer part of the integration. Existing dashboards should use Navimower
-Map Card instead.
-
-This removal does not affect camera/VisionFence-related mower settings such as
-Camera positioning (EFLS); it removes only the old Home Assistant SVG map-camera
-entity.
+The old built-in SVG **Legacy Map Camera** is removed. Existing dashboards should
+use Navimower Map Card instead. This does not affect camera/VisionFence-related
+mower settings such as Camera positioning (EFLS); only the old Home Assistant SVG
+map-camera entity was removed.
 
 ## Options
 
@@ -465,91 +442,41 @@ options from the 0.4.1 beta cycle remain removed.
 Use Home Assistant's normal **Download diagnostics** action from the Navimower
 integration/config-entry menu.
 
-The generated document remains sanitized. It contains general mower,
-connectivity, positioning, map, telemetry, history, capability, maintenance,
-schedule, Problem/Error and latest-notification context. Tokens, password, email,
-UID, full mower serial, GPS coordinates and other sensitive account/network
-identifiers are redacted.
+The generated document is snapshot-only and sanitized. It contains general
+mower, connectivity, positioning, map, telemetry, history, capability,
+maintenance, Navimower Schedule, Problem/Error and notification-center context.
+Tokens, password, email, UID, full mower serial, GPS coordinates and other
+sensitive account/network identifiers are redacted.
 
-From **0.4.2-beta2 onward**, Download diagnostics is snapshot-only again: the
-beta1 public-H5 notification discovery has been removed after recovering the
-required request contracts. Downloading diagnostics makes no extra vendor or H5
-requests and never executes notification read actions.
-
-The older passive MQTT discovery, broad endpoint probing, state-transition
-capture and custom `navimower.export_diagnostics` / `mark_discovery_event`
-actions remain removed.
-
-## 0.4.2 beta development
-
-### 0.4.2-beta2
-
-- adds explicit **Mark notification as read** and **Mark all notifications as
-  read** Home Assistant actions for Device notifications;
-- uses the official app's Device message-detail route for one-message field
-  validation and the confirmed `clearBatchMessageRead` mutation for Mark all;
-- forces an immediate Device-feed refresh after a successful action and never
-  invents `read: true` locally;
-- removes the beta1 H5 Download-diagnostics discovery and returns diagnostics to
-  snapshot-only behavior;
-- remains cumulative from stable 0.4.1; beta1 does not need to be installed
-  first.
-
-### 0.4.2-beta1
-
-- removes the deprecated Legacy Map Camera platform and renderer;
-- keeps Navimower Map Card as the supported map UI;
-- keeps Latest notification and the existing read-only Device feed unchanged;
-- confirms/documents notification `read` state as account-specific from field
-  testing;
-- adds a targeted Download diagnostics H5 inspection to recover the official
-  notification read mutation request for future **Mark as read** and **Mark all
-  as read** support;
-- does not send notification write/mutation requests.
-
-## Upgrade from 0.4.0 to 0.4.1
-
-0.4.1 is a cumulative stability and data-correctness release built directly on
-0.4.0. No beta releases need to be installed individually.
-
-Highlights include:
-
-- guarded private-cloud polling under dense MQTT traffic;
-- clearer raw vendor Task/Map/zone telemetry ownership;
-- multi-zone session and same-day trail stability;
-- route/history pose deduplication and mower-specific mowing footprint width;
-- freshness-aware private-cloud position fallback with conservative Gate safety;
-- corrected Idle, Lifted and numeric-fault handling;
-- vendor detail on the Error sensor for reported numeric faults;
-- the new Latest notification Device-feed sensor;
-- initial experimental/unverified i2 AWD capability support;
-- persistent bidirectional Night mowing, Rain and Rain sensor writes;
-- removal of beta-only diagnostics/discovery controls;
-- Legacy Map Camera deprecation notice ahead of its 0.4.2-beta1 removal.
-
-See [CHANGELOG.md](CHANGELOG.md) and
-[`.github/release-notes/0.4.1.md`](.github/release-notes/0.4.1.md) for the release
-summary.
-
-### v0.3.4
-
-The 0.3.4 release established the current capability-driven settings model and
-field-tested H215 control baseline. 0.4.1 retains those controls while adding the
-runtime, notification, error and model-support changes described above.
+Downloading diagnostics does not execute mower commands or notification read
+mutations. Older development-only passive discovery/export controls are not part
+of the normal integration UI.
 
 ## Current limitations
 
 - Private-cloud behavior is undocumented and may change without notice.
 - Model and firmware fields differ; unsupported settings are not invented.
-- i2 AWD support is experimental and not yet field-tested through Navimower.
+- i2 AWD control support remains experimental and is not equally field-tested
+  across models/firmware.
 - Exact dense route history depends on live MQTT pose samples; missing samples
   are not reconstructed.
 - Map writes, boundary edits and other destructive map editing are deliberately
   not included.
-- The old built-in SVG Map Camera is removed from the 0.4.2 beta line; use
-  Navimower Map Card.
-- Single-message notification read behavior is still being field-validated in
-  beta2; Mark all as read uses the directly recovered official mutation contract.
+
+For release-by-release changes, see [CHANGELOG.md](CHANGELOG.md).
+
+## Project origins
+
+The private-cloud foundation used by Navimower was created by **Roberto
+Gualandris** in [ilguala/navimow_pro](https://github.com/ilguala/navimow_pro).
+That project reverse-engineered the Navimow mobile application's private-cloud
+communication and implemented the authentication, encrypted protocol, map
+handling and control foundation on which this integration builds.
+
+Navimower extends that foundation with official Smart Home OAuth/MQTT live data,
+persistent mowing history, physical-zone and gate logic, richer Home Assistant
+entities, and a separately maintained
+[Navimower Map Card](https://github.com/vahesoo/navimower-map-card).
 
 ## Credits and licence
 

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta23"
+  "version": "0.4.3-beta24"
 }

--- a/custom_components/navimower/navimower_schedule.py
+++ b/custom_components/navimower/navimower_schedule.py
@@ -150,6 +150,11 @@ class NavimowerScheduleController:
         return tuple(sorted(self._selected_zone_ids))
 
     @property
+    def configured(self) -> bool:
+        """Return whether the user has saved Navimower Schedule setup."""
+        return self._selection_configured
+
+    @property
     def start_time(self) -> time:
         return self._start
 
@@ -409,6 +414,35 @@ class NavimowerScheduleController:
         pending = self._runtime.get("pending_command")
         return _age_seconds(pending.get("sent_at")) if isinstance(pending, dict) else None
 
+    def _sync_active_cycle_id(self) -> bool:
+        """Attach the newly-created history cycle once cutting actually starts."""
+        if (
+            self._runtime.get("active_zone_id") is None
+            or self._runtime.get("active_cycle_id") is not None
+        ):
+            return False
+        history = getattr(self.coordinator, "history", None)
+        active = getattr(history, "active_session", None)
+        if not isinstance(active, dict) or not active.get("id"):
+            return False
+        try:
+            zone_id = int(self._runtime["active_zone_id"])
+        except (TypeError, ValueError):
+            return False
+        observed: set[int] = set()
+        for value in [
+            *(active.get("zone_ids") or []),
+            *(active.get("cycle_reset_zone_ids") or []),
+        ]:
+            try:
+                observed.add(int(value))
+            except (TypeError, ValueError):
+                continue
+        if zone_id not in observed:
+            return False
+        self._runtime["active_cycle_id"] = str(active["id"])
+        return True
+
     async def _reconcile_unconfirmed_mow_start(self, activity: Any) -> None:
         """Recover safely when a new-zone start confirmation is lost across restart."""
         pending = self._runtime.get("pending_command")
@@ -481,6 +515,8 @@ class NavimowerScheduleController:
         completed_now = await self._confirm_active_completion()
         activity = data.get("activity")
         await self._confirm_pending(activity)
+        if self._sync_active_cycle_id():
+            await self._save()
         await self._reconcile_unconfirmed_mow_start(activity)
 
         if not in_window:
@@ -686,7 +722,11 @@ class NavimowerScheduleController:
             self.coordinator.start_new_mowing_cycle([zone_id], source=source)
             post_reset_row = self._zone(zone_id) or row
             self._runtime["active_zone_id"] = zone_id
-            self._runtime["active_cycle_id"] = post_reset_row.get("cycle_id")
+            # start_new_mowing_cycle closes the old history session and arms a
+            # new one. Do not copy the previous zone model's cycle_id here; the
+            # real new session is attached by _sync_active_cycle_id after the
+            # mower confirms cutting.
+            self._runtime["active_cycle_id"] = None
             self._runtime["active_zone_baseline_completed_at"] = later_iso(
                 row.get("last_completed_at"),
                 post_reset_row.get("last_completed_at"),

--- a/custom_components/navimower/notification_center.py
+++ b/custom_components/navimower/notification_center.py
@@ -617,7 +617,13 @@ class NavimowerNotificationCenter:
         ids = self._observed_task_zone_ids(snapshot)
         names_by_id = _zone_names(snapshot)
         names = [names_by_id.get(value, f"Zone {value}") for value in ids]
-        content = "Started an external mowing task"
+        # This Home Assistant instance cannot prove the source when no fresh
+        # local Mow/Resume trace exists. NM1003 used to be titled
+        # "External mowing task started", but that was too strong: the command
+        # may have come from another Navimower HA instance, the app, mower
+        # controls or voice control. The observed fallback does not assume it
+        # came from the mobile app or from any other specific external source.
+        content = "Observed a mowing task start"
         if names:
             content += f" in {_zone_phrase(names)}"
         else:
@@ -625,15 +631,15 @@ class NavimowerNotificationCenter:
         content += "."
         item = self._emit(
             "NM1003",
-            "External mowing task started",
+            "Mowing task started",
             content,
-            kind="external_mowing_started",
-            confidence="observed_external_start",
+            kind="observed_mowing_started",
+            confidence="observed_start_without_local_command",
         )
         self._active_task = {
             "task_id": (item or {}).get("message_id"),
-            "origin": "external",
-            "trigger": "external_or_vendor",
+            "origin": "observed",
+            "trigger": "observed_without_local_command",
             "zone_ids": ids,
             "zone_names": names,
             "ordered": None,
@@ -757,24 +763,20 @@ class NavimowerNotificationCenter:
 
         threshold = _as_float((snapshot.get("settings") or {}).get("return_battery_level"))
         if battery is not None and threshold is not None and battery <= threshold + 2:
-            names = list((self._active_task or {}).get("zone_names") or [])
-            content = f"The unfinished mowing task returned to charge at {battery:g}% battery"
-            if names:
-                content += f" while mowing {_zone_phrase(names)}"
-            if progress is not None:
-                content += f" at {progress:g}% task progress"
-            content += "."
-            item = self._emit(
-                "NM1007",
-                "Mowing paused for charging",
-                content,
-                kind="charging_pause",
-                confidence="inferred_from_return_battery_threshold",
-            )
+            # The vendor Device feed already reports the low-battery return,
+            # normally as code 1502. Keep that vendor row as the single visible
+            # charging-pause notification so schedule and non-schedule users see
+            # the same event without a duplicate Navimower-local NM1007 row.
+            # NM1007 "Mowing paused for charging" is therefore retained only as
+            # historical stored data from older releases. Internal task context
+            # is still kept so NM1008 can explain the later charging resume.
             self._interrupted_reason = "charging"
             if self._active_task is not None:
                 self._active_task["charging_paused_at"] = datetime.now(UTC).isoformat()
-            return item is not None
+                self._active_task["charging_pause_confidence"] = (
+                    "inferred_from_return_battery_threshold"
+                )
+            return False
 
         self._interrupted_reason = "unknown"
         return False

--- a/custom_components/navimower/switch.py
+++ b/custom_components/navimower/switch.py
@@ -442,8 +442,16 @@ async def async_setup_entry(
         )
 
     entities = [NavimowSwitch(coordinator, desc) for desc in supported_descriptions]
-    if getattr(coordinator, "navimower_schedule", None) is not None:
+    controller = getattr(coordinator, "navimower_schedule", None)
+    if controller is not None and controller.configured:
         entities.append(NavimowerScheduleSwitch(coordinator))
+    else:
+        registry = er.async_get(hass)
+        entity_id = registry.async_get_entity_id(
+            "switch", DOMAIN, f"{coordinator.sn}_navimower_schedule"
+        )
+        if entity_id is not None:
+            registry.async_remove(entity_id)
     async_add_entities(entities)
 
 

--- a/custom_components/navimower/time.py
+++ b/custom_components/navimower/time.py
@@ -7,6 +7,7 @@ from datetime import time
 from homeassistant.components.time import TimeEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -21,7 +22,14 @@ async def async_setup_entry(
 ) -> None:
     coordinator: NavimowCoordinator = hass.data[DOMAIN][entry.entry_id]
     controller = getattr(coordinator, "navimower_schedule", None)
-    if controller is None:
+    if controller is None or not controller.configured:
+        registry = er.async_get(hass)
+        for key in ("start", "end"):
+            entity_id = registry.async_get_entity_id(
+                "time", DOMAIN, f"{coordinator.sn}_navimower_schedule_{key}"
+            )
+            if entity_id is not None:
+                registry.async_remove(entity_id)
         return
     async_add_entities(
         [

--- a/tests/test_v034_release.py
+++ b/tests/test_v034_release.py
@@ -124,7 +124,10 @@ def test_readme_documents_entities_models_and_testing_scope() -> None:
     assert "Primary field testing has been performed on an **H215**" in readme
     assert "Night light brightness" in readme
     assert "Terrain adapt" in readme
-    assert "### v0.3.4" in readme
+    # README documents current behavior. Release-by-release history belongs in
+    # CHANGELOG.md instead of being duplicated in embedded version sections.
+    assert "[CHANGELOG.md](CHANGELOG.md)" in readme
+    assert "### v0.3.4" not in readme
 
 
 def test_v040_beta1_completed_session_archive_contract() -> None:

--- a/tests/test_v043_beta23.py
+++ b/tests/test_v043_beta23.py
@@ -1,13 +1,10 @@
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta23_identity_and_notes():
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta23"
+def test_beta23_release_notes_remain_available():
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta23.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta23")
 

--- a/tests/test_v043_beta24.py
+++ b/tests/test_v043_beta24.py
@@ -1,0 +1,92 @@
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _source(name: str) -> str:
+    return (COMPONENT / name).read_text(encoding="utf-8")
+
+
+def test_beta24_identity_and_release_notes():
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta24"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta24.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta24")
+
+
+def test_schedule_entities_require_saved_setup_and_cleanup_old_registry_rows():
+    schedule = _source("navimower_schedule.py")
+    switch = _source("switch.py")
+    time_source = _source("time.py")
+    for source in (schedule, switch, time_source):
+        ast.parse(source)
+
+    assert "def configured(self) -> bool:" in schedule
+    assert "return self._selection_configured" in schedule
+    assert "controller is not None and controller.configured" in switch
+    assert 'f"{coordinator.sn}_navimower_schedule"' in switch
+    assert "registry.async_remove(entity_id)" in switch
+    assert "controller is None or not controller.configured" in time_source
+    assert 'f"{coordinator.sn}_navimower_schedule_{key}"' in time_source
+
+
+def test_scheduler_cycle_id_waits_for_the_real_new_history_session():
+    source = _source("navimower_schedule.py")
+    ast.parse(source)
+    assert "def _sync_active_cycle_id(self) -> bool:" in source
+    assert 'active.get("cycle_reset_zone_ids")' in source
+    assert 'self._runtime["active_cycle_id"] = str(active["id"])' in source
+    assert "if self._sync_active_cycle_id():" in source
+
+    send_start = source.index("    async def _async_send_mow")
+    send_end = source.index("    async def _async_send_dock", send_start)
+    send = source[send_start:send_end]
+    assert 'self._runtime["active_cycle_id"] = None' in send
+    assert 'post_reset_row.get("cycle_id")' not in send
+
+
+def test_observed_mowing_start_is_neutral_when_this_ha_has_no_command_trace():
+    source = _source("notification_center.py")
+    ast.parse(source)
+    start = source.index("        ids = self._observed_task_zone_ids(snapshot)")
+    end = source.index("    def _handle_mowing_stop", start)
+    fallback = source[start:end]
+    assert '"NM1003"' in fallback
+    assert '"Mowing task started"' in fallback
+    assert 'kind="observed_mowing_started"' in fallback
+    assert 'confidence="observed_start_without_local_command"' in fallback
+    assert '"origin": "observed"' in fallback
+    assert '"trigger": "observed_without_local_command"' in fallback
+    assert '_emit(\n            "NM1003",\n            "External mowing task started"' not in fallback
+
+
+def test_low_battery_pause_uses_vendor_row_but_retains_resume_context():
+    source = _source("notification_center.py")
+    ast.parse(source)
+    start = source.index('        threshold = _as_float((snapshot.get("settings") or {}).get("return_battery_level"))')
+    end = source.index('        self._interrupted_reason = "unknown"', start)
+    charging = source[start:end]
+    assert 'self._interrupted_reason = "charging"' in charging
+    assert '"charging_paused_at"' in charging
+    assert '"inferred_from_return_battery_threshold"' in charging
+    assert 'return False' in charging
+    assert '_emit(' not in charging
+    assert '"NM1008"' in source
+    assert '"Mowing resumed after charging"' in source
+
+
+def test_readme_is_current_state_documentation_with_installation_before_features():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert readme.index("## Installation") < readme.index("## Main features")
+    assert readme.index("## Setup flow") < readme.index("## Main features")
+    assert "## Navimower Schedule" in readme
+    assert "Before this setup is saved" in readme
+    assert "## 0.4.2 beta development" not in readme
+    assert "## Upgrade from 0.4.0 to 0.4.1" not in readme
+    assert "### v0.3.4" not in readme
+    assert "External mowing task started" not in readme
+    assert "low-battery return uses the vendor Device notification" in readme
+    assert "[CHANGELOG.md](CHANGELOG.md)" in readme


### PR DESCRIPTION
## Summary

Prepare 0.4.3-beta24 as the next release-candidate baseline.

- Hide Navimower Schedule switch/time entities until Schedule setup has actually been saved for that mower, while keeping configured controls visible when merely switched off.
- Remove stale pre-setup Schedule entity-registry rows created by earlier betas.
- Make un-attributed mowing starts neutral (`Mowing task started`) instead of claiming an external source when this HA has no fresh local command trace.
- Deduplicate low-battery charging notifications: keep the vendor Device-feed row visible for all users while retaining local task context for `Mowing resumed after charging`.
- Fix stale Navimower Schedule `active_cycle_id` by attaching the real new history session only after it exists.
- Reorganize README so installation/setup precede functionality and release history remains only in CHANGELOG.

## Validation

Remote beta build passed full pytest (218 tests), compileall, diff-check, exact diff-scope, and focused Schedule/notification/README checks. The clean release branch tree is identical to that validated build tree.

The ongoing 24-hour Schedule field test remains on beta22 until round 1 rolls into round 2, so the live test is not disturbed mid-run.