### PR TITLE
Navimower 0.4.3-beta26: native GPS device tracker

### DIFF
--- a/.github/release-notes/0.4.3-beta26.md
+++ b/.github/release-notes/0.4.3-beta26.md
@@ -1,0 +1,23 @@
+title: Navimower 0.4.3-beta26
+
+Add a native Home Assistant GPS device tracker for each mower.
+
+### Added
+- Add a **Location** `device_tracker` entity to the existing mower device when the private cloud reports valid geographic latitude/longitude.
+- The tracker uses Home Assistant's native GPS tracker model, so the mower can appear on the built-in HA Map and participate in Home Assistant zones.
+- Reuse the geographic coordinates already returned by Navimower's existing private-cloud location poll. No additional vendor endpoint or GPS request is introduced.
+
+### Position source
+- This first tracker version intentionally uses the vendor-reported private-cloud geographic coordinates only.
+- Dense official MQTT `postureX/postureY` remains a local Cartesian map coordinate stream and is **not** converted into latitude/longitude yet.
+- The tracker exposes no invented GPS accuracy radius; availability requires both coordinates to be finite and inside valid latitude/longitude ranges.
+
+### Privacy
+- Home Assistant itself necessarily receives the tracker's latitude/longitude so it can place the mower on the user's own Map.
+- **Download diagnostics remains sanitized.** Latitude, longitude, last latitude/longitude and map GPS references such as `origin_gps`, `center_gps`, `ne_gps` and `sw_gps` remain redacted by the existing diagnostics sanitizer.
+- No new raw geographic-coordinate section is added to diagnostics.
+
+### Unchanged
+- Navimower Map Card continues to use the mower's local map coordinate system for now.
+- Automatic local-X/Y to geographic-map transformation and multi-mower/aerial-map overlays are future work and are not part of this beta.
+- Active-error H5 discovery remains unchanged and read-only.

--- a/custom_components/navimower/__init__.py
+++ b/custom_components/navimower/__init__.py
@@ -46,6 +46,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.LAWN_MOWER,
+    Platform.DEVICE_TRACKER,
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.SELECT,

--- a/custom_components/navimower/device_tracker.py
+++ b/custom_components/navimower/device_tracker.py
@@ -1,0 +1,78 @@
+"""Native Home Assistant GPS device tracker for Navimower."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.device_tracker import SourceType, TrackerEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import NavimowCoordinator
+from .entity import NavimowEntity
+
+
+def _coordinate(value: Any, *, minimum: float, maximum: float) -> float | None:
+    """Return one finite coordinate inside the geographic range."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed != parsed or parsed in (float("inf"), float("-inf")):
+        return None
+    return parsed if minimum <= parsed <= maximum else None
+
+
+def _latitude(data: dict[str, Any]) -> float | None:
+    return _coordinate(data.get("latitude"), minimum=-90.0, maximum=90.0)
+
+
+def _longitude(data: dict[str, Any]) -> float | None:
+    return _coordinate(data.get("longitude"), minimum=-180.0, maximum=180.0)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the mower location tracker."""
+    coordinator: NavimowCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([NavimowerDeviceTracker(coordinator)])
+
+
+class NavimowerDeviceTracker(NavimowEntity, TrackerEntity):
+    """Expose the mower's vendor-reported geographic position to Home Assistant."""
+
+    _attr_name = "Location"
+    _attr_icon = "mdi:robot-mower"
+    _attr_source_type = SourceType.GPS
+    # A position tracker is a user-facing entity, not a diagnostic-only entity.
+    _attr_entity_category = None
+    # The private-cloud location response does not expose a trustworthy accuracy
+    # radius, so do not invent one. Home Assistant treats zero as unspecified.
+    _attr_location_accuracy = 0
+
+    def __init__(self, coordinator: NavimowCoordinator) -> None:
+        """Initialize one mower tracker on the existing mower HA device."""
+        NavimowEntity.__init__(self, coordinator, "location")
+
+    @property
+    def latitude(self) -> float | None:
+        """Return the private-cloud geographic latitude."""
+        return _latitude(self.data)
+
+    @property
+    def longitude(self) -> float | None:
+        """Return the private-cloud geographic longitude."""
+        return _longitude(self.data)
+
+    @property
+    def available(self) -> bool:
+        """Only publish a map position when both coordinates are valid."""
+        return (
+            super().available
+            and self.latitude is not None
+            and self.longitude is not None
+        )

--- a/custom_components/navimower/device_tracker.py
+++ b/custom_components/navimower/device_tracker.py
@@ -45,13 +45,15 @@ async def async_setup_entry(
 class NavimowerDeviceTracker(NavimowEntity, TrackerEntity):
     """Expose the mower's vendor-reported geographic position to Home Assistant."""
 
-    _attr_name = "Location"
+    # This is the mower's primary map marker, so use the device name directly
+    # (for example "Tont") instead of displaying "Tont Location" on HA Map.
+    _attr_name = None
     _attr_icon = "mdi:robot-mower"
     _attr_source_type = SourceType.GPS
     # A position tracker is a user-facing entity, not a diagnostic-only entity.
     _attr_entity_category = None
     # The private-cloud location response does not expose a trustworthy accuracy
-    # radius, so do not invent one. Home Assistant treats zero as unspecified.
+    # radius, so do not invent one.
     _attr_location_accuracy = 0
 
     def __init__(self, coordinator: NavimowCoordinator) -> None:

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta25"
+  "version": "0.4.3-beta26"
 }

--- a/tests/test_v043_beta25.py
+++ b/tests/test_v043_beta25.py
@@ -1,14 +1,11 @@
 import ast
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta25_identity_and_notes():
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta25"
+def test_beta25_release_notes_remain_available():
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta25.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta25")
 

--- a/tests/test_v043_beta26.py
+++ b/tests/test_v043_beta26.py
@@ -1,0 +1,66 @@
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta26_identity_and_release_notes():
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta26"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta26.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta26")
+
+
+def test_native_device_tracker_platform_is_loaded():
+    init_source = (COMPONENT / "__init__.py").read_text(encoding="utf-8")
+    tracker_source = (COMPONENT / "device_tracker.py").read_text(encoding="utf-8")
+    ast.parse(init_source)
+    ast.parse(tracker_source)
+    assert "Platform.DEVICE_TRACKER" in init_source
+    assert "class NavimowerDeviceTracker(NavimowEntity, TrackerEntity):" in tracker_source
+    assert '_attr_source_type = SourceType.GPS' in tracker_source
+    assert 'NavimowEntity.__init__(self, coordinator, "location")' in tracker_source
+
+
+def test_device_tracker_uses_existing_private_cloud_geographic_fields_only():
+    tracker_source = (COMPONENT / "device_tracker.py").read_text(encoding="utf-8")
+    coordinator_source = (COMPONENT / "coordinator.py").read_text(encoding="utf-8")
+    assert 'data.get("latitude")' in tracker_source
+    assert 'data.get("longitude")' in tracker_source
+    assert '"latitude": _as_float(_find(location, "latitude", "lat"))' in coordinator_source
+    assert '"longitude": _as_float(_find(location, "longitude", "lng", "lon"))' in coordinator_source
+    assert "mqtt" not in tracker_source.lower()
+    assert "posture" not in tracker_source.lower()
+
+
+def test_device_tracker_rejects_missing_or_invalid_coordinates():
+    tracker_source = (COMPONENT / "device_tracker.py").read_text(encoding="utf-8")
+    assert "minimum=-90.0, maximum=90.0" in tracker_source
+    assert "minimum=-180.0, maximum=180.0" in tracker_source
+    assert "self.latitude is not None" in tracker_source
+    assert "self.longitude is not None" in tracker_source
+
+
+def test_download_diagnostics_still_redacts_geographic_location():
+    sanitize_source = (COMPONENT / "diagnostics_sanitize.py").read_text(encoding="utf-8")
+    diagnostics_source = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
+    ast.parse(sanitize_source)
+    ast.parse(diagnostics_source)
+    for key in (
+        '"latitude"',
+        '"longitude"',
+        '"last_latitude"',
+        '"last_longitude"',
+        '"origin_gps"',
+        '"center_gps"',
+        '"ne_gps"',
+        '"sw_gps"',
+    ):
+        assert key in sanitize_source
+    assert 'if "latitude" in normalized or "longitude" in normalized:' in sanitize_source
+    assert 'if normalized.endswith("_gps") or normalized.startswith("gps_"):' in sanitize_source
+    # Diagnostics may pass coordinator data through sanitize(), but must not
+    # publish a dedicated unsanitized tracker-coordinate section.
+    assert '"device_tracker_location"' not in diagnostics_source


### PR DESCRIPTION
## Summary

Add a native Home Assistant `device_tracker` for each Navimower mower using the real geographic latitude/longitude already returned by the existing private-cloud location poll.

### Behavior
- Adds `Platform.DEVICE_TRACKER` and a user-facing `Location` GPS tracker on the existing mower device.
- Uses only private-cloud geographic coordinates for this first version; dense MQTT X/Y stays local Cartesian and is not transformed to GPS yet.
- Validates latitude/longitude ranges and makes the tracker unavailable when either coordinate is missing/invalid.
- Adds no new vendor API request.

### Privacy
- Home Assistant receives the coordinates because its native Map requires them.
- Download diagnostics remains sanitized by the existing latitude/longitude/GPS-key redaction rules.
- No new unsanitized GPS diagnostics section is added.

### Tests
- Adds beta26 identity/platform/source/privacy regression coverage.
- Converts beta25 manifest identity test into a historical release-note check.