### PR TITLE
Navimower 0.4.3-beta27: confirm managed starts from mower state

### DIFF
--- a/.github/release-notes/0.4.3-beta27.md
+++ b/.github/release-notes/0.4.3-beta27.md
@@ -1,0 +1,13 @@
+title: Navimower 0.4.3-beta27
+
+Keep the managed one-zone scheduler simple while making new-zone starts depend on real mower state.
+
+### Fixed
+- A successful cloud command transport no longer makes a scheduler zone active immediately. A new-zone command stays pending until the mower itself confirms mowing.
+- Scheduler start confirmation no longer trusts Home Assistant's short optimistic `activity=mowing` state. It uses raw vendor mowing state and, for seamless zone-to-zone handoff, the observed active target zone.
+- The local mowing/history cycle is now started only after that vendor confirmation, so an asynchronously rejected command cannot create a fake active scheduler zone or reset local cycle state.
+- If a new-zone start is not confirmed within the existing confirmation window, the scheduler suspends without inventing an active zone.
+- The scheduler does not dispatch a new zone while the mower itself reports the dock charging state (`0102` / MQTT charging). Charging remains mower-owned behavior; no charging-interruption state or automatic Resume logic is added.
+
+### Scheduler model
+The core loop remains intentionally small: choose the oldest eligible zone, send one command, wait for the mower to confirm the start, wait for confirmed completion, then choose the next zone. Robot-owned charging, rain and other temporary interruptions remain outside the scheduler's normal decision loop.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta26"
+  "version": "0.4.3-beta27"
 }

--- a/custom_components/navimower/navimower_schedule.py
+++ b/custom_components/navimower/navimower_schedule.py
@@ -22,6 +22,8 @@ from .const import (
     DEFAULT_SCHEDULE_MODE,
     DEFAULT_SCHEDULE_START,
     DOMAIN,
+    MQTT_STATE_CHARGING,
+    MQTT_STATE_MOWING,
     OPT_SCHEDULE_ENABLED,
     OPT_SCHEDULE_END,
     OPT_SCHEDULE_MODE,
@@ -29,6 +31,9 @@ from .const import (
     OPT_SCHEDULE_ZONE_IDS,
     SCHEDULE_MODE_CONTINUOUS,
     SCHEDULE_MODE_WINDOW,
+    STATE_IDLE_DOCKED_POST,
+    STATE_MOWING,
+    STATE_MOWING_MANUAL,
     encode_partition_ids,
     mow_setup,
 )
@@ -73,6 +78,13 @@ def _age_seconds(value: Any) -> float | None:
     if parsed is None:
         return None
     return max(0.0, (datetime.now(UTC) - parsed.astimezone(UTC)).total_seconds())
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
 
 
 class NavimowerScheduleController:
@@ -414,6 +426,37 @@ class NavimowerScheduleController:
         pending = self._runtime.get("pending_command")
         return _age_seconds(pending.get("sent_at")) if isinstance(pending, dict) else None
 
+    @staticmethod
+    def _vendor_mowing(data: dict[str, Any]) -> bool:
+        """Return only a mower-confirmed cutting state, never optimistic HA activity."""
+        mqtt_state = _as_int(data.get("mqtt_vehicle_state"))
+        if mqtt_state is not None:
+            return mqtt_state == MQTT_STATE_MOWING
+        return str(data.get("state_code") or "") in {STATE_MOWING, STATE_MOWING_MANUAL}
+
+    @staticmethod
+    def _vendor_charging(data: dict[str, Any]) -> bool:
+        """Return whether the mower itself currently reports charging in the dock."""
+        mqtt_state = _as_int(data.get("mqtt_vehicle_state"))
+        if mqtt_state is not None:
+            return mqtt_state == MQTT_STATE_CHARGING
+        return str(data.get("state_code") or "") == STATE_IDLE_DOCKED_POST
+
+    def _pending_mow_confirmed(self, pending: dict[str, Any], data: dict[str, Any]) -> bool:
+        """Confirm a scheduler start from vendor state and the commanded target."""
+        if not self._vendor_mowing(data):
+            return False
+        zone_id = _as_int(pending.get("zone_id"))
+        if zone_id is None:
+            return False
+        observed_zone = _as_int(data.get("active_zone_progress_zone_id"))
+        if observed_zone == zone_id:
+            return True
+        # A start from dock/paused has a real vendor transition from non-mowing
+        # to mowing. A seamless next-zone handoff starts while the previous zone
+        # still reports mowing, so that case waits for the target zone to change.
+        return pending.get("vendor_mowing_at_send") is False
+
     def _sync_active_cycle_id(self) -> bool:
         """Attach the newly-created history cycle once cutting actually starts."""
         if (
@@ -443,34 +486,25 @@ class NavimowerScheduleController:
         self._runtime["active_cycle_id"] = str(active["id"])
         return True
 
-    async def _reconcile_unconfirmed_mow_start(self, activity: Any) -> None:
-        """Recover safely when a new-zone start confirmation is lost across restart."""
+    async def _reconcile_unconfirmed_mow_start(self) -> None:
+        """Stop safely when a scheduler start was never confirmed by the mower."""
         pending = self._runtime.get("pending_command")
-        if isinstance(pending, dict) and pending.get("kind") == "mow":
-            age = self._pending_age()
-            if age is not None and age >= _MOW_CONFIRM_SECONDS and activity != ACTIVITY_MOWING:
-                zone_id = pending.get("zone_id") or self._runtime.get("active_zone_id")
-                self._runtime["pending_command"] = None
-                self._runtime["suspended_reason"] = "mow_start_not_confirmed"
-                self._runtime["last_error"] = (
-                    "New-zone mowing start was not confirmed; automatic reset retry was refused"
-                )
-                self._runtime["last_command"] = f"mow_start_unconfirmed:{zone_id}"
-                self._runtime["last_command_at"] = _utc_now()
-                await self._save()
-                return
-
-        if (
-            self._runtime.get("suspended_reason") == "mow_start_not_confirmed"
-            and activity == ACTIVITY_MOWING
-            and self._runtime.get("active_zone_id") is not None
-        ):
-            zone_id = self._runtime.get("active_zone_id")
-            self._runtime["suspended_reason"] = None
-            self._runtime["last_error"] = None
-            self._runtime["last_command"] = f"late_mow_confirmed:{zone_id}"
-            self._runtime["last_command_at"] = _utc_now()
-            await self._save()
+        if not isinstance(pending, dict) or pending.get("kind") != "mow":
+            return
+        age = self._pending_age()
+        if age is None or age < _MOW_CONFIRM_SECONDS:
+            return
+        zone_id = pending.get("zone_id")
+        self.coordinator.clear_pending_activity()
+        self.coordinator.clear_command_target()
+        self._runtime["pending_command"] = None
+        self._runtime["suspended_reason"] = "mow_start_not_confirmed"
+        self._runtime["last_error"] = (
+            "New-zone mowing start was not confirmed by the mower; automatic reset retry was refused"
+        )
+        self._runtime["last_command"] = f"mow_start_unconfirmed:{zone_id}"
+        self._runtime["last_command_at"] = _utc_now()
+        await self._save()
 
     def _retry_ready(self) -> bool:
         stamp = self._runtime.get("retry_not_before")
@@ -514,10 +548,10 @@ class NavimowerScheduleController:
 
         completed_now = await self._confirm_active_completion()
         activity = data.get("activity")
-        await self._confirm_pending(activity)
+        await self._confirm_pending(data, activity)
         if self._sync_active_cycle_id():
             await self._save()
-        await self._reconcile_unconfirmed_mow_start(activity)
+        await self._reconcile_unconfirmed_mow_start()
 
         if not in_window:
             await self._enforce_closed_window(activity)
@@ -543,6 +577,10 @@ class NavimowerScheduleController:
         if isinstance(pending, dict):
             return
         if not self._retry_ready():
+            return
+        # Charging is a normal mower-owned interruption. Do not start another
+        # scheduler task while the mower itself reports 0102/MQTT charging.
+        if self._vendor_charging(data):
             return
         if activity not in {ACTIVITY_DOCKED, ACTIVITY_PAUSED} and not (
             completed_now and activity == ACTIVITY_MOWING
@@ -617,15 +655,34 @@ class NavimowerScheduleController:
         await self._save()
         return True
 
-    async def _confirm_pending(self, activity: Any) -> None:
+    async def _confirm_pending(self, data: dict[str, Any], activity: Any) -> None:
         pending = self._runtime.get("pending_command")
         if not isinstance(pending, dict):
             return
         kind = str(pending.get("kind") or "")
-        if kind in {"mow", "resume", "continue"} and activity == ACTIVITY_MOWING:
+        if kind == "mow":
+            if not self._pending_mow_confirmed(pending, data):
+                return
+            zone_id = _as_int(pending.get("zone_id"))
+            if zone_id is None:
+                return
+            baseline = pending.get("baseline_completed_at")
+            sent_at = str(pending.get("sent_at") or _utc_now())
+            source = str(pending.get("source") or "navimower_schedule_next_zone")
+            self.coordinator.start_new_mowing_cycle([zone_id], source=source)
+            self._runtime["active_zone_id"] = zone_id
+            self._runtime["active_cycle_id"] = None
+            self._runtime["active_zone_baseline_completed_at"] = baseline
+            self._runtime["dispatch_started_at"] = sent_at
+            self._runtime["just_completed_zone_id"] = None
+            self._runtime["retry_not_before"] = None
             self._runtime["pending_command"] = None
-            if kind in {"resume", "continue"}:
-                self._runtime["resume_pending"] = False
+            self._runtime["last_error"] = None
+            await self._save()
+            return
+        if kind in {"resume", "continue"} and activity == ACTIVITY_MOWING:
+            self._runtime["pending_command"] = None
+            self._runtime["resume_pending"] = False
             self._runtime["last_error"] = None
             await self._save()
         elif kind == "dock" and activity in {ACTIVITY_RETURNING, ACTIVITY_DOCKED}:
@@ -685,6 +742,8 @@ class NavimowerScheduleController:
         row = self._zone(zone_id) or {}
         partition_ids = encode_partition_ids([zone_id])
         partition_setup = mow_setup(reset=reset, ordered=False)
+        data_before_send = self.coordinator.data or {}
+        vendor_mowing_at_send = self._vendor_mowing(data_before_send)
         self.coordinator.begin_mow_command_trace(
             source=source,
             requested_zone_ids=[zone_id],
@@ -718,23 +777,7 @@ class NavimowerScheduleController:
             await self._save()
             return
 
-        if reset:
-            self.coordinator.start_new_mowing_cycle([zone_id], source=source)
-            post_reset_row = self._zone(zone_id) or row
-            self._runtime["active_zone_id"] = zone_id
-            # start_new_mowing_cycle closes the old history session and arms a
-            # new one. Do not copy the previous zone model's cycle_id here; the
-            # real new session is attached by _sync_active_cycle_id after the
-            # mower confirms cutting.
-            self._runtime["active_cycle_id"] = None
-            self._runtime["active_zone_baseline_completed_at"] = later_iso(
-                row.get("last_completed_at"),
-                post_reset_row.get("last_completed_at"),
-            )
-            self._runtime["dispatch_started_at"] = sent_at
-            self._runtime["just_completed_zone_id"] = None
-            self._runtime["retry_not_before"] = None
-        else:
+        if not reset:
             self._runtime["active_zone_id"] = int(self._runtime.get("active_zone_id") or zone_id)
             self._runtime["resume_pending"] = True
         self._runtime["pending_command"] = {
@@ -742,6 +785,9 @@ class NavimowerScheduleController:
             "zone_id": zone_id,
             "reset": reset,
             "sent_at": sent_at,
+            "source": source,
+            "baseline_completed_at": row.get("last_completed_at") if reset else None,
+            "vendor_mowing_at_send": vendor_mowing_at_send if reset else None,
         }
         self._runtime["last_command"] = f"mow:{zone_id}:reset={str(reset).lower()}"
         self._runtime["last_command_at"] = sent_at

--- a/tests/test_v043_beta19.py
+++ b/tests/test_v043_beta19.py
@@ -44,7 +44,8 @@ def test_restart_restores_runtime_and_reconciles_stale_new_zone_start():
     assert "_reconcile_unconfirmed_mow_start" in source
     assert '"mow_start_not_confirmed"' in source
     assert "automatic reset retry was refused" in source
-    assert '"late_mow_confirmed:' in source
+    reconcile = source[source.index("    async def _reconcile_unconfirmed_mow_start"):source.index("    def _retry_ready")]
+    assert 'self._runtime["active_zone_id"] =' not in reconcile
 
 
 def test_restart_reconciliation_runs_before_window_and_suspend_guards():
@@ -52,7 +53,7 @@ def test_restart_reconciliation_runs_before_window_and_suspend_guards():
     evaluate_start = source.index("    async def _evaluate_locked")
     evaluate_end = source.index("    async def _confirm_active_completion", evaluate_start)
     evaluate = source[evaluate_start:evaluate_end]
-    reconcile = evaluate.index("await self._reconcile_unconfirmed_mow_start(activity)")
+    reconcile = evaluate.index("await self._reconcile_unconfirmed_mow_start()")
     closed = evaluate.index("if not in_window:")
     suspended = evaluate.index('if self._runtime.get("suspended_reason"):')
     assert reconcile < closed < suspended

--- a/tests/test_v043_beta24.py
+++ b/tests/test_v043_beta24.py
@@ -38,11 +38,11 @@ def test_scheduler_cycle_id_waits_for_the_real_new_history_session():
     assert 'self._runtime["active_cycle_id"] = str(active["id"])' in source
     assert "if self._sync_active_cycle_id():" in source
 
-    send_start = source.index("    async def _async_send_mow")
-    send_end = source.index("    async def _async_send_dock", send_start)
-    send = source[send_start:send_end]
-    assert 'self._runtime["active_cycle_id"] = None' in send
-    assert 'post_reset_row.get("cycle_id")' not in send
+    confirm_start = source.index("    async def _confirm_pending")
+    confirm_end = source.index("    async def _enforce_closed_window", confirm_start)
+    confirm = source[confirm_start:confirm_end]
+    assert 'self._runtime["active_cycle_id"] = None' in confirm
+    assert 'post_reset_row.get("cycle_id")' not in source
 
 
 def test_observed_mowing_start_is_neutral_when_this_ha_has_no_command_trace():

--- a/tests/test_v043_beta26.py
+++ b/tests/test_v043_beta26.py
@@ -1,14 +1,11 @@
 import ast
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta26_identity_and_release_notes():
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta26"
+def test_beta26_release_notes_remain_available():
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta26.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta26")
 
@@ -61,6 +58,4 @@ def test_download_diagnostics_still_redacts_geographic_location():
         assert key in sanitize_source
     assert 'if "latitude" in normalized or "longitude" in normalized:' in sanitize_source
     assert 'if normalized.endswith("_gps") or normalized.startswith("gps_"):' in sanitize_source
-    # Diagnostics may pass coordinator data through sanitize(), but must not
-    # publish a dedicated unsanitized tracker-coordinate section.
     assert '"device_tracker_location"' not in diagnostics_source

--- a/tests/test_v043_beta27.py
+++ b/tests/test_v043_beta27.py
@@ -1,0 +1,70 @@
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _function(source: str, name: str) -> str:
+    start = source.index(f"    async def {name}(")
+    next_method = source.find("\n    async def ", start + 1)
+    if next_method < 0:
+        next_method = source.find("\n    def ", start + 1)
+    return source[start:] if next_method < 0 else source[start:next_method]
+
+
+def test_beta27_identity_and_release_notes():
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta27"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta27.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta27")
+
+
+def test_scheduler_new_zone_start_stays_pending_until_vendor_confirmation():
+    source = (COMPONENT / "navimower_schedule.py").read_text(encoding="utf-8")
+    ast.parse(source)
+    send = _function(source, "_async_send_mow")
+    confirm = _function(source, "_confirm_pending")
+
+    assert '"kind": "mow" if reset else "continue"' in send
+    assert '"baseline_completed_at": row.get("last_completed_at") if reset else None' in send
+    assert '"vendor_mowing_at_send": vendor_mowing_at_send if reset else None' in send
+    assert "self.coordinator.start_new_mowing_cycle" not in send
+    assert 'if not reset:' in send
+
+    assert 'if kind == "mow":' in confirm
+    assert "self._pending_mow_confirmed(pending, data)" in confirm
+    assert "self.coordinator.start_new_mowing_cycle([zone_id], source=source)" in confirm
+    assert 'self._runtime["active_zone_id"] = zone_id' in confirm
+
+
+def test_scheduler_uses_raw_vendor_state_not_optimistic_activity_for_new_start():
+    source = (COMPONENT / "navimower_schedule.py").read_text(encoding="utf-8")
+    assert "MQTT_STATE_MOWING" in source
+    assert "STATE_MOWING" in source
+    assert "STATE_MOWING_MANUAL" in source
+    assert 'data.get("mqtt_vehicle_state")' in source
+    assert 'data.get("state_code")' in source
+
+    confirmed_start = source[source.index("    def _pending_mow_confirmed"):source.index("    def _sync_active_cycle_id")]
+    assert "ACTIVITY_MOWING" not in confirmed_start
+    assert 'data.get("active_zone_progress_zone_id")' in confirmed_start
+
+
+def test_scheduler_does_not_dispatch_a_new_zone_while_vendor_reports_charging():
+    source = (COMPONENT / "navimower_schedule.py").read_text(encoding="utf-8")
+    assert "MQTT_STATE_CHARGING" in source
+    assert "STATE_IDLE_DOCKED_POST" in source
+    evaluate = _function(source, "_evaluate_locked")
+    guard = evaluate.index("if self._vendor_charging(data):")
+    dispatch = evaluate.index("await self._async_send_mow(zone_id, reset=True")
+    assert guard < dispatch
+
+
+def test_unconfirmed_start_cannot_leave_a_fake_active_zone():
+    source = (COMPONENT / "navimower_schedule.py").read_text(encoding="utf-8")
+    reconcile = _function(source, "_reconcile_unconfirmed_mow_start")
+    assert 'self._runtime["pending_command"] = None' in reconcile
+    assert 'self._runtime["suspended_reason"] = "mow_start_not_confirmed"' in reconcile
+    assert 'self._runtime["active_zone_id"] =' not in reconcile


### PR DESCRIPTION
## Summary

Fix the managed one-zone scheduler deadlock seen when a new-zone command was accepted by transport but rejected asynchronously by the mower because the battery was low.

### What changes
- A reset/new-zone command remains `pending_command` until the mower itself confirms cutting.
- Scheduler confirmation does not trust the coordinator's optimistic `activity=mowing` state.
- Vendor-confirmed mowing uses raw MQTT/private mower state; seamless zone-to-zone handoff also waits for the observed active target to move to the commanded zone.
- `active_zone_id` and the local new mowing/history cycle are created only after confirmation.
- An unconfirmed start times out without creating a fake active zone.
- A new scheduler task is not dispatched while the mower itself reports charging (`0102` / MQTT charging).

### Intentionally unchanged
- No Notification Center dependency.
- No `charging_interrupted` scheduler state.
- No new automatic Resume behavior.
- Charging, rain and temporary robot-owned interruptions remain the mower's responsibility.

This keeps the core loop intentionally simple: choose zone -> send -> confirm real start -> wait for completion -> choose next.