### PR TITLE
Navimower 0.4.3-beta28: keep map edits out of mowing timestamps

### DIFF
--- a/.github/release-notes/0.4.3-beta28.md
+++ b/.github/release-notes/0.4.3-beta28.md
@@ -1,0 +1,11 @@
+title: Navimower 0.4.3-beta28
+
+Keep per-zone mowing timestamps tied to actual observed cutting instead of vendor coverage-cycle timestamps.
+
+### Fixed
+- Map edits that reset an edited zone no longer turn the vendor `path-info-time` `startTime` into a fake **Last started** or **Last mowed** timestamp.
+- `Last started` and `Last mowed` remain owned by the integration's observed cutting/session history.
+- Raw vendor `startTime` / `endTime` remain available as `vendor_start_time` / `vendor_end_time` for coverage, cycle and completion diagnostics.
+
+### Why
+Navimow rewrites the edited zone's coverage `startTime` when map geometry is changed and that zone's mowing progress is reset. That timestamp is therefore a coverage/cycle marker, not reliable proof that mowing actually started.

--- a/custom_components/navimower/__init__.py
+++ b/custom_components/navimower/__init__.py
@@ -31,7 +31,7 @@ from .const import (
     OPT_INCLUDE_RETURN_TRAIL,
     OPT_TRAIL_RETENTION_DAYS,
 )
-from .coordinator import NavimowCoordinator, state_store
+from .coordinator_semantics import NavimowCoordinator, state_store
 from .gate import parse_gates
 from .history import NavimowerHistory
 from .map_api import async_register_map_api

--- a/custom_components/navimower/coordinator_semantics.py
+++ b/custom_components/navimower/coordinator_semantics.py
@@ -1,0 +1,37 @@
+"""Narrow semantic corrections layered on the main Navimower coordinator."""
+from __future__ import annotations
+
+from typing import Any
+
+from .coordinator import NavimowCoordinator as _BaseNavimowCoordinator
+from .coordinator import state_store
+
+
+class NavimowCoordinator(_BaseNavimowCoordinator):
+    """Coordinator with strict observed-mowing timestamp semantics.
+
+    The vendor path-info-time ``startTime``/``endTime`` fields are coverage/cycle
+    metadata. A map edit can rewrite ``startTime`` while resetting the edited
+    zone to 0%, so those values must not become user-facing Last started / Last
+    mowed timestamps. Real per-zone mowing timestamps are owned by the history
+    manager and are written only from observed cutting poses.
+    """
+
+    def _build_zone_details(
+        self,
+        coverage: dict[str, Any] | None,
+        global_height: int | None,
+        cutting_height_supported: bool,
+    ) -> list[dict[str, Any]]:
+        details = super()._build_zone_details(
+            coverage,
+            global_height,
+            cutting_height_supported,
+        )
+        for detail in details:
+            detail.pop("last_started_at", None)
+            detail.pop("last_mowed_at", None)
+        return details
+
+
+__all__ = ["NavimowCoordinator", "state_store"]

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta27"
+  "version": "0.4.3-beta28"
 }

--- a/tests/test_v043_beta27.py
+++ b/tests/test_v043_beta27.py
@@ -1,5 +1,4 @@
 import ast
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -14,9 +13,7 @@ def _function(source: str, name: str) -> str:
     return source[start:] if next_method < 0 else source[start:next_method]
 
 
-def test_beta27_identity_and_release_notes():
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta27"
+def test_beta27_release_notes_are_retained():
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta27.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta27")
 

--- a/tests/test_v043_beta28.py
+++ b/tests/test_v043_beta28.py
@@ -1,0 +1,31 @@
+"""Regression guards for 0.4.3-beta28 map-edit timestamp semantics."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+semantics = (ROOT / "custom_components/navimower/coordinator_semantics.py").read_text()
+init_source = (ROOT / "custom_components/navimower/__init__.py").read_text()
+history = (ROOT / "custom_components/navimower/history.py").read_text()
+manifest = json.loads(
+    (ROOT / "custom_components/navimower/manifest.json").read_text()
+)
+
+# The runtime coordinator must strip the ambiguous vendor coverage timestamps
+# before zone history sees them. Raw vendor fields stay in the base coordinator
+# for cycle/completion evidence.
+assert 'detail.pop("last_started_at", None)' in semantics
+assert 'detail.pop("last_mowed_at", None)' in semantics
+assert "super()._build_zone_details(" in semantics
+assert "from .coordinator_semantics import NavimowCoordinator, state_store" in init_source
+
+# Actual Last started / Last mowed timestamps continue to be written from real
+# cutting observations in the persistent history manager.
+assert '"last_mowed_at": observed_iso' in history
+assert 'record["last_started_at"] = observed_iso' in history
+assert "if cutting:" in history
+
+assert manifest["version"] == "0.4.3-beta28"
+print("beta28 map-edit timestamp regression tests passed")


### PR DESCRIPTION
## Summary

Fix the per-zone timestamp semantics exposed by the 2026-08-23 H215 map-edit diagnostics.

### What changes
- Vendor `path-info-time` `startTime` / `endTime` remain raw coverage/cycle metadata, but they no longer feed user-facing **Last started** / **Last mowed**.
- Per-zone Last started / Last mowed remain owned by actual observed cutting/session history.
- Map editing can therefore reset a zone to 0% and rewrite the vendor coverage `startTime` without creating a fake mowing event.
- Version bumped to `0.4.3-beta28` with a focused regression guard.

### Evidence
The same logical map remained active while the Yard boundary and one existing off-limit area were edited. Navimow reset Yard from 51% to 0% and rewrote the vendor `startTime` to the map-edit time even though no new mowing session existed. After the mower returned to dock, that vendor timestamp remained, proving it is not reliable evidence of mowing activity.

No scheduler behavior, map geometry parsing, coverage reset behavior, or completion arbitration is changed.