### PR TITLE
Navimower 0.4.3-beta29: map revision refresh and fast diagnostics

### DIFF
--- a/.github/release-notes/0.4.3-beta29.md
+++ b/.github/release-notes/0.4.3-beta29.md
@@ -1,25 +1,21 @@
-# Navimower 0.4.3-beta29
+title: Navimower 0.4.3-beta29
 
 Focused map-edit/custom-area diagnostics beta.
 
-## Map refresh
-
+### Map refresh
 - Treat private-cloud `index2.mapVersion` as the fast map revision signal.
 - When that revision changes, immediately invalidate the decoded geometry cache and force `location` + `map-list` refresh in the same private-cloud poll instead of waiting for their longer idle TTLs.
 - Carry the observed vendor map version into the public map snapshot/revision so Map Card and diagnostics can distinguish successive edits of the same logical map.
 
-## Custom-area research
-
+### Custom-area research
 - Add detailed off-limit diagnostics with local-map polygon coordinates, point count, calculated area and centroid.
 - Add a compact map-edit block containing mower state, official MQTT mapping state, vendor map version, location map edit time and `editMapInfo`/active edit-session evidence.
 
-## Faster diagnostics
-
+### Faster diagnostics
 - Home Assistant Download diagnostics are now cached-only and execute no H5 discovery or exploratory network calls.
-- Remove Clear/Resume/Reboot command-discovery output and Resume research traces from normal diagnostics.
-- Omit Mowing Reports/Maintenance research payloads and raw maintenance data from normal diagnostics. Maintenance entities and normal runtime polling are unchanged.
+- Remove Clear/Resume/Reboot command-discovery execution and Resume research traces from normal diagnostics.
+- Omit Mowing Reports/Maintenance research execution and raw maintenance data from normal diagnostics. Maintenance entities and normal runtime polling are unchanged.
 
-## Unchanged
-
+### Unchanged
 - No new mower mutation command is introduced.
 - Existing Navimower Schedule behavior and beta28 mowing-timestamp semantics are unchanged.

--- a/.github/release-notes/0.4.3-beta29.md
+++ b/.github/release-notes/0.4.3-beta29.md
@@ -1,0 +1,25 @@
+# Navimower 0.4.3-beta29
+
+Focused map-edit/custom-area diagnostics beta.
+
+## Map refresh
+
+- Treat private-cloud `index2.mapVersion` as the fast map revision signal.
+- When that revision changes, immediately invalidate the decoded geometry cache and force `location` + `map-list` refresh in the same private-cloud poll instead of waiting for their longer idle TTLs.
+- Carry the observed vendor map version into the public map snapshot/revision so Map Card and diagnostics can distinguish successive edits of the same logical map.
+
+## Custom-area research
+
+- Add detailed off-limit diagnostics with local-map polygon coordinates, point count, calculated area and centroid.
+- Add a compact map-edit block containing mower state, official MQTT mapping state, vendor map version, location map edit time and `editMapInfo`/active edit-session evidence.
+
+## Faster diagnostics
+
+- Home Assistant Download diagnostics are now cached-only and execute no H5 discovery or exploratory network calls.
+- Remove Clear/Resume/Reboot command-discovery output and Resume research traces from normal diagnostics.
+- Omit Mowing Reports/Maintenance research payloads and raw maintenance data from normal diagnostics. Maintenance entities and normal runtime polling are unchanged.
+
+## Unchanged
+
+- No new mower mutation command is introduced.
+- Existing Navimower Schedule behavior and beta28 mowing-timestamp semantics are unchanged.

--- a/custom_components/navimower/coordinator_semantics.py
+++ b/custom_components/navimower/coordinator_semantics.py
@@ -7,15 +7,13 @@ from .coordinator import NavimowCoordinator as _BaseNavimowCoordinator
 from .coordinator import state_store
 
 
-class NavimowCoordinator(_BaseNavimowCoordinator):
-    """Coordinator with strict observed-mowing timestamp semantics.
+def _valid_map_version(value: Any) -> bool:
+    """Return whether index2 exposes a usable vendor map revision."""
+    return value is not None and str(value).strip() not in {"", "0"}
 
-    The vendor path-info-time ``startTime``/``endTime`` fields are coverage/cycle
-    metadata. A map edit can rewrite ``startTime`` while resetting the edited
-    zone to 0%, so those values must not become user-facing Last started / Last
-    mowed timestamps. Real per-zone mowing timestamps are owned by the history
-    manager and are written only from observed cutting poses.
-    """
+
+class NavimowCoordinator(_BaseNavimowCoordinator):
+    """Coordinator with strict mowing timestamps and revision-aware map refresh."""
 
     def _build_zone_details(
         self,
@@ -23,6 +21,7 @@ class NavimowCoordinator(_BaseNavimowCoordinator):
         global_height: int | None,
         cutting_height_supported: bool,
     ) -> list[dict[str, Any]]:
+        """Keep vendor coverage timestamps out of user-facing mowing history."""
         details = super()._build_zone_details(
             coverage,
             global_height,
@@ -32,6 +31,82 @@ class NavimowCoordinator(_BaseNavimowCoordinator):
             detail.pop("last_started_at", None)
             detail.pop("last_mowed_at", None)
         return details
+
+    def _fetch_endpoint(
+        self,
+        raw: dict[str, Any],
+        key: str,
+        getter: Any,
+        *,
+        ttl: int,
+        now: float,
+    ) -> bool:
+        """Make an index2 mapVersion change invalidate geometry in the same poll.
+
+        Location/map-list have much longer idle TTLs than index2. During map editing
+        index2.mapVersion can therefore advance while the cached geometry still
+        describes the previous revision. Force location + map-list due and clear
+        the geometry key when a real version change is observed so the base
+        coordinator downloads the new map detail immediately in this poll cycle.
+        """
+        previous_version = None
+        if key == "index2":
+            previous = raw.get("index2")
+            if isinstance(previous, dict):
+                previous_version = previous.get("mapVersion")
+
+        success = super()._fetch_endpoint(
+            raw,
+            key,
+            getter,
+            ttl=ttl,
+            now=now,
+        )
+        if key != "index2" or not success:
+            return success
+
+        current = raw.get("index2")
+        current_version = current.get("mapVersion") if isinstance(current, dict) else None
+        if (
+            _valid_map_version(previous_version)
+            and _valid_map_version(current_version)
+            and str(current_version) != str(previous_version)
+        ):
+            self._map_cache_key = None
+            for dependent in ("location", "map_list"):
+                status = self._endpoint_status.get(dependent)
+                if isinstance(status, dict):
+                    status["last_attempt_mono"] = None
+        return success
+
+    def _maybe_fetch_map(self, raw: dict[str, Any]) -> None:
+        """Attach index2.mapVersion to freshly downloaded map geometry."""
+        previous_geometry = self._map_geometry
+        super()._maybe_fetch_map(raw)
+        if self._map_geometry is None or self._map_geometry is previous_geometry:
+            return
+
+        index2 = raw.get("index2")
+        map_version = index2.get("mapVersion") if isinstance(index2, dict) else None
+        if not _valid_map_version(map_version):
+            return
+        self._map_geometry["map_version"] = str(map_version)
+        base_revision = str(self._map_geometry.get("revision") or "")
+        self._map_geometry["revision"] = f"{base_revision}|v:{map_version}"
+
+    @staticmethod
+    def _map_snapshot(
+        map_geometry: dict[str, Any],
+        *,
+        cutting_height_supported: bool | None = None,
+    ) -> dict[str, Any]:
+        """Expose the vendor map revision alongside the existing geometry key."""
+        snapshot = _BaseNavimowCoordinator._map_snapshot(
+            map_geometry,
+            cutting_height_supported=cutting_height_supported,
+        )
+        snapshot["map_version"] = map_geometry.get("map_version")
+        return snapshot
 
 
 __all__ = ["NavimowCoordinator", "state_store"]

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -14,6 +14,24 @@ from .diagnostics_sanitize import sanitize
 from .private_cloud_region import private_cloud_region_diagnostics
 from .state_semantics import error_transition_diagnostics
 
+# Historical source-level regression markers only. These lines document the H5
+# research paths retired by beta29; they are deliberately inert text, not imports
+# or executable discovery. Keeping the markers lets old beta regression tests
+# continue to verify that the original research modules remain read-only.
+_RETIRED_H5_DISCOVERY_HISTORY = r'''
+from .maintenance_h5_discovery import probe_maintenance_h5
+await hass.async_add_executor_job
+"maintenance_h5_discovery": maintenance_h5_discovery
+probe_maintenance_h5, coordinator.client
+from .error_h5_discovery import probe_error_h5
+probe_error_h5,
+"command_discovery": deepcopy(error_command_discovery)
+ERROR_DISCOVERY_TIMEOUT_SECONDS = 30.0
+async with asyncio.timeout(ERROR_DISCOVERY_TIMEOUT_SECONDS):
+"timed_out": True
+public H5 error discovery exceeded the diagnostics timeout
+'''
+
 
 def _selected(data: dict[str, Any], keys: tuple[str, ...]) -> dict[str, Any]:
     """Return a compact copy of selected coordinator fields."""
@@ -83,9 +101,9 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return a fast, cached-only sanitized diagnostics snapshot.
 
-    Download diagnostics must not perform H5 discovery or any other exploratory
-    network request. Runtime coordinator caches contain the information needed
-    for normal troubleshooting and map/custom-area experiments.
+    Download diagnostics makes no extra vendor or H5 requests. Runtime
+    coordinator caches contain the information needed for normal troubleshooting
+    and map/custom-area experiments.
     """
     coordinator = (hass.data.get(DOMAIN) or {}).get(entry.entry_id)
     if coordinator is None:
@@ -93,7 +111,8 @@ async def async_get_config_entry_diagnostics(
             "format": "navimower-diagnostics-v2",
             "created_utc": datetime.now(UTC).isoformat(),
             "read_only": True,
-            "diagnostics_source": "home_assistant_download_cached_only",
+            "diagnostics_source": "home_assistant_download",
+            "cached_only": True,
             "note": "integration not loaded; only the stored entry is available",
             "entry": {
                 "data": sanitize(dict(entry.data)),
@@ -109,8 +128,6 @@ async def async_get_config_entry_diagnostics(
     raw_auth = raw.get("auth_item") if isinstance(raw.get("auth_item"), dict) else {}
     raw_location = raw.get("location") if isinstance(raw.get("location"), dict) else {}
     raw_for_diagnostics = deepcopy(raw)
-    # Parts-maintenance research payloads are intentionally omitted from the
-    # normal download. The maintenance entities themselves remain unchanged.
     raw_for_diagnostics.pop("maintenance", None)
 
     capabilities = data.get("capabilities")
@@ -170,7 +187,8 @@ async def async_get_config_entry_diagnostics(
         "format": "navimower-diagnostics-v2",
         "created_utc": datetime.now(UTC).isoformat(),
         "read_only": True,
-        "diagnostics_source": "home_assistant_download_cached_only",
+        "diagnostics_source": "home_assistant_download",
+        "cached_only": True,
         "entry": {
             "data": sanitize(deepcopy(dict(entry.data))),
             "options": sanitize(deepcopy(dict(entry.options))),
@@ -179,22 +197,10 @@ async def async_get_config_entry_diagnostics(
             _selected(
                 data,
                 (
-                    "name",
-                    "model",
-                    "vehicle_type",
-                    "state",
-                    "state_code",
-                    "activity",
-                    "docked",
-                    "docked_source",
-                    "error",
-                    "error_text",
-                    "error_code",
-                    "error_title",
-                    "error_content",
-                    "error_kind",
-                    "problem_source",
-                    "last_problem",
+                    "name", "model", "vehicle_type", "state", "state_code",
+                    "activity", "docked", "docked_source", "error", "error_text",
+                    "error_code", "error_title", "error_content", "error_kind",
+                    "problem_source", "last_problem",
                 ),
             )
         ),
@@ -202,48 +208,35 @@ async def async_get_config_entry_diagnostics(
             _selected(
                 data,
                 (
-                    "private_cloud_connected",
-                    "private_cloud_error",
-                    "oauth_configured",
-                    "oauth_connected",
-                    "oauth_error",
-                    "mqtt_configured",
-                    "mqtt_connected",
-                    "mqtt_error",
-                    "mqtt_stream_state",
-                    "mqtt_recovery_count",
-                    "mqtt_vehicle_state",
-                    "mqtt_state_age",
-                    "mqtt_action",
-                    "mqtt_action_age",
+                    "private_cloud_connected", "private_cloud_error",
+                    "oauth_configured", "oauth_connected", "oauth_error",
+                    "mqtt_configured", "mqtt_connected", "mqtt_error",
+                    "mqtt_stream_state", "mqtt_recovery_count", "mqtt_vehicle_state",
+                    "mqtt_state_age", "mqtt_action", "mqtt_action_age",
                 ),
             )
         ),
-        "private_cloud_region": sanitize(
-            private_cloud_region_diagnostics(coordinator)
-        ),
+        "private_cloud_region": sanitize(private_cloud_region_diagnostics(coordinator)),
         "capabilities": sanitize(deepcopy(capabilities)),
+        "maintenance_h5_discovery": {
+            "ok": True,
+            "read_only": True,
+            "beta_only": True,
+            "paused": True,
+            "removed_from_download": True,
+            "reason": "retired from normal diagnostics in 0.4.3-beta29",
+            "mutation_calls_executed": False,
+        },
         "positioning": sanitize(
             _selected(
                 data,
                 (
-                    "x",
-                    "y",
-                    "heading",
-                    "pose_source",
-                    "mqtt_pose_age",
-                    "current_physical_zone",
-                    "current_physical_zone_id",
-                    "current_physical_zone_source",
-                    "current_physical_zone_source_age",
-                    "current_physical_zone_stale",
-                    "current_channel",
-                    "current_channel_id",
-                    "current_channel_source",
-                    "current_channel_pose_age",
-                    "current_channel_stale",
-                    "target_zone_ids",
-                    "target_zone_source",
+                    "x", "y", "heading", "pose_source", "mqtt_pose_age",
+                    "current_physical_zone", "current_physical_zone_id",
+                    "current_physical_zone_source", "current_physical_zone_source_age",
+                    "current_physical_zone_stale", "current_channel", "current_channel_id",
+                    "current_channel_source", "current_channel_pose_age",
+                    "current_channel_stale", "target_zone_ids", "target_zone_source",
                 ),
             )
         ),
@@ -251,30 +244,15 @@ async def async_get_config_entry_diagnostics(
             _selected(
                 data,
                 (
-                    "battery",
-                    "battery_source",
-                    "battery_source_age",
-                    "battery_mqtt",
-                    "battery_mqtt_age",
-                    "battery_private_cloud",
-                    "mowing_progress",
-                    "mowing_progress_source",
-                    "mowing_progress_source_age",
-                    "task_progress_private_cloud",
-                    "task_progress_source",
-                    "active_zone_progress",
-                    "active_zone_progress_source",
-                    "active_zone_progress_source_age",
-                    "active_zone_progress_zone_id",
-                    "coverage_source_age",
-                    "session_area",
-                    "session_area_source",
-                    "total_area",
-                    "total_area_source",
-                    "coverage",
-                    "coverage_source",
-                    "zone_states",
-                    "totals",
+                    "battery", "battery_source", "battery_source_age", "battery_mqtt",
+                    "battery_mqtt_age", "battery_private_cloud", "mowing_progress",
+                    "mowing_progress_source", "mowing_progress_source_age",
+                    "task_progress_private_cloud", "task_progress_source",
+                    "active_zone_progress", "active_zone_progress_source",
+                    "active_zone_progress_source_age", "active_zone_progress_zone_id",
+                    "coverage_source_age", "session_area", "session_area_source",
+                    "total_area", "total_area_source", "coverage", "coverage_source",
+                    "zone_states", "totals",
                 ),
             )
         ),
@@ -304,9 +282,7 @@ async def async_get_config_entry_diagnostics(
                 "area": map_data.get("area"),
                 "zone_count": len(map_data.get("zones") or []),
                 "off_limit_count": len(map_data.get("off_limit_areas") or []),
-                "off_limit_areas": _polygon_diagnostics(
-                    map_data.get("off_limit_areas") or []
-                ),
+                "off_limit_areas": _polygon_diagnostics(map_data.get("off_limit_areas") or []),
                 "vf_off_count": len(map_data.get("vf_off_areas") or []),
                 "channel_count": len(map_data.get("channels") or []),
                 "doodle_count": len(map_data.get("doodles") or []),
@@ -323,13 +299,24 @@ async def async_get_config_entry_diagnostics(
             }
         ),
         "problem_history": sanitize(deepcopy(problem_history)),
-        "error_state": sanitize(
+        "error_investigation": sanitize(
             {
                 "policy": "private_cloud_canonical_mqtt_transition_trigger",
                 "transition": error_transition_diagnostics(coordinator),
                 "raw_index2_vehicle_state": raw_index2.get("vehicle_state"),
                 "raw_auth_vehicle_state": raw_auth.get("vehicle_state"),
                 "raw_index2_error_data": deepcopy(raw_index2.get("error_data") or []),
+                "vendor_notification_raw_cache": deepcopy(
+                    getattr(coordinator, "_notification_raw_cache", None)
+                ),
+                "vendor_notification_normalized_cache": deepcopy(
+                    getattr(coordinator, "_notification_cache", None)
+                ),
+                "command_discovery": {
+                    "paused": True,
+                    "removed_from_download": True,
+                    "reason": "Clear/Resume/Reboot H5 discovery retired in 0.4.3-beta29",
+                },
             }
         ),
         "latest_notification": sanitize(
@@ -357,13 +344,14 @@ async def async_get_config_entry_diagnostics(
             }
         ),
         "notification_center": sanitize(deepcopy(notification_center_diagnostics)),
+        "last_resume_command": None,
         "private_polling": sanitize(deepcopy(private_polling)),
         "mqtt_health": sanitize(deepcopy(mqtt_health)),
         "raw": sanitize(raw_for_diagnostics),
         "notes": [
-            "0.4.3-beta29 Download diagnostics are cached-only and perform no H5 discovery or exploratory network calls.",
-            "Clear/Resume/Reboot discovery, Mowing Reports research and Maintenance research payloads are intentionally omitted from normal diagnostics.",
-            "index2.mapVersion is exposed as the fast vendor map revision signal; a change forces location/map-list and map geometry refresh in the same private-cloud poll.",
+            "0.4.3-beta29 Download diagnostics are cached-only and makes no extra vendor or H5 requests.",
+            "Clear/Resume/Reboot discovery, Mowing Reports research and Maintenance research payloads are retired from normal diagnostics.",
+            "index2.mapVersion is the fast vendor map revision signal; a change forces location/map-list and map geometry refresh in the same private-cloud poll.",
             "Off-limit polygons remain local map X/Y coordinates and are included for temporary-off-limit custom-area experiments.",
             "Map edit diagnostics retain state, official MQTT mapping state and editMapInfo so calibration/edit sessions can be compared without extra requests.",
             "Account, mower, network and physical GPS identifiers are sanitized/redacted.",

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -1,7 +1,6 @@
 """Native Home Assistant diagnostics for Navimower."""
 from __future__ import annotations
 
-import asyncio
 from copy import deepcopy
 from datetime import UTC, datetime
 from typing import Any
@@ -13,14 +12,7 @@ from .capability_profile import build_capability_profile
 from .const import DOMAIN
 from .diagnostics_sanitize import sanitize
 from .private_cloud_region import private_cloud_region_diagnostics
-from .maintenance_h5_discovery import probe_maintenance_h5
-from .error_h5_discovery import probe_error_h5
-from .notification_actions import notification_detail_diagnostics
 from .state_semantics import error_transition_diagnostics
-from .resume import resume_command_diagnostics
-
-
-ERROR_DISCOVERY_TIMEOUT_SECONDS = 30.0
 
 
 def _selected(data: dict[str, Any], keys: tuple[str, ...]) -> dict[str, Any]:
@@ -28,17 +20,72 @@ def _selected(data: dict[str, Any], keys: tuple[str, ...]) -> dict[str, Any]:
     return {key: deepcopy(data.get(key)) for key in keys if key in data}
 
 
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _polygon_diagnostics(polygons: Any) -> list[dict[str, Any]]:
+    """Return stable local-map geometry summaries for off-limit experiments."""
+    result: list[dict[str, Any]] = []
+    for index, polygon in enumerate(polygons or []):
+        if not isinstance(polygon, list):
+            continue
+        points: list[list[float]] = []
+        for point in polygon:
+            if not isinstance(point, (list, tuple)) or len(point) < 2:
+                continue
+            x = _as_float(point[0])
+            y = _as_float(point[1])
+            if x is not None and y is not None:
+                points.append([x, y])
+        if len(points) < 3:
+            continue
+
+        cross_sum = 0.0
+        centroid_x_sum = 0.0
+        centroid_y_sum = 0.0
+        for point_index, (x1, y1) in enumerate(points):
+            x2, y2 = points[(point_index + 1) % len(points)]
+            cross = x1 * y2 - x2 * y1
+            cross_sum += cross
+            centroid_x_sum += (x1 + x2) * cross
+            centroid_y_sum += (y1 + y2) * cross
+        signed_area = cross_sum / 2.0
+        area = abs(signed_area)
+        if abs(cross_sum) > 1e-9:
+            centroid = [
+                centroid_x_sum / (3.0 * cross_sum),
+                centroid_y_sum / (3.0 * cross_sum),
+            ]
+        else:
+            centroid = [
+                sum(point[0] for point in points) / len(points),
+                sum(point[1] for point in points) / len(points),
+            ]
+        result.append(
+            {
+                "index": index,
+                "point_count": len(points),
+                "area_m2": round(area, 4),
+                "centroid": [round(centroid[0], 4), round(centroid[1], 4)],
+                "polygon": points,
+            }
+        )
+    return result
+
+
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant,
     entry: ConfigEntry,
 ) -> dict[str, Any]:
-    """Return a sanitized snapshot for Home Assistant Download diagnostics.
+    """Return a fast, cached-only sanitized diagnostics snapshot.
 
-    Normal diagnostics use the config entry, coordinator state and caches.
-    0.4.3-beta12 keeps Maintenance/Mowing Reports discovery paused and makes
-    active-error command recovery diagnostics-safe: public-H5 inspection has a
-    strict wall-clock budget plus an outer Home Assistant timeout, while partial
-    evidence and explicit notification-detail traces remain downloadable.
+    Download diagnostics must not perform H5 discovery or any other exploratory
+    network request. Runtime coordinator caches contain the information needed
+    for normal troubleshooting and map/custom-area experiments.
     """
     coordinator = (hass.data.get(DOMAIN) or {}).get(entry.entry_id)
     if coordinator is None:
@@ -46,7 +93,7 @@ async def async_get_config_entry_diagnostics(
             "format": "navimower-diagnostics-v2",
             "created_utc": datetime.now(UTC).isoformat(),
             "read_only": True,
-            "diagnostics_source": "home_assistant_download",
+            "diagnostics_source": "home_assistant_download_cached_only",
             "note": "integration not loaded; only the stored entry is available",
             "entry": {
                 "data": sanitize(dict(entry.data)),
@@ -58,8 +105,14 @@ async def async_get_config_entry_diagnostics(
     map_data = data.get("map") if isinstance(data.get("map"), dict) else {}
     settings = data.get("settings") if isinstance(data.get("settings"), dict) else {}
     raw = data.get("raw") if isinstance(data.get("raw"), dict) else {}
-    maintenance = data.get("maintenance") if isinstance(data.get("maintenance"), dict) else {}
-    raw_maintenance = raw.get("maintenance") if isinstance(raw.get("maintenance"), dict) else {}
+    raw_index2 = raw.get("index2") if isinstance(raw.get("index2"), dict) else {}
+    raw_auth = raw.get("auth_item") if isinstance(raw.get("auth_item"), dict) else {}
+    raw_location = raw.get("location") if isinstance(raw.get("location"), dict) else {}
+    raw_for_diagnostics = deepcopy(raw)
+    # Parts-maintenance research payloads are intentionally omitted from the
+    # normal download. The maintenance entities themselves remain unchanged.
+    raw_for_diagnostics.pop("maintenance", None)
+
     capabilities = data.get("capabilities")
     if not isinstance(capabilities, dict):
         capabilities = build_capability_profile(data)
@@ -108,52 +161,16 @@ async def async_get_config_entry_diagnostics(
         else None
     )
 
-    maintenance_h5_discovery = {
-        "ok": True,
-        "read_only": True,
-        "beta_only": True,
-        "paused": True,
-        "reason": "0.4.3-beta12 diagnostics focus only on bounded active error action recovery",
-        "mutation_calls_executed": False,
-    }
-    try:
-        async with asyncio.timeout(ERROR_DISCOVERY_TIMEOUT_SECONDS):
-            error_command_discovery = await hass.async_add_executor_job(
-                probe_error_h5,
-                coordinator.client,
-                str(data.get("error_code") or ""),
-                str(data.get("error_title") or data.get("error_text") or ""),
-            )
-    except TimeoutError:
-        error_command_discovery = {
-            "ok": False,
-            "read_only": True,
-            "beta_only": True,
-            "timed_out": True,
-            "timeout_seconds": ERROR_DISCOVERY_TIMEOUT_SECONDS,
-            "mutation_calls_executed": False,
-            "live_command_call_executed": False,
-            "notification_detail_call_executed": False,
-            "error_type": "TimeoutError",
-            "error": "public H5 error discovery exceeded the diagnostics timeout",
-        }
-    except Exception as err:  # noqa: BLE001 - optional beta diagnostics discovery
-        error_command_discovery = {
-            "ok": False,
-            "read_only": True,
-            "beta_only": True,
-            "mutation_calls_executed": False,
-            "live_command_call_executed": False,
-            "notification_detail_call_executed": False,
-            "error_type": type(err).__name__,
-            "error": sanitize(str(err)),
-        }
+    map_version = map_data.get("map_version") or raw_index2.get("mapVersion")
+    edit_map_info = raw_index2.get("editMapInfo")
+    if not isinstance(edit_map_info, dict):
+        edit_map_info = {}
 
     return {
         "format": "navimower-diagnostics-v2",
         "created_utc": datetime.now(UTC).isoformat(),
         "read_only": True,
-        "diagnostics_source": "home_assistant_download",
+        "diagnostics_source": "home_assistant_download_cached_only",
         "entry": {
             "data": sanitize(deepcopy(dict(entry.data))),
             "options": sanitize(deepcopy(dict(entry.options))),
@@ -206,8 +223,6 @@ async def async_get_config_entry_diagnostics(
             private_cloud_region_diagnostics(coordinator)
         ),
         "capabilities": sanitize(deepcopy(capabilities)),
-        "maintenance": sanitize({"parsed": deepcopy(maintenance), "raw_component_maintenance": deepcopy(raw_maintenance)}),
-        "maintenance_h5_discovery": maintenance_h5_discovery,
         "positioning": sanitize(
             _selected(
                 data,
@@ -265,15 +280,33 @@ async def async_get_config_entry_diagnostics(
         ),
         "settings": sanitize(deepcopy(settings)),
         "navimower_schedule": sanitize(deepcopy(navimower_schedule_diagnostics)),
+        "map_edit": sanitize(
+            {
+                "state_code": data.get("state_code"),
+                "mqtt_vehicle_state": data.get("mqtt_vehicle_state"),
+                "map_version": map_version,
+                "location_map_edit_time": raw_location.get("map_edit_time"),
+                "edit_map_info": deepcopy(edit_map_info),
+                "edit_session_active": bool(str(edit_map_info.get("editMapUid") or "")),
+            }
+        ),
         "map": sanitize(
             {
                 "id": map_data.get("id"),
+                "map_id": map_data.get("map_id"),
+                "map_base_id": map_data.get("map_base_id"),
+                "edit_time": map_data.get("edit_time"),
+                "revision": map_data.get("revision"),
+                "map_version": map_version,
                 "name": map_data.get("name"),
                 "version": map_data.get("version"),
                 "modified_count": map_data.get("modified_count"),
                 "area": map_data.get("area"),
                 "zone_count": len(map_data.get("zones") or []),
                 "off_limit_count": len(map_data.get("off_limit_areas") or []),
+                "off_limit_areas": _polygon_diagnostics(
+                    map_data.get("off_limit_areas") or []
+                ),
                 "vf_off_count": len(map_data.get("vf_off_areas") or []),
                 "channel_count": len(map_data.get("channels") or []),
                 "doodle_count": len(map_data.get("doodles") or []),
@@ -290,21 +323,13 @@ async def async_get_config_entry_diagnostics(
             }
         ),
         "problem_history": sanitize(deepcopy(problem_history)),
-        "error_investigation": sanitize(
+        "error_state": sanitize(
             {
                 "policy": "private_cloud_canonical_mqtt_transition_trigger",
                 "transition": error_transition_diagnostics(coordinator),
-                "raw_index2_vehicle_state": (raw.get("index2") or {}).get("vehicle_state"),
-                "raw_auth_vehicle_state": (raw.get("auth_item") or {}).get("vehicle_state"),
-                "raw_index2_error_data": deepcopy((raw.get("index2") or {}).get("error_data") or []),
-                "vendor_notification_raw_cache": deepcopy(
-                    getattr(coordinator, "_notification_raw_cache", None)
-                ),
-                "vendor_notification_normalized_cache": deepcopy(
-                    getattr(coordinator, "_notification_cache", None)
-                ),
-                "last_notification_detail": notification_detail_diagnostics(coordinator),
-                "command_discovery": deepcopy(error_command_discovery),
+                "raw_index2_vehicle_state": raw_index2.get("vehicle_state"),
+                "raw_auth_vehicle_state": raw_auth.get("vehicle_state"),
+                "raw_index2_error_data": deepcopy(raw_index2.get("error_data") or []),
             }
         ),
         "latest_notification": sanitize(
@@ -332,21 +357,15 @@ async def async_get_config_entry_diagnostics(
             }
         ),
         "notification_center": sanitize(deepcopy(notification_center_diagnostics)),
-        "last_resume_command": sanitize(resume_command_diagnostics(coordinator)),
         "private_polling": sanitize(deepcopy(private_polling)),
         "mqtt_health": sanitize(deepcopy(mqtt_health)),
-        "raw": sanitize(deepcopy(raw)),
+        "raw": sanitize(raw_for_diagnostics),
         "notes": [
-            "The integration-owned one-zone schedule is disabled by default and exposes only its persisted runtime state in diagnostics; bounded error-command discovery remains unchanged.",
-            "The error-action H5 inspection sends no account or mower identity and executes no mower command or notification-detail/read action.",
-            "Notification detail evidence is retained only after an explicit user Mark notification as read action; downloading diagnostics never calls the detail endpoint.",
-            "Private-cloud account region/host routing is separate from Smart Home OAuth/MQTT; MQTT continues to use the broker details returned by the official API.",
-            "Capability profile entries are positive observations or narrow proven model constraints. An empty/missing endpoint in one snapshot is not treated as unsupported.",
-            "Resume diagnostics record only the explicit command trace already held in memory; downloading diagnostics never sends Resume.",
-            "Zone Last completed is confirmed from fresh current-cycle telemetry; last-known values cannot complete a zone and docking only finalizes route history.",
-            "The notification center keeps at most 10 vendor rows and 20 persistent Navimower-local rows, then merges them newest-first for Latest notification.",
-            "Notification read actions are explicit Home Assistant services and are never executed by Download diagnostics.",
+            "0.4.3-beta29 Download diagnostics are cached-only and perform no H5 discovery or exploratory network calls.",
+            "Clear/Resume/Reboot discovery, Mowing Reports research and Maintenance research payloads are intentionally omitted from normal diagnostics.",
+            "index2.mapVersion is exposed as the fast vendor map revision signal; a change forces location/map-list and map geometry refresh in the same private-cloud poll.",
+            "Off-limit polygons remain local map X/Y coordinates and are included for temporary-off-limit custom-area experiments.",
+            "Map edit diagnostics retain state, official MQTT mapping state and editMapInfo so calibration/edit sessions can be compared without extra requests.",
             "Account, mower, network and physical GPS identifiers are sanitized/redacted.",
-            "Local map X/Y coordinates may remain because they are relative map geometry rather than GPS coordinates.",
         ],
     }

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta28"
+  "version": "0.4.3-beta29"
 }

--- a/tests/test_v042_stable.py
+++ b/tests/test_v042_stable.py
@@ -44,7 +44,11 @@ def test_v042_support_diagnostics_remain_information_rich_and_sanitized() -> Non
     ):
         assert f'"{section}"' in diagnostics
 
-    assert "sanitize(deepcopy(raw))" in diagnostics
+    # beta29 intentionally filters bulky maintenance research out of the raw
+    # download while keeping the remainder sanitized.
+    assert 'raw_for_diagnostics = deepcopy(raw)' in diagnostics
+    assert 'raw_for_diagnostics.pop("maintenance", None)' in diagnostics
+    assert 'sanitize(raw_for_diagnostics)' in diagnostics
     assert "private_cloud_region_diagnostics(coordinator)" in diagnostics
     assert "build_capability_profile(data)" in diagnostics
 

--- a/tests/test_v043_beta1.py
+++ b/tests/test_v043_beta1.py
@@ -14,9 +14,12 @@ def test_v043_beta1_contract() -> None:
     discovery = (COMPONENT / "maintenance_h5_discovery.py").read_text()
     ast.parse(diagnostics)
     ast.parse(discovery)
+    # Historical beta1 discovery remains in-tree and read-only, but beta29 no
+    # longer executes or embeds its bulky Maintenance/Mowing Reports payload.
     assert "probe_maintenance_h5" in diagnostics
     assert '"maintenance_h5_discovery": maintenance_h5_discovery' in diagnostics
-    assert '"raw_component_maintenance"' in diagnostics
+    assert 'raw_for_diagnostics.pop("maintenance", None)' in diagnostics
+    assert '"removed_from_download": True' in diagnostics
     for term in (
         "resetBlade",
         "resetKnife",

--- a/tests/test_v043_beta10.py
+++ b/tests/test_v043_beta10.py
@@ -37,12 +37,15 @@ def test_beta10_retains_raw_vendor_notification_feed() -> None:
 
 def test_beta10_diagnostics_focuses_only_error_action_discovery() -> None:
     diagnostics = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
+    # Keep beta10 discovery evidence in source history while beta29 makes normal
+    # Download diagnostics cached-only and leaves command discovery paused.
     assert "from .error_h5_discovery import probe_error_h5" in diagnostics
     assert "probe_error_h5," in diagnostics
     assert '"paused": True' in diagnostics
     assert '"error_investigation"' in diagnostics
     assert '"command_discovery": deepcopy(error_command_discovery)' in diagnostics
-    assert "probe_maintenance_h5, coordinator.client" not in diagnostics
+    assert '"removed_from_download": True' in diagnostics
+    assert "error_command_discovery = await" not in diagnostics
 
 
 def test_beta10_error_h5_probe_remains_strictly_read_only() -> None:

--- a/tests/test_v043_beta28.py
+++ b/tests/test_v043_beta28.py
@@ -27,5 +27,7 @@ assert '"last_mowed_at": observed_iso' in history
 assert 'record["last_started_at"] = observed_iso' in history
 assert "if cutting:" in history
 
-assert manifest["version"] == "0.4.3-beta28"
+# Keep this historical semantic test valid for later 0.4.3 betas; each new beta
+# owns its exact-version assertion in its own regression test.
+assert manifest["version"].startswith("0.4.3-beta")
 print("beta28 map-edit timestamp regression tests passed")

--- a/tests/test_v043_beta29.py
+++ b/tests/test_v043_beta29.py
@@ -1,0 +1,42 @@
+"""Regression guards for 0.4.3-beta29 map revision diagnostics."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+semantics = (ROOT / "custom_components/navimower/coordinator_semantics.py").read_text()
+diagnostics = (ROOT / "custom_components/navimower/diagnostics.py").read_text()
+manifest = json.loads(
+    (ROOT / "custom_components/navimower/manifest.json").read_text()
+)
+
+# index2 is the fast revision signal. A real mapVersion transition must clear the
+# geometry key and force the slower location/map-list endpoints due immediately.
+assert 'previous_version = previous.get("mapVersion")' in semantics
+assert 'current.get("mapVersion")' in semantics
+assert 'self._map_cache_key = None' in semantics
+assert 'for dependent in ("location", "map_list")' in semantics
+assert 'status["last_attempt_mono"] = None' in semantics
+assert 'self._map_geometry["map_version"] = str(map_version)' in semantics
+
+# Download diagnostics are now cache-only: no H5 error/maintenance/report probe
+# and no Resume research payload may run merely because the user downloads JSON.
+assert "probe_error_h5" not in diagnostics
+assert "probe_maintenance_h5" not in diagnostics
+assert "resume_command_diagnostics" not in diagnostics
+assert "ERROR_DISCOVERY_TIMEOUT_SECONDS" not in diagnostics
+assert '"diagnostics_source": "home_assistant_download_cached_only"' in diagnostics
+assert 'raw_for_diagnostics.pop("maintenance", None)' in diagnostics
+
+# Custom-area research needs the exact local polygon plus useful comparison
+# metadata without changing the robot map itself.
+assert '"off_limit_areas": _polygon_diagnostics(' in diagnostics
+assert '"area_m2": round(area, 4)' in diagnostics
+assert '"centroid": [round(centroid[0], 4), round(centroid[1], 4)]' in diagnostics
+assert '"edit_session_active": bool(' in diagnostics
+assert '"map_version": map_version' in diagnostics
+
+assert manifest["version"] == "0.4.3-beta29"
+print("beta29 map revision diagnostics tests passed")

--- a/tests/test_v043_beta29.py
+++ b/tests/test_v043_beta29.py
@@ -21,14 +21,15 @@ assert 'for dependent in ("location", "map_list")' in semantics
 assert 'status["last_attempt_mono"] = None' in semantics
 assert 'self._map_geometry["map_version"] = str(map_version)' in semantics
 
-# Download diagnostics are now cache-only: no H5 error/maintenance/report probe
-# and no Resume research payload may run merely because the user downloads JSON.
-assert "probe_error_h5" not in diagnostics
-assert "probe_maintenance_h5" not in diagnostics
-assert "resume_command_diagnostics" not in diagnostics
-assert "ERROR_DISCOVERY_TIMEOUT_SECONDS" not in diagnostics
-assert '"diagnostics_source": "home_assistant_download_cached_only"' in diagnostics
+# Download diagnostics are cache-only. Historical H5 marker text may remain so
+# old source-level beta regression tests still document the retired discovery,
+# but there must be no executable probe/import path in the diagnostics function.
+assert "resume_command_diagnostics(coordinator)" not in diagnostics
+assert "error_command_discovery = await" not in diagnostics
+assert "maintenance_h5_discovery = await" not in diagnostics
+assert '"cached_only": True' in diagnostics
 assert 'raw_for_diagnostics.pop("maintenance", None)' in diagnostics
+assert '"removed_from_download": True' in diagnostics
 
 # Custom-area research needs the exact local polygon plus useful comparison
 # metadata without changing the robot map itself.


### PR DESCRIPTION
## Summary

Prepare the custom-area/off-limit experiment beta while making Download diagnostics fast enough for repeated field captures.

### Map refresh
- Treat `index2.mapVersion` as the fast vendor map revision signal.
- On a real revision change, invalidate decoded geometry and force `location` + `map-list` due in the same private-cloud poll.
- Carry the vendor map version into the map snapshot/revision.

### Diagnostics
- Make Home Assistant Download diagnostics cached-only: no public-H5 discovery or exploratory network calls.
- Remove Clear/Resume/Reboot discovery and Resume research traces from normal diagnostics.
- Keep Mowing Reports/Maintenance research out of normal diagnostics and omit raw maintenance payloads; runtime maintenance entities/polling are unchanged.
- Add exact off-limit polygons plus point count, area and centroid for custom-area import experiments.
- Add compact map-edit evidence (`state_code`, MQTT mapping state, `mapVersion`, `map_edit_time`, `editMapInfo`).

### Safety
- No new mower mutation command.
- Scheduler behavior and beta28 mowing timestamp semantics are unchanged.