### PR TITLE
Navimower 0.4.3-beta32: simplify Custom Area capture

### DIFF
--- a/.github/release-notes/0.4.3-beta32.md
+++ b/.github/release-notes/0.4.3-beta32.md
@@ -1,4 +1,4 @@
-# Navimower 0.4.3-beta32
+title: Navimower 0.4.3-beta32
 
 - Fixes the Custom Area capture flow so selecting **Add custom area** immediately refreshes the map and captures the baseline before the user creates the temporary off-limit area.
 - Removes the easy-to-misinterpret first empty Submit step that could accidentally capture the already-edited map and cause `custom_area_not_detected`.

--- a/.github/release-notes/0.4.3-beta32.md
+++ b/.github/release-notes/0.4.3-beta32.md
@@ -1,0 +1,6 @@
+# Navimower 0.4.3-beta32
+
+- Fixes the Custom Area capture flow so selecting **Add custom area** immediately refreshes the map and captures the baseline before the user creates the temporary off-limit area.
+- Removes the easy-to-misinterpret first empty Submit step that could accidentally capture the already-edited map and cause `custom_area_not_detected`.
+- The next screen is now the detection step: create and save exactly one temporary off-limit area in the Navimow app, return to Home Assistant, then Submit to detect it.
+- No polygon matching, persistence, deletion, gate, scheduler or mower-control behavior is changed.

--- a/custom_components/navimower/config_flow.py
+++ b/custom_components/navimower/config_flow.py
@@ -1,7 +1,7 @@
 """Navimower config flow with experimental Custom Area import support.
 
-The stable beta29 flow is kept in ``config_flow_base`` so beta30 can add the
-Custom Area experiment without disturbing the already field-tested login,
+The stable beta29 flow is kept in ``config_flow_base`` so the Custom Area
+experiment can evolve without disturbing the already field-tested login,
 scheduler, gate and legacy channel flows.
 """
 from __future__ import annotations
@@ -64,7 +64,7 @@ class NavimowOptionsFlow(_BaseNavimowOptionsFlow):
         return str(map_data.get("revision") or map_data.get("map_version") or "")
 
     async def _refresh_map_for_custom_area(self) -> None:
-        """Bypass endpoint TTLs once so Detect sees the just-saved app map."""
+        """Bypass endpoint TTLs once so capture/detect sees the current app map."""
         coordinator = self._coordinator()
         if coordinator is None:
             return
@@ -103,9 +103,16 @@ class NavimowOptionsFlow(_BaseNavimowOptionsFlow):
     async def async_step_custom_area_add(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Capture the pre-edit off-limit set before the user opens map editor."""
+        """Refresh and capture the baseline as soon as Add Custom Area is selected."""
+        del user_input
         errors: dict[str, str] = {}
-        if user_input is not None:
+
+        try:
+            await self._refresh_map_for_custom_area()
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("Could not refresh Navimow map before Custom Area capture")
+            errors["base"] = "custom_area_refresh_failed"
+        else:
             coordinator = self._coordinator()
             data = getattr(coordinator, "data", None) or {}
             map_data = data.get("map") if isinstance(data.get("map"), dict) else {}
@@ -117,8 +124,7 @@ class NavimowOptionsFlow(_BaseNavimowOptionsFlow):
                 self._custom_area_candidate = None
                 return await self.async_step_custom_area_detect()
 
-        # beta30 intentionally keeps this first form simple: submit it while the
-        # normal Navimow map is loaded and before creating the temporary island.
+        # This retry form is only shown if the fresh baseline could not be captured.
         return self.async_show_form(
             step_id="custom_area_add",
             data_schema=vol.Schema({}),
@@ -228,7 +234,7 @@ class NavimowOptionsFlow(_BaseNavimowOptionsFlow):
 
 @callback
 def _async_get_options_flow(entry: ConfigEntry) -> NavimowOptionsFlow:
-    """Return the beta30 options-flow extension for the registered handler."""
+    """Return the Custom Area options-flow extension for the registered handler."""
     del entry
     return NavimowOptionsFlow()
 

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta31"
+  "version": "0.4.3-beta32"
 }

--- a/tests/test_v043_beta29.py
+++ b/tests/test_v043_beta29.py
@@ -39,5 +39,10 @@ assert '"centroid": [round(centroid[0], 4), round(centroid[1], 4)]' in diagnosti
 assert '"edit_session_active": bool(' in diagnostics
 assert '"map_version": map_version' in diagnostics
 
-assert manifest["version"] in {"0.4.3-beta29", "0.4.3-beta30", "0.4.3-beta31"}
+assert manifest["version"] in {
+    "0.4.3-beta29",
+    "0.4.3-beta30",
+    "0.4.3-beta31",
+    "0.4.3-beta32",
+}
 print("beta29 map revision diagnostics tests passed")

--- a/tests/test_v043_beta31.py
+++ b/tests/test_v043_beta31.py
@@ -19,7 +19,6 @@ def test_custom_area_flow_has_visible_guidance_in_strings_and_english_translatio
         steps = options["step"]
         assert steps["init"]["menu_options"]["custom_areas"] == "Custom areas"
         assert steps["custom_areas"]["menu_options"]["custom_area_add"] == "Add custom area"
-        assert "Press Submit now to capture the current map as the baseline" in steps["custom_area_add"]["description"]
         assert "Now open the Navimow app and Map editor" in steps["custom_area_detect"]["description"]
         assert "{baseline_revision}" in steps["custom_area_detect"]["description"]
         assert "After it is saved, you can delete the temporary off-limit area" in steps["custom_area_name"]["description"]
@@ -35,6 +34,6 @@ def test_custom_area_flow_has_visible_guidance_in_strings_and_english_translatio
         assert options["abort"]["no_custom_areas"]
 
 
-def test_manifest_is_beta31() -> None:
-    manifest = _load(COMPONENT / "manifest.json")
-    assert manifest["version"] == "0.4.3-beta31"
+def test_beta31_release_notes_remain_available() -> None:
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta31.md").read_text(encoding="utf-8")
+    assert "0.4.3-beta31" in notes

--- a/tests/test_v043_beta32.py
+++ b/tests/test_v043_beta32.py
@@ -1,0 +1,24 @@
+"""Regression guards for 0.4.3-beta32 Custom Area capture UX."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_add_custom_area_captures_baseline_immediately() -> None:
+    source = (COMPONENT / "config_flow.py").read_text(encoding="utf-8")
+    start = source.index("    async def async_step_custom_area_add(")
+    end = source.index("    async def async_step_custom_area_detect(", start)
+    block = source[start:end]
+    assert "await self._refresh_map_for_custom_area()" in block
+    assert "self._custom_area_baseline = self._off_limit_polygons()" in block
+    assert "return await self.async_step_custom_area_detect()" in block
+    assert "if user_input is not None:" not in block
+
+
+def test_manifest_is_beta32() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta32"


### PR DESCRIPTION
Fixes the Custom Area import UX discovered during field testing. Selecting Add custom area now refreshes the current map and captures the baseline immediately, before the user creates the temporary off-limit area. This removes the ambiguous first empty Submit step that could capture the edited map and lead to custom_area_not_detected.

After selecting Add custom area, the flow proceeds directly to the detection screen. The user then creates and saves exactly one temporary off-limit area in the Navimow app, returns to Home Assistant, and presses Submit to detect it.

Polygon comparison/storage behavior is unchanged.