### PR TITLE
Navimower 0.4.3-beta33: Custom Area occupancy sensor

### DIFF
--- a/.github/release-notes/0.4.3-beta33.md
+++ b/.github/release-notes/0.4.3-beta33.md
@@ -1,0 +1,8 @@
+title: Navimower 0.4.3-beta33
+
+- Adds one Home Assistant binary sensor for every configured NaviMower Custom Area.
+- The sensor is ON only while the mower's fresh official MQTT local X/Y pose is inside or exactly on the stored Custom Area polygon boundary; it is OFF while the fresh pose is outside.
+- If the live MQTT pose is missing or stale, the Custom Area sensor becomes unavailable instead of retaining a misleading occupancy state.
+- Occupancy uses the persistent NaviMower-owned polygon and is independent of Navimow zone IDs/names, so remapping or renaming mower zones does not invalidate the Custom Area sensor.
+- The sensor exposes the stored area metadata plus MQTT position source/age as attributes.
+- No mower command, map write, cutting-height override or work-mode override is added.

--- a/custom_components/navimower/binary_sensor.py
+++ b/custom_components/navimower/binary_sensor.py
@@ -18,6 +18,12 @@ from .channel import NavimowerChannel
 from .gate import NavimowerGate
 from .const import DOMAIN, MAP_EDIT_STATES
 from .coordinator import NavimowCoordinator
+from .custom_area import (
+    OPT_CUSTOM_AREAS,
+    NavimowerCustomArea,
+    parse_custom_areas,
+    point_in_polygon,
+)
 from .entity import NavimowEntity
 
 
@@ -107,6 +113,10 @@ async def async_setup_entry(
         for channel in coordinator.channels
     )
     entities.extend(
+        NavimowerCustomAreaBinarySensor(coordinator, area)
+        for area in parse_custom_areas(entry.options.get(OPT_CUSTOM_AREAS))
+    )
+    entities.extend(
         NavimowerGateRequiredBinarySensor(coordinator, gate)
         for gate in coordinator.gates
     )
@@ -160,6 +170,36 @@ class NavimowerChannelBinarySensor(NavimowEntity, BinarySensorEntity):
     @property
     def extra_state_attributes(self) -> dict:
         return self.channel.as_dict()
+
+
+class NavimowerCustomAreaBinarySensor(NavimowEntity, BinarySensorEntity):
+    """On while the mower's fresh live X/Y pose is inside a Custom Area."""
+
+    _attr_icon = "mdi:vector-polygon"
+
+    def __init__(self, coordinator: NavimowCoordinator, area: NavimowerCustomArea) -> None:
+        super().__init__(coordinator, f"custom_area_{area.slug}")
+        self.area = area
+        self._attr_name = area.name
+
+    @property
+    def is_on(self) -> bool | None:
+        position = self.coordinator._fresh_mqtt_position()
+        if position is None:
+            return None
+        return point_in_polygon(position["x"], position["y"], self.area.polygon)
+
+    @property
+    def available(self) -> bool:
+        return super().available and self.coordinator._fresh_mqtt_position() is not None
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        return {
+            **self.area.as_dict(),
+            "position_source": "mqtt",
+            "position_age": self.coordinator.pose_age(),
+        }
 
 
 class NavimowerGateRequiredBinarySensor(NavimowEntity, BinarySensorEntity):

--- a/custom_components/navimower/custom_area.py
+++ b/custom_components/navimower/custom_area.py
@@ -79,6 +79,49 @@ def find_new_polygons(before: Any, after: Any) -> list[list[list[float]]]:
     return result
 
 
+def _point_on_segment(
+    x: float,
+    y: float,
+    x1: float,
+    y1: float,
+    x2: float,
+    y2: float,
+    *,
+    tolerance: float = 1e-6,
+) -> bool:
+    """Return whether a local-map point lies on one polygon edge."""
+    cross = (x - x1) * (y2 - y1) - (y - y1) * (x2 - x1)
+    if abs(cross) > tolerance:
+        return False
+    return (
+        min(x1, x2) - tolerance <= x <= max(x1, x2) + tolerance
+        and min(y1, y2) - tolerance <= y <= max(y1, y2) + tolerance
+    )
+
+
+def point_in_polygon(x: Any, y: Any, raw: Any) -> bool | None:
+    """Return whether X/Y is inside or on the boundary of a Custom Area."""
+    polygon = normalize_polygon(raw)
+    if polygon is None:
+        return None
+    try:
+        px, py = float(x), float(y)
+    except (TypeError, ValueError):
+        return None
+
+    inside = False
+    for index, (x1, y1) in enumerate(polygon):
+        x2, y2 = polygon[(index + 1) % len(polygon)]
+        if _point_on_segment(px, py, x1, y1, x2, y2):
+            return True
+        if (y1 > py) == (y2 > py):
+            continue
+        crossing_x = (x2 - x1) * (py - y1) / (y2 - y1) + x1
+        if px < crossing_x:
+            inside = not inside
+    return inside
+
+
 def polygon_area_m2(raw: Any) -> float | None:
     """Return polygon area in the mower map's metre coordinate system."""
     polygon = normalize_polygon(raw)

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta32"
+  "version": "0.4.3-beta33"
 }

--- a/tests/test_v043_beta29.py
+++ b/tests/test_v043_beta29.py
@@ -44,5 +44,6 @@ assert manifest["version"] in {
     "0.4.3-beta30",
     "0.4.3-beta31",
     "0.4.3-beta32",
+    "0.4.3-beta33",
 }
 print("beta29 map revision diagnostics tests passed")

--- a/tests/test_v043_beta32.py
+++ b/tests/test_v043_beta32.py
@@ -1,7 +1,6 @@
 """Regression guards for 0.4.3-beta32 Custom Area capture UX."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -19,6 +18,6 @@ def test_add_custom_area_captures_baseline_immediately() -> None:
     assert "if user_input is not None:" not in block
 
 
-def test_manifest_is_beta32() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta32"
+def test_beta32_release_notes_remain_available() -> None:
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta32.md").read_text(encoding="utf-8")
+    assert "0.4.3-beta32" in notes

--- a/tests/test_v043_beta33.py
+++ b/tests/test_v043_beta33.py
@@ -1,0 +1,50 @@
+"""Regression guards for 0.4.3-beta33 Custom Area occupancy."""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _load_custom_area():
+    spec = importlib.util.spec_from_file_location(
+        "navimower_custom_area_beta33_test", COMPONENT / "custom_area.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_point_in_polygon_includes_inside_and_boundary_but_not_outside() -> None:
+    custom = _load_custom_area()
+    square = [[0, 0], [4, 0], [4, 4], [0, 4]]
+    assert custom.point_in_polygon(2, 2, square) is True
+    assert custom.point_in_polygon(0, 2, square) is True
+    assert custom.point_in_polygon(4, 4, square) is True
+    assert custom.point_in_polygon(5, 2, square) is False
+
+
+def test_binary_sensor_creates_one_entity_per_saved_custom_area() -> None:
+    source = (COMPONENT / "binary_sensor.py").read_text(encoding="utf-8")
+    assert "parse_custom_areas(entry.options.get(OPT_CUSTOM_AREAS))" in source
+    assert "NavimowerCustomAreaBinarySensor" in source
+    assert 'super().__init__(coordinator, f"custom_area_{area.slug}")' in source
+    assert 'self._attr_name = area.name' in source
+
+
+def test_custom_area_occupancy_requires_fresh_mqtt_xy() -> None:
+    source = (COMPONENT / "binary_sensor.py").read_text(encoding="utf-8")
+    assert "position = self.coordinator._fresh_mqtt_position()" in source
+    assert "point_in_polygon(position[\"x\"], position[\"y\"], self.area.polygon)" in source
+    assert "return super().available and self.coordinator._fresh_mqtt_position() is not None" in source
+
+
+def test_manifest_is_beta33() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta33"


### PR DESCRIPTION
Adds the next Custom Area layer after the beta30-beta32 import/storage field test.

- Creates one binary sensor per configured Custom Area.
- Uses the fresh official MQTT local X/Y pose directly against the persistent Custom Area polygon.
- ON means the mower is inside or on the polygon boundary; OFF means a fresh pose is outside.
- Missing/stale MQTT pose makes the sensor unavailable rather than retaining a stale occupancy state.
- Occupancy is independent of Navimow zone IDs and names, so the newly remapped zones do not affect the stored Custom Area.
- Adds point-in-polygon boundary tests and release regression guards.
- No mower mutation, map write, cutting-height override or work-mode override is included.