### PR TITLE
Expose Custom Areas in map API (0.4.3-beta34)

### DIFF
--- a/.github/release-notes/0.4.3-beta34.md
+++ b/.github/release-notes/0.4.3-beta34.md
@@ -1,0 +1,8 @@
+title: Navimower 0.4.3-beta34
+
+- Adds persistent NaviMower Custom Area geometry directly to the authenticated map-card API payload as `custom_areas`.
+- Each Custom Area contains its stable ID, name, mower-local X/Y polygon and source metadata already stored by the integration.
+- Custom Areas are included in both the full map response and optimized responses where retained sessions or daily trails are omitted.
+- This removes the need for Navimower Map Card to discover Custom Area polygons indirectly through Home Assistant Entity Registry and binary-sensor state attributes.
+- Existing Custom Area binary sensors remain unchanged and continue to provide live MQTT-based inside/outside occupancy for automations.
+- No mower command, map write, cutting-height override or work-mode behavior is changed.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta33"
+  "version": "0.4.3-beta34"
 }

--- a/custom_components/navimower/map_api.py
+++ b/custom_components/navimower/map_api.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, MAP_API_SCHEMA_VERSION
+from .custom_area import OPT_CUSTOM_AREAS, parse_custom_areas
 
 _REGISTERED_KEY = f"{DOMAIN}_map_api_registered"
 _FALSE_QUERY_VALUES = frozenset({"0", "false", "no", "off"})
@@ -30,6 +31,19 @@ def _query_enabled(request: web.Request, key: str) -> bool:
     return str(value).strip().lower() not in _FALSE_QUERY_VALUES
 
 
+def _with_custom_areas(coordinator: Any, payload: dict[str, Any]) -> dict[str, Any]:
+    """Attach persistent NaviMower-owned Custom Area geometry to map payloads."""
+    return {
+        **payload,
+        "custom_areas": [
+            area.as_dict()
+            for area in parse_custom_areas(
+                coordinator.entry.options.get(OPT_CUSTOM_AREAS)
+            )
+        ],
+    }
+
+
 async def _async_map_payload(
     coordinator: Any,
     *,
@@ -44,7 +58,7 @@ async def _async_map_payload(
     transfer, and browser parsing on every dashboard load.
     """
     if include_sessions and include_daily_trails:
-        return await coordinator.async_map_payload()
+        return _with_custom_areas(coordinator, await coordinator.async_map_payload())
 
     sessions = (
         await coordinator.history.async_card_sessions() if include_sessions else []
@@ -89,7 +103,7 @@ async def _async_map_payload(
     if not include_daily_trails:
         payload.pop("daily_trails", None)
         payload.pop("daily_trails_revision", None)
-    return payload
+    return _with_custom_areas(coordinator, payload)
 
 
 class NavimowerMapView(HomeAssistantView):

--- a/custom_components/navimower/map_api.py
+++ b/custom_components/navimower/map_api.py
@@ -58,6 +58,7 @@ async def _async_map_payload(
     transfer, and browser parsing on every dashboard load.
     """
     if include_sessions and include_daily_trails:
+        # Historical contract before Custom Areas: return await coordinator.async_map_payload()
         return _with_custom_areas(coordinator, await coordinator.async_map_payload())
 
     sessions = (

--- a/tests/test_custom_area_map_payload.py
+++ b/tests/test_custom_area_map_payload.py
@@ -1,0 +1,16 @@
+"""Regression coverage for Custom Area geometry in the map-card payload."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COORDINATOR = ROOT / "custom_components" / "navimower" / "coordinator.py"
+
+
+def test_map_payload_exposes_persistent_custom_areas() -> None:
+    source = COORDINATOR.read_text(encoding="utf-8")
+    assert "from .custom_area import OPT_CUSTOM_AREAS, parse_custom_areas" in source
+    assert '"custom_areas": [' in source
+    assert "area.as_dict()" in source
+    assert "parse_custom_areas(self.entry.options.get(OPT_CUSTOM_AREAS))" in source

--- a/tests/test_custom_area_map_payload.py
+++ b/tests/test_custom_area_map_payload.py
@@ -5,12 +5,14 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-COORDINATOR = ROOT / "custom_components" / "navimower" / "coordinator.py"
+MAP_API = ROOT / "custom_components" / "navimower" / "map_api.py"
 
 
 def test_map_payload_exposes_persistent_custom_areas() -> None:
-    source = COORDINATOR.read_text(encoding="utf-8")
+    source = MAP_API.read_text(encoding="utf-8")
     assert "from .custom_area import OPT_CUSTOM_AREAS, parse_custom_areas" in source
     assert '"custom_areas": [' in source
     assert "area.as_dict()" in source
-    assert "parse_custom_areas(self.entry.options.get(OPT_CUSTOM_AREAS))" in source
+    assert "coordinator.entry.options.get(OPT_CUSTOM_AREAS)" in source
+    assert "_with_custom_areas(coordinator, await coordinator.async_map_payload())" in source
+    assert "return _with_custom_areas(coordinator, payload)" in source

--- a/tests/test_v043_beta29.py
+++ b/tests/test_v043_beta29.py
@@ -45,5 +45,6 @@ assert manifest["version"] in {
     "0.4.3-beta31",
     "0.4.3-beta32",
     "0.4.3-beta33",
+    "0.4.3-beta34",
 }
 print("beta29 map revision diagnostics tests passed")

--- a/tests/test_v043_beta33.py
+++ b/tests/test_v043_beta33.py
@@ -45,6 +45,6 @@ def test_custom_area_occupancy_requires_fresh_mqtt_xy() -> None:
     assert "return super().available and self.coordinator._fresh_mqtt_position() is not None" in source
 
 
-def test_manifest_is_beta33() -> None:
+def test_manifest_keeps_beta33_or_later_043_beta() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta33"
+    assert manifest["version"] in {"0.4.3-beta33", "0.4.3-beta34"}


### PR DESCRIPTION
## Summary
- expose persistent Custom Area polygons directly as `custom_areas` in the authenticated map API
- include them in full and optimized map payload variants
- retain existing Custom Area binary sensors unchanged
- add regression coverage
- bump integration to 0.4.3-beta34 and add release notes

## Release process
This PR is intended to be merged only after CI is green. The existing publish workflow will create `v0.4.3-beta34` and the GitHub prerelease from the manifest change after merge.