### PR TITLE
Prepare Navimower 0.4.3-beta37

### DIFF
--- a/.github/release-notes/0.4.3-beta37.md
+++ b/.github/release-notes/0.4.3-beta37.md
@@ -1,0 +1,9 @@
+title: Navimower 0.4.3-beta37
+
+## Schedule order UX
+
+- Moves Automatic/Custom order selection into the main Navimower Schedule configuration screen.
+- Removes the raw custom queue ID text field from the user-facing options flow.
+- When Custom order is selected for the first time, seeds its queue from the same least-recently-completed ordering used by Automatic order.
+- Keeps an existing Custom queue persistent when switching modes; newly selected zones can be arranged later in Navimower Map Card.
+- Adds the missing Home Assistant strings/translations for the order selector.

--- a/.github/scripts/beta37_builder.py
+++ b/.github/scripts/beta37_builder.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path.cwd()
+COMP = ROOT / "custom_components" / "navimower"
+
+# Identity
+manifest_path = COMP / "manifest.json"
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+manifest["version"] = "0.4.3-beta37"
+manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+# Integrate order mode into the main Schedule screen and remove the raw queue editor.
+flow_path = COMP / "config_flow.py"
+flow = flow_path.read_text(encoding="utf-8")
+flow = flow.replace('                "navimower_schedule_order",\n', '')
+flow = flow.replace(
+    '        self._custom_area_candidate: list[list[float]] | None = None\n',
+    '        self._custom_area_candidate: list[list[float]] | None = None\n'
+    '        self._pending_schedule_order_mode: str | None = None\n',
+)
+pattern = re.compile(
+    r'\n\n    async def async_step_navimower_schedule_order\(.*?\n    async def async_step_custom_areas',
+    re.S,
+)
+replacement = r'''
+
+    def _schedule_order_selector(self, mode: str):
+        return SelectSelector(
+            SelectSelectorConfig(
+                options=[
+                    {"value": SCHEDULE_ORDER_AUTOMATIC, "label": "Automatic order"},
+                    {"value": SCHEDULE_ORDER_CUSTOM, "label": "Custom order"},
+                ],
+                mode=SelectSelectorMode.LIST,
+            )
+        )
+
+    def _seed_custom_queue(self, zone_ids: Any) -> list[str]:
+        selected = {str(value) for value in (zone_ids or [])}
+        coordinator = self._coordinator()
+        data = getattr(coordinator, "data", None) or {}
+        rows = []
+        for row in data.get("zone_states") or []:
+            if not isinstance(row, dict):
+                continue
+            zone_id = str(row.get("id") or "")
+            completed = row.get("last_completed_at")
+            if zone_id in selected and completed:
+                rows.append((str(completed), zone_id))
+        rows.sort(key=lambda item: (item[0], item[1]))
+        return [zone_id for _, zone_id in rows]
+
+    def _apply_schedule_order(self, result: ConfigFlowResult, mode: str) -> ConfigFlowResult:
+        if result.get("type") == "form" and result.get("step_id") == "navimower_schedule":
+            schema = dict(result["data_schema"].schema)
+            schema[vol.Required(OPT_SCHEDULE_ORDER_MODE, default=mode)] = self._schedule_order_selector(mode)
+            result["data_schema"] = vol.Schema(schema)
+            return result
+        if result.get("type") == "create_entry":
+            data = dict(result.get("data") or {})
+            data[OPT_SCHEDULE_ORDER_MODE] = mode
+            if mode == SCHEDULE_ORDER_CUSTOM:
+                selected = data.get("navimower_schedule_zone_ids", self._options().get("navimower_schedule_zone_ids", []))
+                existing = list(self._options().get(OPT_SCHEDULE_CUSTOM_QUEUE, []) or [])
+                selected_set = {str(value) for value in (selected or [])}
+                queue = [str(value) for value in existing if str(value) in selected_set]
+                if not queue:
+                    queue = self._seed_custom_queue(selected)
+                data[OPT_SCHEDULE_CUSTOM_QUEUE] = queue
+            result["data"] = data
+        return result
+
+    async def async_step_navimower_schedule(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        options = self._options()
+        mode = str(options.get(OPT_SCHEDULE_ORDER_MODE, SCHEDULE_ORDER_AUTOMATIC))
+        payload = None if user_input is None else dict(user_input)
+        if payload is not None:
+            mode = str(payload.pop(OPT_SCHEDULE_ORDER_MODE, mode) or SCHEDULE_ORDER_AUTOMATIC)
+            if mode not in {SCHEDULE_ORDER_AUTOMATIC, SCHEDULE_ORDER_CUSTOM}:
+                mode = SCHEDULE_ORDER_AUTOMATIC
+            self._pending_schedule_order_mode = mode
+        result = await super().async_step_navimower_schedule(payload)
+        return self._apply_schedule_order(result, mode)
+
+    async def async_step_navimower_schedule_window(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        result = await super().async_step_navimower_schedule_window(user_input)
+        mode = self._pending_schedule_order_mode or str(
+            self._options().get(OPT_SCHEDULE_ORDER_MODE, SCHEDULE_ORDER_AUTOMATIC)
+        )
+        return self._apply_schedule_order(result, mode)
+
+    async def async_step_custom_areas'''
+flow, count = pattern.subn(replacement, flow, count=1)
+if count != 1:
+    raise SystemExit(f"Could not replace beta36 schedule-order step: {count}")
+flow_path.write_text(flow, encoding="utf-8")
+
+# Home Assistant translations: field labels must live in both files.
+for rel in ("strings.json", "translations/en.json"):
+    path = COMP / rel
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    step = doc["options"]["step"]["navimower_schedule"]
+    step["data"]["navimower_schedule_order_mode"] = "Zone order"
+    step.setdefault("data_description", {})["navimower_schedule_order_mode"] = (
+        "Automatic order selects the least recently completed selected zone first. "
+        "Custom order keeps a persistent queue that can later be rearranged in Navimower Map Card."
+    )
+    path.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+# Historical version guards.
+for path in (ROOT / "tests").glob("test_v043_beta*.py"):
+    text = path.read_text(encoding="utf-8")
+    if "0.4.3-beta36" in text and "0.4.3-beta37" not in text:
+        if path.name == "test_v043_beta36.py":
+            text = text.replace("assert '0.4.3-beta36' in Path('custom_components/navimower/manifest.json').read_text()", "assert any(v in Path('custom_components/navimower/manifest.json').read_text() for v in ('0.4.3-beta36', '0.4.3-beta37'))")
+            text = text.replace("assert 'async_step_navimower_schedule_order' in s", "assert 'async_step_navimower_schedule' in s")
+        else:
+            text = text.replace('"0.4.3-beta36"}', '"0.4.3-beta36", "0.4.3-beta37"}')
+            text = text.replace('"0.4.3-beta36",\n}', '"0.4.3-beta36", "0.4.3-beta37",\n}')
+            text = text.replace("or '\"version\": \"0.4.3-beta36\"' in manifest)", "or '\"version\": \"0.4.3-beta36\"' in manifest or '\"version\": \"0.4.3-beta37\"' in manifest)")
+        path.write_text(text, encoding="utf-8")
+
+(ROOT / "tests" / "test_v043_beta37.py").write_text('''from pathlib import Path\nimport json\n\nROOT = Path(__file__).resolve().parents[1]\nCOMP = ROOT / "custom_components" / "navimower"\n\ndef test_beta37_identity_and_release_notes():\n    manifest = json.loads((COMP / "manifest.json").read_text())\n    assert manifest["version"] == "0.4.3-beta37"\n    notes = (ROOT / ".github/release-notes/0.4.3-beta37.md").read_text()\n    assert notes.startswith("title: Navimower 0.4.3-beta37")\n\ndef test_order_mode_is_on_main_schedule_form_without_raw_queue_field():\n    source = (COMP / "config_flow.py").read_text()\n    init = source[source.index("async def async_step_init"):source.index("def _schedule_order_selector")]\n    assert '"navimower_schedule_order"' not in init\n    assert "async_step_navimower_schedule" in source\n    assert "OPT_SCHEDULE_ORDER_MODE" in source\n    assert "vol.Optional(OPT_SCHEDULE_CUSTOM_QUEUE" not in source\n    assert "_seed_custom_queue" in source\n\ndef test_schedule_order_translation_contract():\n    for rel in ("strings.json", "translations/en.json"):\n        doc = json.loads((COMP / rel).read_text())\n        step = doc["options"]["step"]["navimower_schedule"]\n        assert step["data"]["navimower_schedule_order_mode"] == "Zone order"\n''', encoding="utf-8")
+
+(ROOT / ".github" / "release-notes" / "0.4.3-beta37.md").write_text('''title: Navimower 0.4.3-beta37\n\n## Schedule order UX\n\n- Moves Automatic/Custom order selection into the main Navimower Schedule configuration screen.\n- Removes the raw custom queue ID text field from the user-facing options flow.\n- When Custom order is selected for the first time, seeds its queue from the same least-recently-completed ordering used by Automatic order.\n- Keeps an existing Custom queue persistent when switching modes; newly selected zones can be arranged later in Navimower Map Card.\n- Adds the missing Home Assistant strings/translations for the order selector.\n''', encoding="utf-8")

--- a/.github/workflows/remote-beta-build.yml
+++ b/.github/workflows/remote-beta-build.yml
@@ -11,26 +11,21 @@ permissions:
 jobs:
   build:
     if: >-
-      github.event.issue.title == 'RUN NAVIMOWER 0.4.3-BETA19 BUILD' &&
+      github.event.issue.title == 'RUN NAVIMOWER 0.4.3-BETA37 BUILD' &&
       github.event.issue.user.login == github.repository_owner
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
-      BUILD_BRANCH: release/0.4.3-beta19
+      BUILD_BRANCH: release/0.4.3-beta37
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ env.BUILD_BRANCH }}
           fetch-depth: 0
-
       - uses: actions/setup-python@v5
         with:
           python-version: "3.14"
-
-      - name: Install test dependencies
-        run: python -m pip install --upgrade pytest voluptuous cryptography pyyaml
-
-      - name: Build and validate beta
+      - name: Build and validate beta37
         id: build
         continue-on-error: true
         shell: bash
@@ -38,95 +33,39 @@ jobs:
           set -o pipefail
           exec > >(tee /tmp/remote-beta-build.log) 2>&1
           set -euo pipefail
-          git checkout -B "${BUILD_BRANCH}" origin/main
-
-          python .github/scripts/remote_beta_builder.py
+          python .github/scripts/beta37_builder.py
+          python -m pip install --upgrade pytest voluptuous cryptography pyyaml
           python -m pytest -q
           python -m compileall -q custom_components/navimower
           git diff --check
-
           python - <<'PY'
+          import json
           from pathlib import Path
-          import subprocess
-
-          expected = {
-              ".github/release-notes/0.4.3-beta19.md",
-              "CHANGELOG.md",
-              "custom_components/navimower/manifest.json",
-              "custom_components/navimower/navimower_schedule.py",
-              "tests/test_v043_beta18.py",
-              "tests/test_v043_beta19.py",
-          }
-          committed = set(
-              subprocess.check_output(
-                  ["git", "diff", "--name-only", "origin/main...HEAD"], text=True
-              ).splitlines()
-          )
-          unstaged = set(
-              subprocess.check_output(["git", "diff", "--name-only"], text=True).splitlines()
-          )
-          untracked = set(
-              subprocess.check_output(
-                  ["git", "ls-files", "--others", "--exclude-standard"], text=True
-              ).splitlines()
-          )
-          changed = committed | unstaged | untracked
-          if changed != expected:
-              raise SystemExit(f"Unexpected beta19 diff scope: {sorted(changed)}")
-
-          schedule = Path("custom_components/navimower/navimower_schedule.py").read_text(encoding="utf-8")
-          assert "_MOW_CONFIRM_SECONDS = 120" in schedule
-          assert "_reconcile_unconfirmed_mow_start" in schedule
-          assert '"mow_start_not_confirmed"' in schedule
-          assert "automatic reset retry was refused" in schedule
-          assert "night_mow" not in schedule
-          resolver = schedule[
-              schedule.index("    def _window_state(self, now: datetime)"):
-              schedule.index("    def _zone(self, zone_id", schedule.index("    def _window_state(self, now: datetime)"))
-          ]
-          assert 'return True, "continuous"' in resolver
-          enforce = schedule[
-              schedule.index("    async def _enforce_closed_window"):
-              schedule.index("    async def _continue_interrupted_task")
-          ]
-          assert 'await self._async_send_dock("navimower_schedule_window_closed")' in enforce
-          reconcile = schedule[
-              schedule.index("    async def _reconcile_unconfirmed_mow_start"):
-              schedule.index("    def _retry_ready")
-          ]
-          assert "reset=True" not in reconcile
+          c=Path('custom_components/navimower')
+          assert json.loads((c/'manifest.json').read_text())['version']=='0.4.3-beta37'
+          f=(c/'config_flow.py').read_text()
+          assert 'vol.Optional(OPT_SCHEDULE_CUSTOM_QUEUE' not in f
+          assert '_seed_custom_queue' in f
+          for p in (c/'strings.json', c/'translations/en.json'):
+              d=json.loads(p.read_text())
+              assert d['options']['step']['navimower_schedule']['data']['navimower_schedule_order_mode']=='Zone order'
           PY
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .github/release-notes/0.4.3-beta19.md \
-                  CHANGELOG.md \
-                  custom_components/navimower/manifest.json \
-                  custom_components/navimower/navimower_schedule.py \
-                  tests/test_v043_beta18.py \
-                  tests/test_v043_beta19.py
-          git commit -m "Prepare Navimower 0.4.3-beta19 schedule hardening"
+          git add custom_components/navimower/config_flow.py custom_components/navimower/manifest.json custom_components/navimower/strings.json custom_components/navimower/translations/en.json tests .github/release-notes/0.4.3-beta37.md
+          git commit -m "Prepare Navimower 0.4.3-beta37 schedule order UX"
           git push origin "${BUILD_BRANCH}"
           echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       - name: Comment success
         if: steps.build.outcome == 'success'
-        shell: bash
         run: |
-          gh issue comment "${{ github.event.issue.number }}" --body "0.4.3-beta19 remote build succeeded. Full tests, compileall, diff-check, exact diff-scope and focused schedule/restart safety checks passed; branch \`${BUILD_BRANCH}\` was pushed at \`${{ steps.build.outputs.commit }}\`."
+          gh issue comment "${{ github.event.issue.number }}" --body "0.4.3-beta37 build succeeded; tests, compileall, translations and focused UX checks passed at \`${{ steps.build.outputs.commit }}\`."
           gh issue close "${{ github.event.issue.number }}" --reason completed
-
       - name: Comment failure
         if: steps.build.outcome != 'success'
         shell: bash
         run: |
           tail -n 260 /tmp/remote-beta-build.log > /tmp/build-tail.txt || true
-          {
-            echo '0.4.3-beta19 remote build failed before publishing the completed release branch.'
-            echo
-            echo '```text'
-            cat /tmp/build-tail.txt
-            echo '```'
-          } > /tmp/failure-comment.md
+          { echo '0.4.3-beta37 build failed.'; echo; echo '```text'; cat /tmp/build-tail.txt; echo '```'; } > /tmp/failure-comment.md
           gh issue comment "${{ github.event.issue.number }}" --body-file /tmp/failure-comment.md
           exit 1

--- a/.github/workflows/remote-beta-build.yml
+++ b/.github/workflows/remote-beta-build.yml
@@ -22,10 +22,15 @@ jobs:
         with:
           ref: ${{ env.BUILD_BRANCH }}
           fetch-depth: 0
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.14"
-      - name: Build and validate beta37
+
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pytest voluptuous cryptography pyyaml
+
+      - name: Build and validate beta
         id: build
         continue-on-error: true
         shell: bash
@@ -34,38 +39,43 @@ jobs:
           exec > >(tee /tmp/remote-beta-build.log) 2>&1
           set -euo pipefail
           python .github/scripts/beta37_builder.py
-          python -m pip install --upgrade pytest voluptuous cryptography pyyaml
           python -m pytest -q
           python -m compileall -q custom_components/navimower
           git diff --check
-          python - <<'PY'
-          import json
-          from pathlib import Path
-          c=Path('custom_components/navimower')
-          assert json.loads((c/'manifest.json').read_text())['version']=='0.4.3-beta37'
-          f=(c/'config_flow.py').read_text()
-          assert 'vol.Optional(OPT_SCHEDULE_CUSTOM_QUEUE' not in f
-          assert '_seed_custom_queue' in f
-          for p in (c/'strings.json', c/'translations/en.json'):
-              d=json.loads(p.read_text())
-              assert d['options']['step']['navimower_schedule']['data']['navimower_schedule_order_mode']=='Zone order'
-          PY
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add custom_components/navimower/config_flow.py custom_components/navimower/manifest.json custom_components/navimower/strings.json custom_components/navimower/translations/en.json tests .github/release-notes/0.4.3-beta37.md
+          git add custom_components/navimower/config_flow.py \
+                  custom_components/navimower/strings.json \
+                  custom_components/navimower/translations/en.json \
+                  custom_components/navimower/manifest.json \
+                  .github/release-notes/0.4.3-beta37.md \
+                  tests/test_v043_beta29.py \
+                  tests/test_v043_beta33.py \
+                  tests/test_v043_beta35.py \
+                  tests/test_v043_beta36.py \
+                  tests/test_v043_beta37.py
           git commit -m "Prepare Navimower 0.4.3-beta37 schedule order UX"
-          git push origin "${BUILD_BRANCH}"
+          git push origin HEAD:${BUILD_BRANCH}
           echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Comment success
         if: steps.build.outcome == 'success'
+        shell: bash
         run: |
-          gh issue comment "${{ github.event.issue.number }}" --body "0.4.3-beta37 build succeeded; tests, compileall, translations and focused UX checks passed at \`${{ steps.build.outputs.commit }}\`."
+          gh issue comment "${{ github.event.issue.number }}" --body "0.4.3-beta37 remote build succeeded. Full tests, compileall and diff-check passed; branch \`${BUILD_BRANCH}\` was pushed at \`${{ steps.build.outputs.commit }}\`."
           gh issue close "${{ github.event.issue.number }}" --reason completed
+
       - name: Comment failure
         if: steps.build.outcome != 'success'
         shell: bash
         run: |
           tail -n 260 /tmp/remote-beta-build.log > /tmp/build-tail.txt || true
-          { echo '0.4.3-beta37 build failed.'; echo; echo '```text'; cat /tmp/build-tail.txt; echo '```'; } > /tmp/failure-comment.md
+          {
+            echo '0.4.3-beta37 remote build failed before publishing the completed release branch.'
+            echo
+            echo '```text'
+            cat /tmp/build-tail.txt
+            echo '```'
+          } > /tmp/failure-comment.md
           gh issue comment "${{ github.event.issue.number }}" --body-file /tmp/failure-comment.md
           exit 1

--- a/custom_components/navimower/config_flow.py
+++ b/custom_components/navimower/config_flow.py
@@ -46,6 +46,7 @@ class NavimowOptionsFlow(_BaseNavimowOptionsFlow):
         self._custom_area_baseline: list[list[list[float]]] | None = None
         self._custom_area_baseline_revision: str | None = None
         self._custom_area_candidate: list[list[float]] | None = None
+        self._pending_schedule_order_mode: str | None = None
 
     def _custom_areas(self):
         return parse_custom_areas(self.config_entry.options.get(OPT_CUSTOM_AREAS))
@@ -89,7 +90,6 @@ class NavimowOptionsFlow(_BaseNavimowOptionsFlow):
             menu_options=[
                 "general",
                 "navimower_schedule",
-                "navimower_schedule_order",
                 "gates",
                 "custom_areas",
                 "channels",
@@ -97,34 +97,70 @@ class NavimowOptionsFlow(_BaseNavimowOptionsFlow):
         )
 
 
-    async def async_step_navimower_schedule_order(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        choices = self._schedule_zone_choices()
-        options = self._options()
-        if user_input is not None:
-            order_mode = str(user_input.get(OPT_SCHEDULE_ORDER_MODE) or SCHEDULE_ORDER_AUTOMATIC)
-            raw = str(user_input.get(OPT_SCHEDULE_CUSTOM_QUEUE) or "")
-            queue = []
-            invalid = []
-            for item in raw.split(","):
-                item = item.strip()
-                if not item:
-                    continue
-                if item not in choices:
-                    invalid.append(item)
-                else:
-                    queue.append(item)
-            if order_mode == SCHEDULE_ORDER_CUSTOM and (invalid or not queue):
-                return self.async_show_form(step_id="navimower_schedule_order", data_schema=self._schedule_order_schema(order_mode, raw), errors={"base": "schedule_custom_queue_invalid"})
-            return self._save(**{OPT_SCHEDULE_ORDER_MODE: order_mode, OPT_SCHEDULE_CUSTOM_QUEUE: queue})
-        mode = str(options.get(OPT_SCHEDULE_ORDER_MODE, SCHEDULE_ORDER_AUTOMATIC))
-        queue = ", ".join(str(v) for v in options.get(OPT_SCHEDULE_CUSTOM_QUEUE, []) or [])
-        return self.async_show_form(step_id="navimower_schedule_order", data_schema=self._schedule_order_schema(mode, queue), description_placeholders={"eligible_zones": ", ".join(f"{z}: {n}" for z,n in choices.items())})
+    def _schedule_order_selector(self, mode: str):
+        return SelectSelector(
+            SelectSelectorConfig(
+                options=[
+                    {"value": SCHEDULE_ORDER_AUTOMATIC, "label": "Automatic order"},
+                    {"value": SCHEDULE_ORDER_CUSTOM, "label": "Custom order"},
+                ],
+                mode=SelectSelectorMode.LIST,
+            )
+        )
 
-    def _schedule_order_schema(self, mode: str, queue: str) -> vol.Schema:
-        return vol.Schema({
-            vol.Required(OPT_SCHEDULE_ORDER_MODE, default=mode): SelectSelector(SelectSelectorConfig(options=[{"value": SCHEDULE_ORDER_AUTOMATIC, "label": "Automatic order"}, {"value": SCHEDULE_ORDER_CUSTOM, "label": "Custom order"}], mode=SelectSelectorMode.LIST)),
-            vol.Optional(OPT_SCHEDULE_CUSTOM_QUEUE, default=queue): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
-        })
+    def _seed_custom_queue(self, zone_ids: Any) -> list[str]:
+        selected = {str(value) for value in (zone_ids or [])}
+        coordinator = self._coordinator()
+        data = getattr(coordinator, "data", None) or {}
+        rows = []
+        for row in data.get("zone_states") or []:
+            if not isinstance(row, dict):
+                continue
+            zone_id = str(row.get("id") or "")
+            completed = row.get("last_completed_at")
+            if zone_id in selected and completed:
+                rows.append((str(completed), zone_id))
+        rows.sort(key=lambda item: (item[0], item[1]))
+        return [zone_id for _, zone_id in rows]
+
+    def _apply_schedule_order(self, result: ConfigFlowResult, mode: str) -> ConfigFlowResult:
+        if result.get("type") == "form" and result.get("step_id") == "navimower_schedule":
+            schema = dict(result["data_schema"].schema)
+            schema[vol.Required(OPT_SCHEDULE_ORDER_MODE, default=mode)] = self._schedule_order_selector(mode)
+            result["data_schema"] = vol.Schema(schema)
+            return result
+        if result.get("type") == "create_entry":
+            data = dict(result.get("data") or {})
+            data[OPT_SCHEDULE_ORDER_MODE] = mode
+            if mode == SCHEDULE_ORDER_CUSTOM:
+                selected = data.get("navimower_schedule_zone_ids", self._options().get("navimower_schedule_zone_ids", []))
+                existing = list(self._options().get(OPT_SCHEDULE_CUSTOM_QUEUE, []) or [])
+                selected_set = {str(value) for value in (selected or [])}
+                queue = [str(value) for value in existing if str(value) in selected_set]
+                if not queue:
+                    queue = self._seed_custom_queue(selected)
+                data[OPT_SCHEDULE_CUSTOM_QUEUE] = queue
+            result["data"] = data
+        return result
+
+    async def async_step_navimower_schedule(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        options = self._options()
+        mode = str(options.get(OPT_SCHEDULE_ORDER_MODE, SCHEDULE_ORDER_AUTOMATIC))
+        payload = None if user_input is None else dict(user_input)
+        if payload is not None:
+            mode = str(payload.pop(OPT_SCHEDULE_ORDER_MODE, mode) or SCHEDULE_ORDER_AUTOMATIC)
+            if mode not in {SCHEDULE_ORDER_AUTOMATIC, SCHEDULE_ORDER_CUSTOM}:
+                mode = SCHEDULE_ORDER_AUTOMATIC
+            self._pending_schedule_order_mode = mode
+        result = await super().async_step_navimower_schedule(payload)
+        return self._apply_schedule_order(result, mode)
+
+    async def async_step_navimower_schedule_window(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        result = await super().async_step_navimower_schedule_window(user_input)
+        mode = self._pending_schedule_order_mode or str(
+            self._options().get(OPT_SCHEDULE_ORDER_MODE, SCHEDULE_ORDER_AUTOMATIC)
+        )
+        return self._apply_schedule_order(result, mode)
 
     async def async_step_custom_areas(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta36"
+  "version": "0.4.3-beta37"
 }

--- a/custom_components/navimower/strings.json
+++ b/custom_components/navimower/strings.json
@@ -185,11 +185,13 @@
         "description": "Choose which proven zones the integration may mow automatically and when it may work. Only zones with at least one confirmed successful completion can be selected. A new or difficult zone must first be fully completed manually once; completing it does not select it automatically.\n\n{unavailable_note}",
         "data": {
           "navimower_schedule_zone_ids": "Automatic mowing zones",
-          "navimower_schedule_mode": "Allowed mowing time"
+          "navimower_schedule_mode": "Allowed mowing time",
+          "navimower_schedule_order_mode": "Zone order"
         },
         "data_description": {
           "navimower_schedule_zone_ids": "The scheduler only dispatches zones selected here. New zones are never added automatically.",
-          "navimower_schedule_mode": "Time window asks for daily start and end times on the next screen. 24 hours keeps the managed scheduler available continuously and starts a new round after every selected zone has completed."
+          "navimower_schedule_mode": "Time window asks for daily start and end times on the next screen. 24 hours keeps the managed scheduler available continuously and starts a new round after every selected zone has completed.",
+          "navimower_schedule_order_mode": "Automatic order selects the least recently completed selected zone first. Custom order keeps a persistent queue that can later be rearranged in Navimower Map Card."
         }
       },
       "navimower_schedule_window": {

--- a/custom_components/navimower/translations/en.json
+++ b/custom_components/navimower/translations/en.json
@@ -185,11 +185,13 @@
         "description": "Choose which proven zones the integration may mow automatically and when it may work. Only zones with at least one confirmed successful completion can be selected. A new or difficult zone must first be fully completed manually once; completing it does not select it automatically.\n\n{unavailable_note}",
         "data": {
           "navimower_schedule_zone_ids": "Automatic mowing zones",
-          "navimower_schedule_mode": "Allowed mowing time"
+          "navimower_schedule_mode": "Allowed mowing time",
+          "navimower_schedule_order_mode": "Zone order"
         },
         "data_description": {
           "navimower_schedule_zone_ids": "The scheduler only dispatches zones selected here. New zones are never added automatically.",
-          "navimower_schedule_mode": "Time window asks for daily start and end times on the next screen. 24 hours keeps the managed scheduler available continuously and starts a new round after every selected zone has completed."
+          "navimower_schedule_mode": "Time window asks for daily start and end times on the next screen. 24 hours keeps the managed scheduler available continuously and starts a new round after every selected zone has completed.",
+          "navimower_schedule_order_mode": "Automatic order selects the least recently completed selected zone first. Custom order keeps a persistent queue that can later be rearranged in Navimower Map Card."
         }
       },
       "navimower_schedule_window": {

--- a/tests/test_v043_beta29.py
+++ b/tests/test_v043_beta29.py
@@ -18,6 +18,6 @@ assert '"map_version": map_version' in diagnostics
 
 assert manifest["version"] in {
     "0.4.3-beta29", "0.4.3-beta30", "0.4.3-beta31", "0.4.3-beta32",
-    "0.4.3-beta33", "0.4.3-beta34", "0.4.3-beta35", "0.4.3-beta36",
+    "0.4.3-beta33", "0.4.3-beta34", "0.4.3-beta35", "0.4.3-beta36", "0.4.3-beta37",
 }
 print("beta29 map revision diagnostics tests passed")

--- a/tests/test_v043_beta33.py
+++ b/tests/test_v043_beta33.py
@@ -45,4 +45,4 @@ def test_custom_area_occupancy_requires_fresh_mqtt_xy() -> None:
 
 def test_manifest_keeps_beta33_or_later_043_beta() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] in {"0.4.3-beta33", "0.4.3-beta34", "0.4.3-beta35", "0.4.3-beta36"}
+    assert manifest["version"] in {"0.4.3-beta33", "0.4.3-beta34", "0.4.3-beta35", "0.4.3-beta36", "0.4.3-beta37"}

--- a/tests/test_v043_beta35.py
+++ b/tests/test_v043_beta35.py
@@ -7,7 +7,7 @@ def test_beta35_schedule_status_contract() -> None:
     sensor = (root / "custom_components/navimower/sensor.py").read_text()
     manifest = (root / "custom_components/navimower/manifest.json").read_text()
 
-    assert ('"version": "0.4.3-beta35"' in manifest or '"version": "0.4.3-beta36"' in manifest)
+    assert ('"version": "0.4.3-beta35"' in manifest or '"version": "0.4.3-beta36"' in manifest or '"version": "0.4.3-beta37"' in manifest)
     assert '"queue": queue' in helper
     assert '"completed_zones": completed' in helper
     assert '"active_zone": active' in helper

--- a/tests/test_v043_beta36.py
+++ b/tests/test_v043_beta36.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 def test_beta36_version_and_constants():
-    assert '0.4.3-beta36' in Path('custom_components/navimower/manifest.json').read_text()
+    assert any(v in Path('custom_components/navimower/manifest.json').read_text() for v in ('0.4.3-beta36', '0.4.3-beta37'))
     c=Path('custom_components/navimower/const.py').read_text()
     assert 'OPT_SCHEDULE_CUSTOM_QUEUE' in c and 'SCHEDULE_ORDER_CUSTOM' in c
 
@@ -18,5 +18,5 @@ def test_status_is_slot_aware():
 
 def test_options_expose_order_mode():
     s=Path('custom_components/navimower/config_flow.py').read_text()
-    assert 'async_step_navimower_schedule_order' in s
+    assert 'async_step_navimower_schedule' in s
     assert 'Automatic order' in s and 'Custom order' in s

--- a/tests/test_v043_beta37.py
+++ b/tests/test_v043_beta37.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import json
+
+ROOT = Path(__file__).resolve().parents[1]
+COMP = ROOT / "custom_components" / "navimower"
+
+def test_beta37_identity_and_release_notes():
+    manifest = json.loads((COMP / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.3-beta37"
+    notes = (ROOT / ".github/release-notes/0.4.3-beta37.md").read_text()
+    assert notes.startswith("title: Navimower 0.4.3-beta37")
+
+def test_order_mode_is_on_main_schedule_form_without_raw_queue_field():
+    source = (COMP / "config_flow.py").read_text()
+    init = source[source.index("async def async_step_init"):source.index("def _schedule_order_selector")]
+    assert '"navimower_schedule_order"' not in init
+    assert "async_step_navimower_schedule" in source
+    assert "OPT_SCHEDULE_ORDER_MODE" in source
+    assert "vol.Optional(OPT_SCHEDULE_CUSTOM_QUEUE" not in source
+    assert "_seed_custom_queue" in source
+
+def test_schedule_order_translation_contract():
+    for rel in ("strings.json", "translations/en.json"):
+        doc = json.loads((COMP / rel).read_text())
+        step = doc["options"]["step"]["navimower_schedule"]
+        assert step["data"]["navimower_schedule_order_mode"] == "Zone order"


### PR DESCRIPTION
Schedule order UX follow-up:
- move Automatic/Custom order selection into the main Navimower Schedule options screen
- remove the raw custom queue ID text field from the user-facing flow
- seed a new Custom queue from oldest/least-recently-completed order
- add missing strings/translations
- keep beta37 regression coverage

Remote beta build #166 passed full pytest, compileall and diff-check before this PR was opened.