### PR TITLE
Prepare Navimower 0.4.3-beta38

### DIFF
--- a/.github/release-notes/0.4.3-beta38.md
+++ b/.github/release-notes/0.4.3-beta38.md
@@ -1,0 +1,6 @@
+title: Navimower 0.4.3-beta38
+
+## Map Card custom queue API
+- Adds `navimower.set_schedule_queue` for persisting Custom order without enabling or starting the scheduler.
+- Validates every queue item against the selected, previously completed schedule zones; duplicate zones are supported.
+- Exposes order mode and custom queue in Schedule Status attributes for dashboard editors.

--- a/.github/scripts/beta38_builder.py
+++ b/.github/scripts/beta38_builder.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import json
+
+root=Path.cwd(); comp=root/'custom_components/navimower'
+# manifest
+p=comp/'manifest.json'; d=json.loads(p.read_text()); d['version']='0.4.3-beta38'; p.write_text(json.dumps(d,indent=2)+'\n')
+# controller public setter + richer attributes
+p=comp/'navimower_schedule.py'; s=p.read_text()
+needle='    def _update_options(self, **updates: Any) -> None:\n'
+insert='''    async def async_set_custom_queue(self, zone_ids: list[int]) -> None:\n        """Persist a user-defined custom mowing queue without starting mowing."""\n        queue = self._normalize_queue(zone_ids)\n        selected = set(self._selected_zone_ids)\n        if not queue:\n            raise ValueError("Custom mowing queue may not be empty")\n        unknown = [zone_id for zone_id in queue if zone_id not in selected]\n        if unknown:\n            raise ValueError(f"Queue contains zones outside the selected schedule allowlist: {unknown}")\n        eligible = {int(row["id"]) for row in self._eligible_zones() if row.get("id") is not None}\n        unproven = [zone_id for zone_id in queue if zone_id not in eligible]\n        if unproven:\n            raise ValueError(f"Queue contains zones without a confirmed completed mowing: {unproven}")\n        self._custom_queue = queue\n        self._order_mode = SCHEDULE_ORDER_CUSTOM\n        self._runtime["completed_queue_slots"] = []\n        self._runtime["active_queue_slot"] = None\n        self._update_options(**{OPT_SCHEDULE_CUSTOM_QUEUE: list(queue), OPT_SCHEDULE_ORDER_MODE: SCHEDULE_ORDER_CUSTOM})\n        await self._save()\n        if self._enabled:\n            self._queue_evaluation()\n\n'''
+assert needle in s; s=s.replace(needle,insert+needle)
+s=s.replace('                "mode",\n                "start",', '                "mode",\n                "order_mode",\n                "custom_queue",\n                "start",')
+p.write_text(s)
+# services.py
+p=comp/'services.py'; s=p.read_text()
+s=s.replace('SERVICE_RESUME = "resume"\n','SERVICE_RESUME = "resume"\nSERVICE_SET_SCHEDULE_QUEUE = "set_schedule_queue"\n')
+s=s.replace('RESUME_SCHEMA = vol.Schema(', 'SET_SCHEDULE_QUEUE_SCHEMA = vol.Schema({vol.Optional("device_id"): cv.string, vol.Required("zones"): vol.All(cv.ensure_list, [vol.Coerce(int)])})\n\nRESUME_SCHEMA = vol.Schema(')
+needle='    async def _resume(call: ServiceCall) -> None:\n'
+insert='''    async def _set_schedule_queue(call: ServiceCall) -> None:\n        coordinator = _resolve_coordinator(call)\n        controller = getattr(coordinator, "navimower_schedule", None)\n        if controller is None:\n            raise ServiceValidationError("Navimower Schedule controller is not available")\n        try:\n            await controller.async_set_custom_queue([int(v) for v in call.data.get("zones") or []])\n        except ValueError as err:\n            raise ServiceValidationError(str(err)) from err\n        except Exception as err:\n            raise HomeAssistantError(f"Navimower set_schedule_queue failed: {err}") from err\n\n'''
+assert needle in s; s=s.replace(needle,insert+needle)
+needle='    if not hass.services.has_service(DOMAIN, SERVICE_RESUME):\n'
+insert='''    if not hass.services.has_service(DOMAIN, SERVICE_SET_SCHEDULE_QUEUE):\n        hass.services.async_register(DOMAIN, SERVICE_SET_SCHEDULE_QUEUE, _set_schedule_queue, schema=SET_SCHEDULE_QUEUE_SCHEMA)\n'''
+s=s.replace(needle,insert+needle); p.write_text(s)
+# yaml
+p=comp/'services.yaml'; s=p.read_text(); s += '''\nset_schedule_queue:\n  name: Set Navimower custom schedule queue\n  description: Persist the ordered Custom queue without enabling or starting Navimower Schedule. Zones may repeat.\n  fields:\n    device_id:\n      name: Mower\n      required: false\n      selector:\n        device:\n          integration: navimower\n    zones:\n      name: Ordered zones\n      description: Selected, previously completed schedule zone IDs in mowing order. IDs may repeat.\n      required: true\n      selector:\n        object:\n'''; p.write_text(s)
+# test + notes
+(root/'tests/test_v043_beta38.py').write_text('''from pathlib import Path\nimport json\nROOT=Path(__file__).resolve().parents[1]; C=ROOT/'custom_components/navimower'\ndef test_identity(): assert json.loads((C/'manifest.json').read_text())['version']=='0.4.3-beta38'\ndef test_queue_api():\n s=(C/'services.py').read_text(); c=(C/'navimower_schedule.py').read_text(); y=(C/'services.yaml').read_text()\n assert 'SERVICE_SET_SCHEDULE_QUEUE' in s and 'async_set_custom_queue' in c and 'set_schedule_queue:' in y\n assert '"order_mode"' in c and '"custom_queue"' in c\n''')
+(root/'.github/release-notes/0.4.3-beta38.md').write_text('''title: Navimower 0.4.3-beta38\n\n## Map Card custom queue API\n- Adds `navimower.set_schedule_queue` for persisting Custom order without enabling or starting the scheduler.\n- Validates every queue item against the selected, previously completed schedule zones; duplicate zones are supported.\n- Exposes order mode and custom queue in Schedule Status attributes for dashboard editors.\n''')

--- a/.github/workflows/remote-beta-build.yml
+++ b/.github/workflows/remote-beta-build.yml
@@ -1,35 +1,27 @@
 name: Remote beta build
-
 on:
   issues:
     types: [opened]
-
 permissions:
   contents: write
   issues: write
-
 jobs:
   build:
-    if: >-
-      github.event.issue.title == 'RUN NAVIMOWER 0.4.3-BETA37 BUILD' &&
-      github.event.issue.user.login == github.repository_owner
+    if: github.event.issue.title == 'RUN NAVIMOWER 0.4.3-BETA38 BUILD' && github.event.issue.user.login == github.repository_owner
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
-      BUILD_BRANCH: release/0.4.3-beta37
+      BUILD_BRANCH: release/0.4.3-beta38
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.BUILD_BRANCH }}
           fetch-depth: 0
-
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
-
+          python-version: '3.14'
       - name: Install test dependencies
         run: python -m pip install --upgrade pytest voluptuous cryptography pyyaml
-
       - name: Build and validate beta
         id: build
         continue-on-error: true
@@ -38,44 +30,25 @@ jobs:
           set -o pipefail
           exec > >(tee /tmp/remote-beta-build.log) 2>&1
           set -euo pipefail
-          python .github/scripts/beta37_builder.py
+          python .github/scripts/beta38_builder.py
           python -m pytest -q
           python -m compileall -q custom_components/navimower
           git diff --check
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add custom_components/navimower/config_flow.py \
-                  custom_components/navimower/strings.json \
-                  custom_components/navimower/translations/en.json \
-                  custom_components/navimower/manifest.json \
-                  .github/release-notes/0.4.3-beta37.md \
-                  tests/test_v043_beta29.py \
-                  tests/test_v043_beta33.py \
-                  tests/test_v043_beta35.py \
-                  tests/test_v043_beta36.py \
-                  tests/test_v043_beta37.py
-          git commit -m "Prepare Navimower 0.4.3-beta37 schedule order UX"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add custom_components/navimower/services.py custom_components/navimower/services.yaml custom_components/navimower/navimower_schedule.py custom_components/navimower/manifest.json .github/release-notes/0.4.3-beta38.md tests/test_v043_beta38.py
+          git commit -m 'Prepare Navimower 0.4.3-beta38 queue API'
           git push origin HEAD:${BUILD_BRANCH}
           echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       - name: Comment success
         if: steps.build.outcome == 'success'
-        shell: bash
         run: |
-          gh issue comment "${{ github.event.issue.number }}" --body "0.4.3-beta37 remote build succeeded. Full tests, compileall and diff-check passed; branch \`${BUILD_BRANCH}\` was pushed at \`${{ steps.build.outputs.commit }}\`."
+          gh issue comment "${{ github.event.issue.number }}" --body "0.4.3-beta38 remote build succeeded. Full tests, compileall and diff-check passed; branch \`${BUILD_BRANCH}\` was pushed at \`${{ steps.build.outputs.commit }}\`."
           gh issue close "${{ github.event.issue.number }}" --reason completed
-
       - name: Comment failure
         if: steps.build.outcome != 'success'
-        shell: bash
         run: |
           tail -n 260 /tmp/remote-beta-build.log > /tmp/build-tail.txt || true
-          {
-            echo '0.4.3-beta37 remote build failed before publishing the completed release branch.'
-            echo
-            echo '```text'
-            cat /tmp/build-tail.txt
-            echo '```'
-          } > /tmp/failure-comment.md
+          { echo '0.4.3-beta38 remote build failed.'; echo; echo '```text'; cat /tmp/build-tail.txt; echo '```'; } > /tmp/failure-comment.md
           gh issue comment "${{ github.event.issue.number }}" --body-file /tmp/failure-comment.md
           exit 1

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta37"
+  "version": "0.4.3-beta38"
 }

--- a/custom_components/navimower/navimower_schedule.py
+++ b/custom_components/navimower/navimower_schedule.py
@@ -264,6 +264,8 @@ class NavimowerScheduleController:
             key: row.get(key)
             for key in (
                 "mode",
+                "order_mode",
+                "custom_queue",
                 "start",
                 "end",
                 "selected_zone_ids",
@@ -324,6 +326,28 @@ class NavimowerScheduleController:
             raise ValueError(f"Unknown schedule time key: {key}")
         self._update_options(**{option_key: format_hhmm(new_value)})
         self._queue_evaluation()
+
+    async def async_set_custom_queue(self, zone_ids: list[int]) -> None:
+        """Persist a user-defined custom mowing queue without starting mowing."""
+        queue = self._normalize_queue(zone_ids)
+        selected = set(self._selected_zone_ids)
+        if not queue:
+            raise ValueError("Custom mowing queue may not be empty")
+        unknown = [zone_id for zone_id in queue if zone_id not in selected]
+        if unknown:
+            raise ValueError(f"Queue contains zones outside the selected schedule allowlist: {unknown}")
+        eligible = {int(row["id"]) for row in self._eligible_zones() if row.get("id") is not None}
+        unproven = [zone_id for zone_id in queue if zone_id not in eligible]
+        if unproven:
+            raise ValueError(f"Queue contains zones without a confirmed completed mowing: {unproven}")
+        self._custom_queue = queue
+        self._order_mode = SCHEDULE_ORDER_CUSTOM
+        self._runtime["completed_queue_slots"] = []
+        self._runtime["active_queue_slot"] = None
+        self._update_options(**{OPT_SCHEDULE_CUSTOM_QUEUE: list(queue), OPT_SCHEDULE_ORDER_MODE: SCHEDULE_ORDER_CUSTOM})
+        await self._save()
+        if self._enabled:
+            self._queue_evaluation()
 
     def _update_options(self, **updates: Any) -> None:
         options = dict(self.entry.options)

--- a/custom_components/navimower/services.py
+++ b/custom_components/navimower/services.py
@@ -46,6 +46,7 @@ install_runtime_extensions()
 SERVICE_SET_SCHEDULE = "set_schedule"
 SERVICE_MOW = "mow"
 SERVICE_RESUME = "resume"
+SERVICE_SET_SCHEDULE_QUEUE = "set_schedule_queue"
 SERVICE_MARK_NOTIFICATION_READ = "mark_notification_read"
 SERVICE_MARK_ALL_NOTIFICATIONS_READ = "mark_all_notifications_read"
 
@@ -83,6 +84,8 @@ MOW_SCHEMA = vol.Schema(
         vol.Optional("reset", default=True): cv.boolean,
     }
 )
+
+SET_SCHEDULE_QUEUE_SCHEMA = vol.Schema({vol.Optional("device_id"): cv.string, vol.Required("zones"): vol.All(cv.ensure_list, [vol.Coerce(int)])})
 
 RESUME_SCHEMA = vol.Schema(
     {
@@ -255,6 +258,18 @@ def async_setup_services(hass: HomeAssistant) -> None:
                 coordinator.clear_command_target()
             raise HomeAssistantError(f"Navimow mow failed: {err}") from err
 
+    async def _set_schedule_queue(call: ServiceCall) -> None:
+        coordinator = _resolve_coordinator(call)
+        controller = getattr(coordinator, "navimower_schedule", None)
+        if controller is None:
+            raise ServiceValidationError("Navimower Schedule controller is not available")
+        try:
+            await controller.async_set_custom_queue([int(v) for v in call.data.get("zones") or []])
+        except ValueError as err:
+            raise ServiceValidationError(str(err)) from err
+        except Exception as err:
+            raise HomeAssistantError(f"Navimower set_schedule_queue failed: {err}") from err
+
     async def _resume(call: ServiceCall) -> None:
         coordinator = _resolve_coordinator(call)
         try:
@@ -290,6 +305,8 @@ def async_setup_services(hass: HomeAssistant) -> None:
         )
     if not hass.services.has_service(DOMAIN, SERVICE_MOW):
         hass.services.async_register(DOMAIN, SERVICE_MOW, _mow, schema=MOW_SCHEMA)
+    if not hass.services.has_service(DOMAIN, SERVICE_SET_SCHEDULE_QUEUE):
+        hass.services.async_register(DOMAIN, SERVICE_SET_SCHEDULE_QUEUE, _set_schedule_queue, schema=SET_SCHEDULE_QUEUE_SCHEMA)
     if not hass.services.has_service(DOMAIN, SERVICE_RESUME):
         hass.services.async_register(
             DOMAIN,

--- a/custom_components/navimower/services.yaml
+++ b/custom_components/navimower/services.yaml
@@ -132,3 +132,20 @@ mark_all_notifications_read:
       selector:
         device:
           integration: navimower
+
+set_schedule_queue:
+  name: Set Navimower custom schedule queue
+  description: Persist the ordered Custom queue without enabling or starting Navimower Schedule. Zones may repeat.
+  fields:
+    device_id:
+      name: Mower
+      required: false
+      selector:
+        device:
+          integration: navimower
+    zones:
+      name: Ordered zones
+      description: Selected, previously completed schedule zone IDs in mowing order. IDs may repeat.
+      required: true
+      selector:
+        object:

--- a/tests/test_v043_beta29.py
+++ b/tests/test_v043_beta29.py
@@ -18,6 +18,6 @@ assert '"map_version": map_version' in diagnostics
 
 assert manifest["version"] in {
     "0.4.3-beta29", "0.4.3-beta30", "0.4.3-beta31", "0.4.3-beta32",
-    "0.4.3-beta33", "0.4.3-beta34", "0.4.3-beta35", "0.4.3-beta36", "0.4.3-beta37",
+    "0.4.3-beta33", "0.4.3-beta34", "0.4.3-beta35", "0.4.3-beta36", "0.4.3-beta37", "0.4.3-beta38",
 }
 print("beta29 map revision diagnostics tests passed")

--- a/tests/test_v043_beta33.py
+++ b/tests/test_v043_beta33.py
@@ -45,4 +45,4 @@ def test_custom_area_occupancy_requires_fresh_mqtt_xy() -> None:
 
 def test_manifest_keeps_beta33_or_later_043_beta() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] in {"0.4.3-beta33", "0.4.3-beta34", "0.4.3-beta35", "0.4.3-beta36", "0.4.3-beta37"}
+    assert manifest["version"] in {"0.4.3-beta33", "0.4.3-beta34", "0.4.3-beta35", "0.4.3-beta36", "0.4.3-beta37", "0.4.3-beta38"}

--- a/tests/test_v043_beta35.py
+++ b/tests/test_v043_beta35.py
@@ -7,7 +7,7 @@ def test_beta35_schedule_status_contract() -> None:
     sensor = (root / "custom_components/navimower/sensor.py").read_text()
     manifest = (root / "custom_components/navimower/manifest.json").read_text()
 
-    assert ('"version": "0.4.3-beta35"' in manifest or '"version": "0.4.3-beta36"' in manifest or '"version": "0.4.3-beta37"' in manifest)
+    assert ('"version": "0.4.3-beta35"' in manifest or '"version": "0.4.3-beta36"' in manifest or '"version": "0.4.3-beta37"' in manifest or '"version": "0.4.3-beta38"' in manifest)
     assert '"queue": queue' in helper
     assert '"completed_zones": completed' in helper
     assert '"active_zone": active' in helper

--- a/tests/test_v043_beta36.py
+++ b/tests/test_v043_beta36.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 def test_beta36_version_and_constants():
-    assert any(v in Path('custom_components/navimower/manifest.json').read_text() for v in ('0.4.3-beta36', '0.4.3-beta37'))
+    assert any(v in Path('custom_components/navimower/manifest.json').read_text() for v in ('0.4.3-beta36', '0.4.3-beta37', '0.4.3-beta38'))
     c=Path('custom_components/navimower/const.py').read_text()
     assert 'OPT_SCHEDULE_CUSTOM_QUEUE' in c and 'SCHEDULE_ORDER_CUSTOM' in c
 

--- a/tests/test_v043_beta37.py
+++ b/tests/test_v043_beta37.py
@@ -6,7 +6,7 @@ COMP = ROOT / "custom_components" / "navimower"
 
 def test_beta37_identity_and_release_notes():
     manifest = json.loads((COMP / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.3-beta37"
+    assert manifest["version"] in {"0.4.3-beta37", "0.4.3-beta38"}
     notes = (ROOT / ".github/release-notes/0.4.3-beta37.md").read_text()
     assert notes.startswith("title: Navimower 0.4.3-beta37")
 

--- a/tests/test_v043_beta38.py
+++ b/tests/test_v043_beta38.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import json
+ROOT=Path(__file__).resolve().parents[1]; C=ROOT/'custom_components/navimower'
+def test_identity(): assert json.loads((C/'manifest.json').read_text())['version']=='0.4.3-beta38'
+def test_queue_api():
+ s=(C/'services.py').read_text(); c=(C/'navimower_schedule.py').read_text(); y=(C/'services.yaml').read_text()
+ assert 'SERVICE_SET_SCHEDULE_QUEUE' in s and 'async_set_custom_queue' in c and 'set_schedule_queue:' in y
+ assert '"order_mode"' in c and '"custom_queue"' in c


### PR DESCRIPTION
Adds the Map Card custom schedule queue API and Schedule Status queue metadata. Full remote build passed: pytest, compileall and diff-check on commit e8b906f3d62ec9c1952f8c2eaeedb224fca6963f.