### PR TITLE
Navimower 0.4.3-beta40 charging resume fix

### DIFF
--- a/.github/release-notes/0.4.3-beta40.md
+++ b/.github/release-notes/0.4.3-beta40.md
@@ -1,0 +1,8 @@
+title: Navimower 0.4.3-beta40
+
+## Managed schedule charging resume
+- Fixes a managed-schedule stall where a zone remained active after the mower returned to charge at its low-battery threshold.
+- Uses the persisted notification-center charging attribution to distinguish a mower-owned charging interruption from manual Dock, night pauses and unknown returns.
+- Preserves the active zone, cycle and progress while charging instead of selecting or resetting another zone.
+- Waits until the mower leaves the vendor charging state, then resumes the retained task; if Resume is not confirmed, the existing safe `reset=false` one-zone continuation fallback is used.
+- Never uses `reset=true` to recover an interrupted charging task.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta39"
+  "version": "0.4.3-beta40"
 }

--- a/custom_components/navimower/navimower_schedule.py
+++ b/custom_components/navimower/navimower_schedule.py
@@ -509,6 +509,26 @@ class NavimowerScheduleController:
             return mqtt_state == MQTT_STATE_CHARGING
         return str(data.get("state_code") or "") == STATE_IDLE_DOCKED_POST
 
+    def _charging_interruption_confirmed(self) -> bool:
+        """Return whether the notification state proved a low-battery charging pause."""
+        center = getattr(self.coordinator, "notification_center", None)
+        return getattr(center, "interrupted_reason", None) == "charging"
+
+    async def _capture_charging_interruption(self) -> None:
+        """Retain the active scheduler zone while the mower charges itself."""
+        zone_id = self._runtime.get("active_zone_id")
+        if zone_id is None or self._runtime.get("resume_pending"):
+            return
+        self._runtime["resume_pending"] = True
+        self._runtime["interrupted_zone_id"] = int(zone_id)
+        self._runtime["interrupted_cycle_id"] = self._runtime.get("active_cycle_id")
+        self._runtime["progress_before_interrupt"] = self._progress_for_zone(int(zone_id))
+        self._runtime["pending_command"] = None
+        self._runtime["last_command"] = f"charging_pause:{zone_id}"
+        self._runtime["last_command_at"] = _utc_now()
+        self._runtime["last_error"] = None
+        await self._save()
+
     def _pending_mow_confirmed(self, pending: dict[str, Any], data: dict[str, Any]) -> bool:
         """Confirm a scheduler start from vendor state and the commanded target."""
         if not self._vendor_mowing(data):
@@ -519,9 +539,6 @@ class NavimowerScheduleController:
         observed_zone = _as_int(data.get("active_zone_progress_zone_id"))
         if observed_zone == zone_id:
             return True
-        # A start from dock/paused has a real vendor transition from non-mowing
-        # to mowing. A seamless next-zone handoff starts while the previous zone
-        # still reports mowing, so that case waits for the target zone to change.
         return pending.get("vendor_mowing_at_send") is False
 
     def _sync_active_cycle_id(self) -> bool:
@@ -628,13 +645,25 @@ class NavimowerScheduleController:
         if self._runtime.get("suspended_reason"):
             return
 
+        if (
+            self._runtime.get("active_zone_id") is not None
+            and not self._runtime.get("resume_pending")
+            and self._charging_interruption_confirmed()
+        ):
+            await self._capture_charging_interruption()
+
         if self._runtime.get("resume_pending"):
             if activity == ACTIVITY_MOWING:
                 self._runtime["resume_pending"] = False
+                self._runtime["interrupted_zone_id"] = None
+                self._runtime["interrupted_cycle_id"] = None
+                self._runtime["progress_before_interrupt"] = None
                 self._runtime["pending_command"] = None
                 self._runtime["last_command"] = "retained_task_already_mowing"
                 self._runtime["last_command_at"] = _utc_now()
                 await self._save()
+                return
+            if self._vendor_charging(data):
                 return
             await self._continue_interrupted_task(activity)
             return
@@ -647,8 +676,6 @@ class NavimowerScheduleController:
             return
         if not self._retry_ready():
             return
-        # Charging is a normal mower-owned interruption. Do not start another
-        # scheduler task while the mower itself reports 0102/MQTT charging.
         if self._vendor_charging(data):
             return
         if activity not in {ACTIVITY_DOCKED, ACTIVITY_PAUSED} and not (
@@ -766,6 +793,9 @@ class NavimowerScheduleController:
         if kind in {"resume", "continue"} and activity == ACTIVITY_MOWING:
             self._runtime["pending_command"] = None
             self._runtime["resume_pending"] = False
+            self._runtime["interrupted_zone_id"] = None
+            self._runtime["interrupted_cycle_id"] = None
+            self._runtime["progress_before_interrupt"] = None
             self._runtime["last_error"] = None
             await self._save()
         elif kind == "dock" and activity in {ACTIVITY_RETURNING, ACTIVITY_DOCKED}:

--- a/tests/test_schedule_charging_resume.py
+++ b/tests/test_schedule_charging_resume.py
@@ -1,0 +1,63 @@
+"""Regression guards for managed-schedule low-battery charging resume."""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = (ROOT / "custom_components" / "navimower" / "navimower_schedule.py").read_text(
+    encoding="utf-8"
+)
+
+
+def _async_function(name: str) -> str:
+    start = SOURCE.index(f"    async def {name}(")
+    next_async = SOURCE.find("\n    async def ", start + 1)
+    next_sync = SOURCE.find("\n    def ", start + 1)
+    candidates = [value for value in (next_async, next_sync) if value >= 0]
+    end = min(candidates) if candidates else len(SOURCE)
+    return SOURCE[start:end]
+
+
+def test_schedule_module_stays_syntax_valid() -> None:
+    ast.parse(SOURCE)
+
+
+def test_vendor_confirmed_charging_interrupts_active_scheduler_zone() -> None:
+    evaluate = _async_function("_evaluate_locked")
+    assert "_charging_interruption_confirmed()" in evaluate
+    assert "await self._capture_charging_interruption()" in evaluate
+    capture = evaluate.index("await self._capture_charging_interruption()")
+    active_return = evaluate.index('if self._runtime.get("active_zone_id") is not None:')
+    assert capture < active_return
+
+    helper = _async_function("_capture_charging_interruption")
+    assert 'self._runtime["resume_pending"] = True' in helper
+    assert 'self._runtime["interrupted_zone_id"] = int(zone_id)' in helper
+    assert 'self._runtime["interrupted_cycle_id"]' in helper
+    assert 'self._runtime["progress_before_interrupt"]' in helper
+    assert 'self._runtime["last_command"] = f"charging_pause:{zone_id}"' in helper
+
+
+def test_charging_waits_for_vendor_to_leave_charging_before_resume() -> None:
+    evaluate = _async_function("_evaluate_locked")
+    resume_block = evaluate[evaluate.index('if self._runtime.get("resume_pending"):'):]
+    assert "if self._vendor_charging(data):" in resume_block
+    wait = resume_block.index("if self._vendor_charging(data):")
+    resume = resume_block.index("await self._continue_interrupted_task(activity)")
+    assert wait < resume
+
+
+def test_only_notification_center_charging_reason_auto_arms_resume() -> None:
+    start = SOURCE.index("    def _charging_interruption_confirmed")
+    end = SOURCE.index("    async def _capture_charging_interruption", start)
+    helper = SOURCE[start:end]
+    assert 'getattr(center, "interrupted_reason", None) == "charging"' in helper
+    assert "return_battery_level" not in helper
+    assert "manual_dock" not in helper
+
+
+def test_retained_task_resume_never_resets_the_zone() -> None:
+    cont = _async_function("_continue_interrupted_task")
+    assert 'reset=False, source="navimower_schedule_continue_fallback"' in cont
+    assert "reset=True" not in cont


### PR DESCRIPTION
Fixes managed-schedule recovery after mower-owned low-battery charging. Preserves the active zone/cycle/progress, waits while vendor charging is active, then resumes the retained task without reset=true. Uses the persisted notification-center charging attribution so manual Dock/night/unknown returns are not auto-resumed. Adds focused regression coverage and release notes.