### PR TITLE
Navimower 0.4.3-beta41: reset-based current-cycle trails

### DIFF
--- a/.github/release-notes/0.4.3-beta41.md
+++ b/.github/release-notes/0.4.3-beta41.md
@@ -1,0 +1,8 @@
+title: Navimower 0.4.3-beta41
+
+## Reset-based current-cycle trail
+- Keeps each zone's completed mowing trail across calendar-day boundaries instead of clearing it at midnight.
+- Treats confirmed reset/completion boundaries as the real per-zone cycle boundary.
+- Preserves pause/resume, charging continuation and other technical session splits inside the same retained zone trail.
+- In multi-zone reset tasks, clears only a zone that the new cycle has actually entered; untouched zones keep their previous current-cycle trail.
+- Keeps the existing `daily_trails` payload key for this beta so the matching Map Card can be tested without a larger API migration; the payload now identifies its semantic scope as `current_cycle`.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta40"
+  "version": "0.4.3-beta41"
 }

--- a/custom_components/navimower/zone_state.py
+++ b/custom_components/navimower/zone_state.py
@@ -1,4 +1,4 @@
-"""Central per-zone progress model and daily trail preparation.
+"""Central per-zone progress model and current-cycle trail preparation.
 
 The integration owns all progress, area, cycle and route interpretation.  The
 frontend receives already-normalized values and only renders them.
@@ -415,8 +415,8 @@ def zone_model_signature(
 
     Live ``last_mowed_at`` timestamps intentionally do not participate. They
     still update the HA sensor attributes, but must not force a static zone-layer
-    rebuild for every retained mower position. Daily route changes have their own
-    ``daily_trails_revision``.
+    rebuild for every retained mower position. Current-cycle route changes have
+    their own ``daily_trails_revision`` compatibility revision.
     """
     return (
         tuple(
@@ -461,7 +461,14 @@ def zone_model_signature(
 def build_daily_trails(
     *, sessions: list[dict[str, Any]], map_zones: list[dict[str, Any]], local_date: date, to_local_date, revision: int,
 ) -> dict[str, Any]:
-    """Keep today's route for the latest confirmed mowing cycle of every zone."""
+    """Keep the latest confirmed mowing-cycle route for every zone.
+
+    ``local_date`` and ``to_local_date`` remain in the compatibility signature,
+    but calendar midnight is intentionally not a route boundary. A zone keeps
+    all completed-session fragments since its latest confirmed reset/completion
+    boundary until the next cycle actually enters that zone.
+    """
+    del to_local_date
     by_zone: dict[int, dict[str, Any]] = {}
     boundary_before_next: set[int] = set()
     ordered = sorted((item for item in sessions if isinstance(item, dict)), key=lambda item: as_int(item.get("started_at_ms")) or 0)
@@ -497,7 +504,7 @@ def build_daily_trails(
         for raw in points:
             if not isinstance(raw, list) or len(raw) < 3: continue
             stamp = as_int(raw[0]); x, y = as_float(raw[1]), as_float(raw[2])
-            if stamp is None or x is None or y is None or to_local_date(stamp) != local_date:
+            if stamp is None or x is None or y is None:
                 flush(); current_zone = None; continue
             zone_id = as_int(raw[7]) if len(raw) > 7 else None
             if zone_id is None: zone_id = zone_id_for_point(x, y, map_zones)
@@ -524,4 +531,4 @@ def build_daily_trails(
     for zone_id in sorted(by_zone):
         row = deepcopy(by_zone[zone_id]); row["segments"] = [segment for segment in row["segments"] if len(segment) >= 2]; row["render_point_count"] = sum(len(segment) for segment in row["segments"])
         if row["segments"]: result.append(row)
-    return {"date": local_date.isoformat(), "revision": revision, "zones": result}
+    return {"date": local_date.isoformat(), "scope": "current_cycle", "revision": revision, "zones": result}

--- a/tests/test_current_cycle_trails_beta41.py
+++ b/tests/test_current_cycle_trails_beta41.py
@@ -1,0 +1,144 @@
+"""Regression coverage for reset-based per-zone current-cycle trails."""
+from __future__ import annotations
+
+from datetime import date
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+PACKAGE = "navimower_beta41_cycle_trail_test"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+package = types.ModuleType(PACKAGE)
+package.__path__ = [str(COMPONENT)]
+sys.modules.setdefault(PACKAGE, package)
+_load_module(f"{PACKAGE}.const", COMPONENT / "const.py")
+zone_state = _load_module(f"{PACKAGE}.zone_state", COMPONENT / "zone_state.py")
+
+TODAY = date(2026, 8, 25)
+YESTERDAY = date(2026, 8, 24)
+
+
+def _point(stamp: int, x: float, zone_id: int) -> list[object]:
+    return [stamp, x, 1.0, 0.0, "mowing", 4, -1, zone_id]
+
+
+def _build(sessions: list[dict]) -> dict[int, dict]:
+    payload = zone_state.build_daily_trails(
+        sessions=sessions,
+        map_zones=[],
+        local_date=TODAY,
+        to_local_date=lambda stamp: YESTERDAY if stamp < 10_000 else TODAY,
+        revision=41,
+    )
+    assert payload["scope"] == "current_cycle"
+    return {row["zone_id"]: row for row in payload["zones"]}
+
+
+def test_same_cycle_survives_calendar_midnight() -> None:
+    zones = _build(
+        [
+            {
+                "id": "before-midnight",
+                "started_at_ms": 1000,
+                "active": False,
+                "completed": False,
+                "segment_starts_ms": [1000],
+                "points": [_point(1000, 1.0, 13), _point(2000, 2.0, 13)],
+            },
+            {
+                "id": "after-midnight",
+                "started_at_ms": 10_000,
+                "active": False,
+                "completed": False,
+                "segment_starts_ms": [10_000],
+                "points": [_point(10_000, 3.0, 13), _point(11_000, 4.0, 13)],
+            },
+        ]
+    )
+
+    assert zones[13]["cycle_id"] == "before-midnight"
+    assert zones[13]["point_count"] == 4
+    assert zones[13]["segments"] == [
+        [[1.0, 1.0], [2.0, 1.0]],
+        [[3.0, 1.0], [4.0, 1.0]],
+    ]
+
+
+def test_confirmed_completion_still_starts_next_cycle_only_on_zone_entry() -> None:
+    zones = _build(
+        [
+            {
+                "id": "old-cycle",
+                "started_at_ms": 1000,
+                "active": False,
+                "completed": True,
+                "completion_reason": "vendor_coverage",
+                "final_progress": {"13": 100},
+                "segment_starts_ms": [1000],
+                "points": [
+                    _point(1000, 1.0, 13),
+                    _point(2000, 2.0, 13),
+                    _point(3000, 10.0, 24),
+                    _point(4000, 11.0, 24),
+                ],
+            },
+            {
+                "id": "next-cycle",
+                "started_at_ms": 10_000,
+                "active": False,
+                "completed": False,
+                "segment_starts_ms": [10_000],
+                "points": [_point(10_000, 3.0, 13), _point(11_000, 4.0, 13)],
+            },
+        ]
+    )
+
+    assert zones[13]["cycle_id"] == "next-cycle"
+    assert zones[13]["segments"] == [[[3.0, 1.0], [4.0, 1.0]]]
+    assert zones[24]["cycle_id"] == "old-cycle"
+    assert zones[24]["segments"] == [[[10.0, 1.0], [11.0, 1.0]]]
+
+
+def test_active_reset_clears_only_zone_actually_entered() -> None:
+    zones = _build(
+        [
+            {
+                "id": "retained-cycle",
+                "started_at_ms": 1000,
+                "active": False,
+                "completed": False,
+                "segment_starts_ms": [1000],
+                "points": [
+                    _point(1000, 1.0, 13),
+                    _point(2000, 2.0, 13),
+                    _point(3000, 10.0, 24),
+                    _point(4000, 11.0, 24),
+                ],
+            },
+            {
+                "id": "reset-task",
+                "started_at_ms": 10_000,
+                "active": True,
+                "cycle_reset_zone_ids": [13, 24],
+                "segment_starts_ms": [10_000],
+                "points": [_point(10_000, 3.0, 13), _point(11_000, 4.0, 13)],
+            },
+        ]
+    )
+
+    assert 13 not in zones
+    assert zones[24]["cycle_id"] == "retained-cycle"
+    assert zones[24]["segments"] == [[[10.0, 1.0], [11.0, 1.0]]]


### PR DESCRIPTION
## Summary
- keep each zone's completed trail across calendar-day boundaries
- use confirmed reset/completion boundaries as the actual per-zone cycle boundary
- preserve pause/resume, charging continuation and technical session splits inside the same retained trail
- clear only zones actually entered by a new reset cycle
- keep the existing `daily_trails` payload key for this beta, with `scope: current_cycle`
- add focused cross-midnight and multi-zone reset regressions

Built on top of beta40, so the managed-schedule low-battery charging resume fix remains included unchanged.