### PR TITLE
Navimower 0.4.3-beta43: passive MQTT discovery switch

### DIFF
--- a/.github/release-notes/0.4.3-beta43.md
+++ b/.github/release-notes/0.4.3-beta43.md
@@ -1,0 +1,8 @@
+title: Navimower 0.4.3-beta43
+
+## Passive MQTT discovery for gate-transition testing
+- Temporarily restores the **Passive protocol discovery** switch under Configure → General and trail history.
+- Keeps the switch disabled by default and preserves it across the options-triggered integration reload while this beta is being field-tested.
+- When enabled, reuses the existing bounded/sanitized MQTT discovery collector so `/realtimeDate/location`, `/realtimeDate/event` and other current-device downlink samples can be correlated with the real Yard2 ↔ Street2 gate transition.
+- Keeps the beta42 MQTT navigation diagnostics and does **not** change `gate_required` behavior yet.
+- The switch is intended only for short controlled diagnostics and should be turned back off after the test.

--- a/custom_components/navimower/__init__.py
+++ b/custom_components/navimower/__init__.py
@@ -62,6 +62,11 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 # releases use only Home Assistant's native Download diagnostics path.
 _DEPRECATED_DIAGNOSTICS_OPTIONS = {"diagnostics_detail", "passive_discovery"}
 
+# beta43 temporarily re-enables only passive discovery for the controlled gate
+# transition field test. Keep the historical deprecated set unchanged so stable
+# cleanup semantics remain explicit and the switch is easy to retire again.
+_BETA43_REENABLED_DIAGNOSTICS_OPTIONS = {"passive_discovery"}
+
 # The standalone map card, Mow Now dialog and schedule editor are distributed
 # from the separate navimower-map-card HACS dashboard repository.
 
@@ -185,12 +190,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Restore local data, then start private cloud and OAuth/MQTT in parallel."""
     async_register_oauth_implementation(hass)
 
-    # Remove beta-only diagnostics options even when the user upgrades without
-    # opening the options flow. This also guarantees passive discovery cannot
-    # remain enabled from an earlier beta configuration.
+    # Remove retired broad diagnostics options even when the user upgrades
+    # without opening the options flow. beta43 deliberately keeps only the
+    # bounded passive-discovery switch while the gate transition is field-tested.
     cleaned_options = dict(entry.options)
     removed = [
-        key for key in _DEPRECATED_DIAGNOSTICS_OPTIONS if key in cleaned_options
+        key
+        for key in _DEPRECATED_DIAGNOSTICS_OPTIONS
+        if key in cleaned_options
+        and key not in _BETA43_REENABLED_DIAGNOSTICS_OPTIONS
     ]
     for key in removed:
         cleaned_options.pop(key, None)

--- a/custom_components/navimower/config_flow.py
+++ b/custom_components/navimower/config_flow.py
@@ -36,6 +36,7 @@ from .custom_area import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+_PASSIVE_DISCOVERY_OPTION = "passive_discovery"
 
 
 class NavimowOptionsFlow(_BaseNavimowOptionsFlow):
@@ -80,6 +81,42 @@ class NavimowOptionsFlow(_BaseNavimowOptionsFlow):
                 status["last_attempt_mono"] = None
                 status["last_attempt_utc"] = None
         await coordinator.async_request_refresh()
+
+    def _save(self, **updates: Any) -> ConfigFlowResult:
+        """Save production options while keeping the beta43 discovery switch."""
+        options = self._options()
+        options.pop("diagnostics_detail", None)
+        options.update(updates)
+        return self.async_create_entry(data=options)
+
+    async def async_step_general(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Temporarily expose passive MQTT discovery for gate-state field tests."""
+        if user_input is not None:
+            enabled = bool(user_input.get(_PASSIVE_DISCOVERY_OPTION, False))
+            payload = dict(user_input)
+            payload.pop(_PASSIVE_DISCOVERY_OPTION, None)
+            result = await super().async_step_general(payload)
+            if result.get("type") == "create_entry":
+                data = dict(result.get("data") or {})
+                data[_PASSIVE_DISCOVERY_OPTION] = enabled
+                result["data"] = data
+            return result
+
+        result = await super().async_step_general(None)
+        if result.get("type") == "form" and result.get("step_id") == "general":
+            schema = dict(result["data_schema"].schema)
+            schema[
+                vol.Required(
+                    _PASSIVE_DISCOVERY_OPTION,
+                    default=bool(
+                        self._options().get(_PASSIVE_DISCOVERY_OPTION, False)
+                    ),
+                )
+            ] = bool
+            result["data_schema"] = vol.Schema(schema)
+        return result
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta42"
+  "version": "0.4.3-beta43"
 }

--- a/tests/test_passive_discovery_beta43.py
+++ b/tests/test_passive_discovery_beta43.py
@@ -1,0 +1,49 @@
+"""Regression guards for Navimower 0.4.3-beta43 passive MQTT discovery."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta43_manifest_and_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.3-beta43"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta43.md").read_text()
+    assert "Passive MQTT discovery" in notes
+    assert "gate_required" in notes
+
+
+def test_beta43_general_flow_exposes_and_persists_passive_discovery() -> None:
+    source = (COMPONENT / "config_flow.py").read_text()
+    ast.parse(source)
+    assert '_PASSIVE_DISCOVERY_OPTION = "passive_discovery"' in source
+    assert "async def async_step_general" in source
+    assert "payload.pop(_PASSIVE_DISCOVERY_OPTION, None)" in source
+    assert "data[_PASSIVE_DISCOVERY_OPTION] = enabled" in source
+    assert "self._options().get(_PASSIVE_DISCOVERY_OPTION, False)" in source
+    assert 'options.pop("passive_discovery", None)' not in source
+
+
+def test_beta43_startup_keeps_only_reenabled_passive_discovery() -> None:
+    source = (COMPONENT / "__init__.py").read_text()
+    ast.parse(source)
+    assert '_DEPRECATED_DIAGNOSTICS_OPTIONS = {"diagnostics_detail", "passive_discovery"}' in source
+    assert '_BETA43_REENABLED_DIAGNOSTICS_OPTIONS = {"passive_discovery"}' in source
+    assert "key not in _BETA43_REENABLED_DIAGNOSTICS_OPTIONS" in source
+
+
+def test_beta43_mqtt_bridge_already_collects_bounded_samples() -> None:
+    source = (COMPONENT / "mqtt.py").read_text()
+    ast.parse(source)
+    for marker in (
+        "self._discovery_enabled",
+        "mqtt_discovery_topics(device_id)",
+        "include_samples=True",
+        "sanitize_discovery_payload(payload)",
+        "def diagnostic_discovery",
+    ):
+        assert marker in source


### PR DESCRIPTION
Temporarily restores the Passive protocol discovery option for controlled gate-transition testing. The switch is shown under General, persists across the options-triggered reload, reuses the existing bounded/sanitized MQTT discovery collector, and does not change gate_required behavior. Includes beta43 regression guards and release notes.