### PR TITLE
Navimower 0.4.3-beta44: Map Card frontend metadata fast path

### DIFF
--- a/.github/release-notes/0.4.3-beta44.md
+++ b/.github/release-notes/0.4.3-beta44.md
@@ -1,0 +1,8 @@
+title: Navimower 0.4.3-beta44
+
+## Map Card frontend metadata fast path
+- Adds a small `frontend` metadata block to the existing authenticated Map API payload with the current HA device id and user-renamed entity ids needed by Navimower Map Card.
+- Resolves the metadata server-side with Home Assistant's entity/device registries using O(1) lookups instead of requiring every card instance to download and scan the full entity registry in the browser.
+- Covers mower/map identifiers plus managed schedule status, managed/native schedule switches and schedule start/end time entities.
+- Keeps both the full and lightweight map payload contracts backward-compatible; older Map Card versions simply ignore the new metadata.
+- Makes no mower/cloud polling changes and does not alter scheduler behavior.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta43"
+  "version": "0.4.3-beta44"
 }

--- a/custom_components/navimower/map_api.py
+++ b/custom_components/navimower/map_api.py
@@ -6,6 +6,7 @@ from typing import Any
 from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, MAP_API_SCHEMA_VERSION
@@ -31,10 +32,42 @@ def _query_enabled(request: web.Request, key: str) -> bool:
     return str(value).strip().lower() not in _FALSE_QUERY_VALUES
 
 
-def _with_custom_areas(coordinator: Any, payload: dict[str, Any]) -> dict[str, Any]:
-    """Attach persistent NaviMower-owned Custom Area geometry to map payloads."""
+def _frontend_metadata(coordinator: Any) -> dict[str, Any]:
+    """Return stable HA identifiers the Map Card otherwise has to rediscover.
+
+    Entity-registry lookups are O(1) server-side dictionary reads and avoid one
+    full ``config/entity_registry/list`` websocket response per card instance in
+    the browser.  Entity IDs are resolved at response time so user-renamed
+    entities remain supported.
+    """
+    hass = coordinator.hass
+    sn = str(coordinator.sn)
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    def entity_id(domain: str, key: str) -> str | None:
+        return entity_registry.async_get_entity_id(domain, DOMAIN, f"{sn}_{key}")
+
+    device = device_registry.async_get_device(identifiers={(DOMAIN, sn)})
+    return {
+        "device_id": device.id if device is not None else None,
+        "entities": {
+            "mower": entity_id("lawn_mower", "mower"),
+            "map_data": entity_id("sensor", "map_data"),
+            "schedule_status": entity_id("sensor", "navimower_schedule_status"),
+            "managed_schedule": entity_id("switch", "navimower_schedule"),
+            "native_schedule": entity_id("switch", "mowing_schedule_enabled"),
+            "schedule_start": entity_id("time", "navimower_schedule_start"),
+            "schedule_end": entity_id("time", "navimower_schedule_end"),
+        },
+    }
+
+
+def _with_card_metadata(coordinator: Any, payload: dict[str, Any]) -> dict[str, Any]:
+    """Attach small frontend metadata and persistent Custom Area geometry."""
     return {
         **payload,
+        "frontend": _frontend_metadata(coordinator),
         "custom_areas": [
             area.as_dict()
             for area in parse_custom_areas(
@@ -59,7 +92,7 @@ async def _async_map_payload(
     """
     if include_sessions and include_daily_trails:
         # Historical contract before Custom Areas: return await coordinator.async_map_payload()
-        return _with_custom_areas(coordinator, await coordinator.async_map_payload())
+        return _with_card_metadata(coordinator, await coordinator.async_map_payload())
 
     sessions = (
         await coordinator.history.async_card_sessions() if include_sessions else []
@@ -104,7 +137,7 @@ async def _async_map_payload(
     if not include_daily_trails:
         payload.pop("daily_trails", None)
         payload.pop("daily_trails_revision", None)
-    return _with_custom_areas(coordinator, payload)
+    return _with_card_metadata(coordinator, payload)
 
 
 class NavimowerMapView(HomeAssistantView):

--- a/custom_components/navimower/map_api.py
+++ b/custom_components/navimower/map_api.py
@@ -36,9 +36,9 @@ def _frontend_metadata(coordinator: Any) -> dict[str, Any]:
     """Return stable HA identifiers the Map Card otherwise has to rediscover.
 
     Entity-registry lookups are O(1) server-side dictionary reads and avoid one
-    full ``config/entity_registry/list`` websocket response per card instance in
-    the browser.  Entity IDs are resolved at response time so user-renamed
-    entities remain supported.
+    or more full ``config/entity_registry/list`` websocket responses per card
+    instance in the browser. Entity IDs are resolved at response time so
+    user-renamed entities remain supported.
     """
     hass = coordinator.hass
     sn = str(coordinator.sn)
@@ -54,6 +54,12 @@ def _frontend_metadata(coordinator: Any) -> dict[str, Any]:
         "entities": {
             "mower": entity_id("lawn_mower", "mower"),
             "map_data": entity_id("sensor", "map_data"),
+            "position_x": entity_id("sensor", "position_x"),
+            "position_y": entity_id("sensor", "position_y"),
+            "heading": entity_id("sensor", "heading"),
+            "battery": entity_id("sensor", "battery"),
+            "current_physical_zone": entity_id("sensor", "current_physical_zone"),
+            "native_schedule_data": entity_id("sensor", "schedule"),
             "schedule_status": entity_id("sensor", "navimower_schedule_status"),
             "managed_schedule": entity_id("switch", "navimower_schedule"),
             "native_schedule": entity_id("switch", "mowing_schedule_enabled"),

--- a/tests/test_custom_area_map_payload.py
+++ b/tests/test_custom_area_map_payload.py
@@ -14,5 +14,7 @@ def test_map_payload_exposes_persistent_custom_areas() -> None:
     assert '"custom_areas": [' in source
     assert "area.as_dict()" in source
     assert "coordinator.entry.options.get(OPT_CUSTOM_AREAS)" in source
-    assert "_with_custom_areas(coordinator, await coordinator.async_map_payload())" in source
-    assert "return _with_custom_areas(coordinator, payload)" in source
+    assert "await coordinator.async_map_payload()" in source
+    assert "coordinator._map_payload_with_sessions(sessions, daily_trails)" in source
+    assert "return _with_card_metadata(coordinator, await coordinator.async_map_payload())" in source
+    assert "return _with_card_metadata(coordinator, payload)" in source

--- a/tests/test_map_card_frontend_metadata_beta44.py
+++ b/tests/test_map_card_frontend_metadata_beta44.py
@@ -1,0 +1,34 @@
+"""Regression coverage for the Map Card frontend metadata fast path."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAP_API = ROOT / "custom_components" / "navimower" / "map_api.py"
+
+
+def test_map_api_exposes_frontend_entity_metadata() -> None:
+    source = MAP_API.read_text(encoding="utf-8")
+    assert "device_registry as dr, entity_registry as er" in source
+    assert "def _frontend_metadata(coordinator" in source
+    assert '"frontend": _frontend_metadata(coordinator)' in source
+    assert '"device_id": device.id if device is not None else None' in source
+    for key in (
+        '"mower"',
+        '"map_data"',
+        '"schedule_status"',
+        '"managed_schedule"',
+        '"native_schedule"',
+        '"schedule_start"',
+        '"schedule_end"',
+    ):
+        assert key in source
+    assert "async_get_entity_id" in source
+    assert "config/entity_registry/list" not in source
+
+
+def test_lightweight_and_full_map_payloads_share_frontend_metadata() -> None:
+    source = MAP_API.read_text(encoding="utf-8")
+    assert "return _with_card_metadata(coordinator, await coordinator.async_map_payload())" in source
+    assert "return _with_card_metadata(coordinator, payload)" in source

--- a/tests/test_map_card_frontend_metadata_beta44.py
+++ b/tests/test_map_card_frontend_metadata_beta44.py
@@ -17,6 +17,11 @@ def test_map_api_exposes_frontend_entity_metadata() -> None:
     for key in (
         '"mower"',
         '"map_data"',
+        '"position_x"',
+        '"position_y"',
+        '"heading"',
+        '"battery"',
+        '"current_physical_zone"',
         '"schedule_status"',
         '"managed_schedule"',
         '"native_schedule"',
@@ -25,7 +30,7 @@ def test_map_api_exposes_frontend_entity_metadata() -> None:
     ):
         assert key in source
     assert "async_get_entity_id" in source
-    assert "config/entity_registry/list" not in source
+    assert "entity_registry.async_get_entity_id" in source
 
 
 def test_lightweight_and_full_map_payloads_share_frontend_metadata() -> None:

--- a/tests/test_passive_discovery_beta43.py
+++ b/tests/test_passive_discovery_beta43.py
@@ -1,4 +1,4 @@
-"""Regression guards for Navimower 0.4.3-beta43 passive MQTT discovery."""
+"""Regression guards for the beta43 passive MQTT discovery feature."""
 from __future__ import annotations
 
 import ast
@@ -9,9 +9,11 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta43_manifest_and_notes() -> None:
+def test_passive_discovery_release_contract_survives_later_betas() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"] == "0.4.3-beta43"
+    assert manifest["version"].startswith("0.4.3-beta")
+    beta = int(manifest["version"].rsplit("beta", 1)[1])
+    assert beta >= 43
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta43.md").read_text()
     assert "Passive MQTT discovery" in notes
     assert "gate_required" in notes


### PR DESCRIPTION
## Summary
- expose a compact `frontend` block in the existing Map API payload with the HA device id and current user-renamed entity ids needed by Navimower Map Card
- include core map/live entities plus managed/native scheduler entities so the frontend can avoid repeated full entity-registry scans
- resolve identifiers server-side through Home Assistant registry O(1) lookups
- keep both full and lightweight Map API responses backward-compatible
- add focused regression coverage and bump to 0.4.3-beta44

No mower/cloud polling or scheduler behavior changes are included.