### PR TITLE
Navimower 0.4.3-beta45: direct managed-schedule zone handoff

### DIFF
--- a/.github/release-notes/0.4.3-beta45.md
+++ b/.github/release-notes/0.4.3-beta45.md
@@ -1,0 +1,8 @@
+title: Navimower 0.4.3-beta45
+
+## Managed schedule direct zone handoff
+- Fixes custom queue slot tracking so a completed queue entry is recorded by slot and duplicate zone entries still advance independently.
+- Prevents a completed first queue slot from being selected again simply because the mower began its normal automatic return-to-dock transition.
+- Allows a confirmed completed scheduler zone to hand off directly to the next queued zone while the mower is already in `returning`, instead of waiting for the dock first.
+- Keeps low-battery charging returns protected: a notification-confirmed charging interruption still blocks direct handoff and uses the existing charge/resume path.
+- Leaves manual/non-completion returning states blocked from starting a new scheduler zone.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta44"
+  "version": "0.4.3-beta45"
 }

--- a/custom_components/navimower/navimower_schedule.py
+++ b/custom_components/navimower/navimower_schedule.py
@@ -678,9 +678,12 @@ class NavimowerScheduleController:
             return
         if self._vendor_charging(data):
             return
-        if activity not in {ACTIVITY_DOCKED, ACTIVITY_PAUSED} and not (
-            completed_now and activity == ACTIVITY_MOWING
-        ):
+        direct_handoff = (
+            completed_now
+            and activity in {ACTIVITY_MOWING, ACTIVITY_RETURNING}
+            and not self._charging_interruption_confirmed()
+        )
+        if activity not in {ACTIVITY_DOCKED, ACTIVITY_PAUSED} and not direct_handoff:
             return
 
         completed = {int(value) for value in self._runtime.get("completed_zone_ids_in_window") or []}
@@ -896,6 +899,7 @@ class NavimowerScheduleController:
         self._runtime["pending_command"] = {
             "kind": "mow" if reset else "continue",
             "zone_id": zone_id,
+            "queue_slot": queue_slot,
             "reset": reset,
             "sent_at": sent_at,
             "source": source,

--- a/tests/test_schedule_handoff_beta45.py
+++ b/tests/test_schedule_handoff_beta45.py
@@ -1,0 +1,52 @@
+"""Regression guards for managed-schedule queue handoff in beta45."""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEDULE = ROOT / "custom_components" / "navimower" / "navimower_schedule.py"
+
+
+def _method_source(name: str) -> str:
+    source = SCHEDULE.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            segment = ast.get_source_segment(source, node)
+            assert segment is not None
+            return segment
+    raise AssertionError(f"Method {name} not found")
+
+
+def test_custom_queue_slot_survives_command_confirmation_and_completion() -> None:
+    send = _method_source("_async_send_mow")
+    confirm = _method_source("_confirm_pending")
+    complete = _method_source("_confirm_active_completion")
+
+    assert '"queue_slot": queue_slot' in send
+    assert 'self._runtime["active_queue_slot"] = pending.get("queue_slot")' in confirm
+    assert 'self._runtime["completed_queue_slots"] = sorted(slots)' in complete
+
+
+def test_completed_zone_can_handoff_while_vendor_is_returning() -> None:
+    evaluate = _method_source("_evaluate_locked")
+
+    assert "direct_handoff = (" in evaluate
+    assert "completed_now" in evaluate
+    assert "activity in {ACTIVITY_MOWING, ACTIVITY_RETURNING}" in evaluate
+    assert "and not self._charging_interruption_confirmed()" in evaluate
+    assert (
+        "activity not in {ACTIVITY_DOCKED, ACTIVITY_PAUSED} and not direct_handoff"
+        in evaluate
+    )
+
+
+def test_returning_without_completion_is_not_a_general_start_state() -> None:
+    evaluate = _method_source("_evaluate_locked")
+
+    # RETURNING is intentionally allowed only inside the completed_now handoff
+    # expression. It must never be added to the ordinary idle start-state set.
+    assert "activity not in {ACTIVITY_DOCKED, ACTIVITY_PAUSED} and not direct_handoff" in evaluate
+    assert "{ACTIVITY_DOCKED, ACTIVITY_PAUSED, ACTIVITY_RETURNING}" not in evaluate


### PR DESCRIPTION
Fixes the managed custom schedule behavior observed in the 2026-08-26 H215 field run.

The scheduler now persists the custom queue slot with the mow command so a completed slot advances correctly instead of selecting the first zone again. A confirmed zone completion may also dispatch the next queued zone while the mower is already in its normal RETURNING transition, avoiding an unnecessary dock round-trip. Notification-confirmed low-battery charging interruptions remain protected and continue through the existing charge/resume path.

Regression coverage verifies queue-slot persistence, RETURNING-only-after-completion handoff, and that RETURNING does not become a general scheduler start state.

Release: 0.4.3-beta45