### PR TITLE
Navimower 0.4.3-beta46: expose mower model to Map Card

### DIFF
--- a/.github/release-notes/0.4.3-beta46.md
+++ b/.github/release-notes/0.4.3-beta46.md
@@ -1,0 +1,7 @@
+title: Navimower 0.4.3-beta46
+
+## Map Card mower model metadata
+- Exposes the mower model directly on the existing `lawn_mower` entity so Navimower Map Card can select the correct mower artwork without reopening the full Home Assistant device registry discovery path.
+- Also exposes `vehicle_type` alongside the model for future model-family fallbacks.
+- Keeps the beta45 scheduler handoff behavior unchanged.
+- Adds regression coverage for the frontend metadata contract.

--- a/custom_components/navimower/lawn_mower.py
+++ b/custom_components/navimower/lawn_mower.py
@@ -170,6 +170,8 @@ class NavimowLawnMower(NavimowEntity, LawnMowerEntity):
         return {
             "state_code": data.get("state_code"),
             "state": data.get("state"),
+            "model": data.get("model") or self.coordinator.entry.data.get("model"),
+            "vehicle_type": self.coordinator.vehicle_type,
             "map_editing": state_code in MAP_EDIT_STATES,
             "current_zone": data.get("current_zone"),
             "current_physical_zone": data.get("current_physical_zone"),

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta45"
+  "version": "0.4.3-beta46"
 }

--- a/tests/test_map_card_mower_model_beta46.py
+++ b/tests/test_map_card_mower_model_beta46.py
@@ -1,0 +1,15 @@
+"""Regression coverage for Map Card mower artwork metadata."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MOWER = ROOT / "custom_components" / "navimower" / "lawn_mower.py"
+
+
+def test_mower_entity_exposes_model_without_device_registry_scan() -> None:
+    source = MOWER.read_text(encoding="utf-8")
+    assert '"model": data.get("model") or self.coordinator.entry.data.get("model")' in source
+    assert '"vehicle_type": self.coordinator.vehicle_type' in source
+    assert '"map_api_path": f"/api/navimower/map/{self.coordinator.entry.entry_id}"' in source


### PR DESCRIPTION
## Summary
- expose the mower model and vehicle type directly on the existing `lawn_mower` entity
- let Navimower Map Card choose model-specific artwork without reopening the full Home Assistant device-registry discovery path
- keep beta45 managed-schedule handoff behavior unchanged
- add regression coverage and prerelease notes for 0.4.3-beta46

This is a lightweight frontend metadata change only; it does not alter cloud/MQTT polling, pose selection, mowing control, scheduler execution or current-cycle history.