### PR TITLE
Navimower 0.4.3-beta49: regional login failure diagnostics

### DIFF
--- a/.github/release-notes/0.4.3-beta49.md
+++ b/.github/release-notes/0.4.3-beta49.md
@@ -1,0 +1,7 @@
+title: Navimower 0.4.3-beta49
+
+## Private-cloud regional login diagnostics
+- Log one clear warning only after all mower-cloud host candidates fail during private login.
+- Include the raw Passport-reported account region, the canonical integration region, and every attempted mower host with its vendor business code and description.
+- Keep credentials, tokens, device IDs and mower serial numbers out of the warning.
+- Preserve the existing regional fallback order and successful-host persistence; this release only improves failure visibility for cases such as US `ore` shared accounts.

--- a/custom_components/navimower/api/__init__.py
+++ b/custom_components/navimower/api/__init__.py
@@ -33,7 +33,10 @@ class NavimowCloudClient(_NavimowCloudClient):
 
     def __init__(self, *args: Any, host: str | None = None, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._region = canonical_region(getattr(self, "_region", None))
+        initial_region = getattr(self, "_region", None)
+        self._reported_region = str(initial_region or "")
+        self._region = canonical_region(initial_region)
+        self._mower_login_attempts: list[dict[str, str]] = []
         cached = _RESOLVED_MOWER_HOSTS.get(self.device_id)
         preferred = mower_hosts(self._region)
         selected = normalize_mower_host(host) or cached or (preferred[0] if preferred else None)
@@ -53,6 +56,16 @@ class NavimowCloudClient(_NavimowCloudClient):
     def host_source(self) -> str:
         """How the current private-cloud host was selected."""
         return self._host_source
+
+    @property
+    def reported_region(self) -> str:
+        """Raw account region reported by Passport before canonical aliases."""
+        return self._reported_region
+
+    @property
+    def mower_login_attempts(self) -> tuple[dict[str, str], ...]:
+        """Sanitized host/code/description rows from the latest mower login."""
+        return tuple(deepcopy(self._mower_login_attempts))
 
     @property
     def mower_host_candidates(self) -> tuple[str, ...]:
@@ -84,14 +97,18 @@ class NavimowCloudClient(_NavimowCloudClient):
     ) -> Tokens:
         """Resolve the private account region, then authenticate there."""
         self._tokens = _passport.login(email, password, region)
-        self._region = canonical_region(self._tokens.region or region)
+        reported = self._tokens.region or region
+        self._reported_region = str(reported or "")
+        self._region = canonical_region(reported)
         self._select_region_default()
         return self._tokens
 
     def refresh_session(self) -> Tokens:
         """Refresh passport tokens against the account's owning region."""
         self._tokens = _passport.refresh(self._tokens, self._region)
-        self._region = canonical_region(self._tokens.region or self._region)
+        reported = self._tokens.region or self._reported_region or self._region
+        self._reported_region = str(reported or "")
+        self._region = canonical_region(reported)
         self._select_region_default()
         return self._tokens
 
@@ -130,24 +147,46 @@ class NavimowCloudClient(_NavimowCloudClient):
         start_host = self._host
         start_source = self._host_source
         last_error: NavimowError | None = None
+        attempts: list[dict[str, str]] = []
+        self._mower_login_attempts = []
         for host in self.mower_host_candidates:
             self._host = host
             try:
                 uid = super().mower_login()
             except NavimowError as err:
                 last_error = err
+                row = {
+                    "host": host,
+                    "code": str(getattr(err, "code", "unknown")),
+                    "desc": str(getattr(err, "desc", "") or "")[:160],
+                }
+                attempts.append(row)
                 _LOGGER.debug(
                     "Navimow private mower host %s was not usable (code=%s)",
                     host,
-                    getattr(err, "code", "unknown"),
+                    row["code"],
                 )
                 continue
+            self._mower_login_attempts = attempts
             source = start_source if host == start_host else "region_probe"
             self.set_host(host, source=source)
             return uid
+        self._mower_login_attempts = attempts
         # Restore the original route so a caller can report stable diagnostics.
         self._host = start_host
         self._host_source = start_source
+        if attempts:
+            attempt_text = "; ".join(
+                f"{row['host']} (code={row['code']}, desc={row['desc'] or '-'})"
+                for row in attempts
+            )
+            _LOGGER.warning(
+                "Navimower private mower login failed: account_region=%s, "
+                "reported_region=%s, attempts=%s",
+                self._region,
+                self._reported_region or "unknown",
+                attempt_text,
+            )
         if last_error is not None:
             raise last_error
         raise NavimowError("no_host", "no private mower-cloud host responded")

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta48"
+  "version": "0.4.3-beta49"
 }

--- a/tests/test_v043_beta47.py
+++ b/tests/test_v043_beta47.py
@@ -1,16 +1,13 @@
 """Release-specific regression guards for Navimower 0.4.3-beta47."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta47_identity_and_release_notes() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta47"
+def test_beta47_release_notes_exist() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta47.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta47\n")
 

--- a/tests/test_v043_beta48.py
+++ b/tests/test_v043_beta48.py
@@ -1,16 +1,13 @@
 """Release-specific regression guards for Navimower 0.4.3-beta48."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta48_identity_and_release_notes() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta48"
+def test_beta48_release_notes_exist() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta48.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta48\n")
 

--- a/tests/test_v043_beta49.py
+++ b/tests/test_v043_beta49.py
@@ -1,0 +1,33 @@
+"""Release-specific regression guards for Navimower 0.4.3-beta49."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta49_identity_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta49"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta49.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta49\n")
+
+
+def test_beta49_failed_regional_login_logs_all_attempts_safely() -> None:
+    source = (COMPONENT / "api" / "__init__.py").read_text(encoding="utf-8")
+    assert "self._reported_region" in source
+    assert "self._mower_login_attempts" in source
+    assert '"Navimower private mower login failed: account_region=%s, "' in source
+    assert '"reported_region=%s, attempts=%s"' in source
+    assert "for host in self.mower_host_candidates" in source
+    assert '"host": host' in source
+    assert '"code": str(getattr(err, "code", "unknown"))' in source
+    assert '"desc": str(getattr(err, "desc", "") or "")[:160]' in source
+    warning_block = source[
+        source.index("        if attempts:"):
+        source.index("        if last_error is not None:", source.index("        if attempts:"))
+    ]
+    for secret in ("access_token", "refresh_token", "device_id", "vehicle_sn"):
+        assert secret not in warning_block


### PR DESCRIPTION
Adds safe regional private-cloud login diagnostics for failed setup/reauth cases. Records the raw Passport-reported region, canonical region, and each attempted mower host with vendor code/description only after every host fails. No credentials, tokens, device IDs, or mower serials are logged.

Also bumps the prerelease version, adds release notes, and adds regression guards.