### PR TITLE
Navimower 0.4.3-beta50: shared-account UID bootstrap

### DIFF
--- a/.github/release-notes/0.4.3-beta50.md
+++ b/.github/release-notes/0.4.3-beta50.md
@@ -1,0 +1,8 @@
+title: Navimower 0.4.3-beta50
+
+## Shared-account UID bootstrap
+- Adds a read-only fallback for private-cloud accounts that authenticate with Passport but do not receive a uid from `/user/user/login`.
+- Probes `/vehicle/vehicle/auth-list` with the authenticated access token and an empty uid across the existing bounded regional mower-host candidates.
+- If a shared mower entry exposes `auth_uid`/`authUid`, Navimower adopts that uid and the responding mower host, then continues through the normal authenticated flow.
+- If no shared mower has been accepted on the account yet, the fallback leaves the session unchanged and the original mower-login failure is still reported.
+- No mower commands or settings are written by this fallback.

--- a/custom_components/navimower/api/__init__.py
+++ b/custom_components/navimower/api/__init__.py
@@ -142,6 +142,59 @@ class NavimowCloudClient(_NavimowCloudClient):
         except urllib.error.URLError as err:
             raise NavimowError("network", str(err.reason)) from err
 
+    def bootstrap_shared_auth_list(self) -> list[dict[str, Any]]:
+        """Try the read-only auth list without a mower-login uid.
+
+        Some shared accounts can authenticate with Passport but do not receive a
+        uid from ``/user/user/login``. The auth-list response itself can carry the
+        shared account's ``auth_uid``. Probe the same bounded regional mower-host
+        set using the normal access token and an empty uid, learn that uid when
+        present, and retain the host that produced the shared vehicle list.
+        """
+        start_host = self._host
+        start_source = self._host_source
+        for host in self.mower_host_candidates:
+            self._host = host
+            try:
+                body = self._common_params(
+                    access_token=self._tokens.access_token,
+                    uid="",
+                )
+                result = self._raw("/vehicle/vehicle/auth-list", body)
+            except NavimowError as err:
+                _LOGGER.debug(
+                    "Navimow shared auth-list bootstrap host %s failed (code=%s)",
+                    host,
+                    getattr(err, "code", "unknown"),
+                )
+                continue
+            code = result.get("code") if isinstance(result, dict) else None
+            if code != _client.CODE_OK:
+                _LOGGER.debug(
+                    "Navimow shared auth-list bootstrap host %s returned code=%s",
+                    host,
+                    code,
+                )
+                continue
+            data = result.get("data") if isinstance(result, dict) else None
+            items = data if isinstance(data, list) else (data or {}).get("list") or []
+            if not items:
+                continue
+            uid = items[0].get("auth_uid") or items[0].get("authUid")
+            if not uid:
+                continue
+            self._uid = str(uid)
+            source = start_source if host == start_host else "shared_auth_list_probe"
+            self.set_host(host, source=source)
+            _LOGGER.info(
+                "Navimow shared account uid bootstrapped from auth-list on %s",
+                host,
+            )
+            return items
+        self._host = start_host
+        self._host_source = start_source
+        return []
+
     def mower_login(self) -> str:
         """Register the app/device identity and retain the first usable mower host."""
         start_host = self._host

--- a/custom_components/navimower/api/__init__.py
+++ b/custom_components/navimower/api/__init__.py
@@ -225,9 +225,12 @@ class NavimowCloudClient(_NavimowCloudClient):
             self.set_host(host, source=source)
             return uid
         self._mower_login_attempts = attempts
-        # Restore the original route so a caller can report stable diagnostics.
+        # Restore the original route before the read-only shared-account fallback.
         self._host = start_host
         self._host_source = start_source
+        shared_items = self.bootstrap_shared_auth_list()
+        if shared_items and self._uid:
+            return self._uid
         if attempts:
             attempt_text = "; ".join(
                 f"{row['host']} (code={row['code']}, desc={row['desc'] or '-'})"

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta49"
+  "version": "0.4.3-beta50"
 }

--- a/tests/test_v043_beta49.py
+++ b/tests/test_v043_beta49.py
@@ -1,16 +1,13 @@
 """Release-specific regression guards for Navimower 0.4.3-beta49."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta49_identity_and_release_notes() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta49"
+def test_beta49_release_notes_present() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta49.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta49\n")
 

--- a/tests/test_v043_beta50.py
+++ b/tests/test_v043_beta50.py
@@ -1,0 +1,29 @@
+"""Release-specific regression guards for Navimower 0.4.3-beta50."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta50_identity_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta50"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta50.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta50\n")
+
+
+def test_beta50_shared_auth_list_bootstrap_contract() -> None:
+    source = (COMPONENT / "api" / "__init__.py").read_text(encoding="utf-8")
+    assert "def bootstrap_shared_auth_list" in source
+    assert 'self._raw("/vehicle/vehicle/auth-list", body)' in source
+    assert 'access_token=self._tokens.access_token' in source
+    assert 'uid=""' in source
+    assert 'items[0].get("auth_uid") or items[0].get("authUid")' in source
+    assert 'source="shared_auth_list_probe"' in source
+    mower_login = source[source.index("    def mower_login"):source.index("    def errors", source.index("    def mower_login"))]
+    assert "shared_items = self.bootstrap_shared_auth_list()" in mower_login
+    assert "if shared_items and self._uid:" in mower_login
+    assert "return self._uid" in mower_login

--- a/tests/test_v043_beta50.py
+++ b/tests/test_v043_beta50.py
@@ -22,7 +22,8 @@ def test_beta50_shared_auth_list_bootstrap_contract() -> None:
     assert 'access_token=self._tokens.access_token' in source
     assert 'uid=""' in source
     assert 'items[0].get("auth_uid") or items[0].get("authUid")' in source
-    assert 'source="shared_auth_list_probe"' in source
+    assert '"shared_auth_list_probe"' in source
+    assert "self.set_host(host, source=source)" in source
     mower_login = source[source.index("    def mower_login"):source.index("    def errors", source.index("    def mower_login"))]
     assert "shared_items = self.bootstrap_shared_auth_list()" in mower_login
     assert "if shared_items and self._uid:" in mower_login


### PR DESCRIPTION
Adds a read-only shared-account fallback for cases where Passport login succeeds but `/user/user/login` returns no uid. The integration probes `/vehicle/vehicle/auth-list` with an empty uid across the bounded regional mower-host candidates, adopts `auth_uid`/`authUid` when a shared mower is visible, and continues through the normal authenticated flow. If no mower has been shared/accepted yet, the original mower-login failure remains unchanged.

Also bumps the prerelease version, adds release notes/regression coverage, and makes the beta49 release regression version-agnostic for future betas.