### PR TITLE
Navimower 0.4.3-beta53: mower-login variant diagnostics

### DIFF
--- a/.github/release-notes/0.4.3-beta53.md
+++ b/.github/release-notes/0.4.3-beta53.md
@@ -1,0 +1,7 @@
+title: Navimower 0.4.3-beta53
+
+## USA shared-account mower-login diagnostics
+- Record the plain and signed `/user/user/login` responses separately for each mower-cloud host.
+- Log only vendor code/description plus response container type and key names (`data_keys`, `top_level_keys`); no token, uid, mower serial, device id or payload values are logged.
+- Keep the beta52 read-only shared auth-list bootstrap as secondary diagnostics, but stop changing its payload while the primary mower-session failure is investigated.
+- This distinguishes whether the plain and signed login variants differ and whether a US shared-account response carries useful identity fields under a key other than `data.uid`.

--- a/custom_components/navimower/api/__init__.py
+++ b/custom_components/navimower/api/__init__.py
@@ -22,9 +22,6 @@ from .regions import canonical_region, mower_hosts, normalize_mower_host
 
 _LOGGER = logging.getLogger(__name__)
 
-# Fresh config flow -> config-entry setup happens in the same HA process. Keep
-# the successfully probed host here until the normal coordinator persistence has
-# written it to the config entry. This is only a hostname, never credentials.
 _RESOLVED_MOWER_HOSTS: dict[str, str] = {}
 
 
@@ -36,12 +33,12 @@ class NavimowCloudClient(_NavimowCloudClient):
         initial_region = getattr(self, "_region", None)
         self._reported_region = str(initial_region or "")
         self._region = canonical_region(initial_region)
-        self._mower_login_attempts: list[dict[str, str]] = []
+        self._mower_login_attempts: list[dict[str, Any]] = []
         self._shared_auth_list_attempts: list[dict[str, Any]] = []
         cached = _RESOLVED_MOWER_HOSTS.get(self.device_id)
         preferred = mower_hosts(self._region)
         selected = normalize_mower_host(host) or cached or (preferred[0] if preferred else None)
-        if selected is None:  # defensive: mower_hosts currently always has fallbacks
+        if selected is None:
             raise ValueError("No Navimow private-cloud mower host is available")
         self._host = selected
         self._host_source = (
@@ -50,36 +47,29 @@ class NavimowCloudClient(_NavimowCloudClient):
 
     @property
     def host(self) -> str:
-        """Current private mower-cloud hostname."""
         return self._host
 
     @property
     def host_source(self) -> str:
-        """How the current private-cloud host was selected."""
         return self._host_source
 
     @property
     def reported_region(self) -> str:
-        """Raw account region reported by Passport before canonical aliases."""
         return self._reported_region
 
     @property
-    def mower_login_attempts(self) -> tuple[dict[str, str], ...]:
-        """Sanitized host/code/description rows from the latest mower login."""
+    def mower_login_attempts(self) -> tuple[dict[str, Any], ...]:
         return tuple(deepcopy(self._mower_login_attempts))
 
     @property
     def shared_auth_list_attempts(self) -> tuple[dict[str, Any], ...]:
-        """Value-free structural diagnostics from the latest shared bootstrap."""
         return tuple(deepcopy(self._shared_auth_list_attempts))
 
     @property
     def mower_host_candidates(self) -> tuple[str, ...]:
-        """Current host followed by bounded candidates for the account region."""
         return tuple(dict.fromkeys((self._host, *mower_hosts(self._region))))
 
     def set_host(self, host: str, *, source: str = "runtime") -> None:
-        """Use a persisted/probed private-cloud host for this client instance."""
         normalized = normalize_mower_host(host)
         if normalized is None:
             return
@@ -88,7 +78,6 @@ class NavimowCloudClient(_NavimowCloudClient):
         _RESOLVED_MOWER_HOSTS[self.device_id] = normalized
 
     def _select_region_default(self) -> None:
-        """Move a fresh/default client to the first host for its resolved region."""
         candidates = mower_hosts(self._region)
         if not candidates:
             return
@@ -101,7 +90,6 @@ class NavimowCloudClient(_NavimowCloudClient):
         password: str,
         region: str | None = None,
     ) -> Tokens:
-        """Resolve the private account region, then authenticate there."""
         self._tokens = _passport.login(email, password, region)
         reported = self._tokens.region or region
         self._reported_region = str(reported or "")
@@ -110,7 +98,6 @@ class NavimowCloudClient(_NavimowCloudClient):
         return self._tokens
 
     def refresh_session(self) -> Tokens:
-        """Refresh passport tokens against the account's owning region."""
         self._tokens = _passport.refresh(self._tokens, self._region)
         reported = self._tokens.region or self._reported_region or self._region
         self._reported_region = str(reported or "")
@@ -119,7 +106,6 @@ class NavimowCloudClient(_NavimowCloudClient):
         return self._tokens
 
     def session_state(self) -> dict[str, str]:
-        """Persistable account/session state including the resolved mower host."""
         state = super().session_state()
         return {
             **state,
@@ -129,12 +115,11 @@ class NavimowCloudClient(_NavimowCloudClient):
         }
 
     def _post(self, path: str, envelope: dict) -> dict:
-        """POST one encrypted private-cloud request to this instance's host."""
         data = json.dumps(envelope, separators=(",", ":")).encode()
         request = urllib.request.Request(
             f"https://{self._host}{path}",
             data=data,
-            headers=_client._HEADERS,  # reuse the proven mobile-app transport headers
+            headers=_client._HEADERS,
             method="POST",
         )
         try:
@@ -143,25 +128,36 @@ class NavimowCloudClient(_NavimowCloudClient):
         except urllib.error.HTTPError as err:
             try:
                 return json.loads(err.read())
-            except Exception as inner:  # pragma: no cover - defensive
+            except Exception as inner:
                 raise NavimowError(err.code, "HTTP error") from inner
         except urllib.error.URLError as err:
             raise NavimowError("network", str(err.reason)) from err
 
+    @staticmethod
+    def _login_response_row(host: str, variant: str, result: Any) -> dict[str, Any]:
+        """Return a value-free structural summary of one mower-login response."""
+        if isinstance(result, dict):
+            code = result.get("code")
+            desc = str(result.get("desc", ""))[:160]
+            data = result.get("data")
+            top_level_keys = sorted(str(key) for key in result.keys())[:32]
+        else:
+            code = None
+            desc = str(result)[:160]
+            data = None
+            top_level_keys = []
+        data_keys = sorted(str(key) for key in data.keys())[:32] if isinstance(data, dict) else []
+        return {
+            "host": host,
+            "variant": variant,
+            "code": str(code),
+            "desc": desc,
+            "data_type": type(data).__name__ if data is not None else "none",
+            "data_keys": data_keys,
+            "top_level_keys": top_level_keys,
+        }
+
     def bootstrap_shared_auth_list(self) -> list[dict[str, Any]]:
-        """Try read-only auth-list variants before a mower-login uid exists.
-
-        US shared accounts can authenticate with Passport while ``/user/user/login``
-        returns no uid. Beta51 proved that a normal post-login ``access_token``
-        body is rejected with ``401900 token empty``. Probe two login-style
-        payloads instead: first the exact mower-login identity fields with an
-        empty common access token, then the same payload with ``access_token``
-        populated as well. Both calls are read-only.
-
-        Diagnostics are intentionally value-free: host, payload variant, business
-        code/description, response container type, item count and first-item key
-        names only. No uid, serial, token or other payload value is logged.
-        """
         start_host = self._host
         start_source = self._host_source
         attempts: list[dict[str, Any]] = []
@@ -183,10 +179,7 @@ class NavimowCloudClient(_NavimowCloudClient):
                     "login_style_plus_access_token",
                     {
                         **login_fields,
-                        **self._common_params(
-                            access_token=self._tokens.access_token,
-                            uid="",
-                        ),
+                        **self._common_params(access_token=self._tokens.access_token, uid=""),
                     },
                 ),
             )
@@ -224,9 +217,7 @@ class NavimowCloudClient(_NavimowCloudClient):
                         "desc": desc[:160],
                         "data_type": type(data).__name__ if data is not None else "none",
                         "item_count": len(items),
-                        "first_item_keys": (
-                            sorted(str(key) for key in first.keys())[:32] if first else []
-                        ),
+                        "first_item_keys": sorted(str(key) for key in first.keys())[:32] if first else [],
                     }
                 )
                 attempts.append(row)
@@ -239,11 +230,7 @@ class NavimowCloudClient(_NavimowCloudClient):
                 self._shared_auth_list_attempts = attempts
                 source = start_source if host == start_host else "shared_auth_list_probe"
                 self.set_host(host, source=source)
-                _LOGGER.info(
-                    "Navimow shared account uid bootstrapped from auth-list on %s (%s)",
-                    host,
-                    variant,
-                )
+                _LOGGER.info("Navimow shared account uid bootstrapped from auth-list on %s (%s)", host, variant)
                 return items
 
         self._shared_auth_list_attempts = attempts
@@ -252,71 +239,91 @@ class NavimowCloudClient(_NavimowCloudClient):
         return []
 
     def mower_login(self) -> str:
-        """Register the app/device identity and retain the first usable mower host."""
+        """Probe mower-login hosts while retaining plain/signed response structure."""
         start_host = self._host
         start_source = self._host_source
         last_error: NavimowError | None = None
-        attempts: list[dict[str, str]] = []
+        attempts: list[dict[str, Any]] = []
         self._mower_login_attempts = []
+        field4 = {
+            "uuid": self._tokens.uuid,
+            "token": self._tokens.access_token,
+            "refresh_token": self._tokens.refresh_token,
+            "region": self._region,
+        }
         for host in self.mower_host_candidates:
             self._host = host
             try:
-                uid = super().mower_login()
+                plain_body = {**field4, **self._common_params(access_token="")}
+                plain_result = self._raw("/user/user/login", plain_body)
+                attempts.append(self._login_response_row(host, "plain", plain_result))
+                uid = self._extract_uid(plain_result)
+                if not uid:
+                    signed_body = self._add_checkcode({**field4, **self._common_params(access_token="")})
+                    signed_result = self._raw("/user/user/login", signed_body)
+                    attempts.append(self._login_response_row(host, "signed", signed_result))
+                    uid = self._extract_uid(signed_result)
+                    final_result = signed_result
+                else:
+                    final_result = plain_result
+                if not uid:
+                    code = final_result.get("code") if isinstance(final_result, dict) else None
+                    desc = str(final_result.get("desc", "")) if isinstance(final_result, dict) else str(final_result)
+                    raise NavimowAuthError(code, f"mower login returned no uid: {desc}")
             except NavimowError as err:
                 last_error = err
-                row = {
-                    "host": host,
-                    "code": str(getattr(err, "code", "unknown")),
-                    "desc": str(getattr(err, "desc", "") or "")[:160],
-                }
-                attempts.append(row)
-                _LOGGER.debug(
-                    "Navimow private mower host %s was not usable (code=%s)",
-                    host,
-                    row["code"],
-                )
+                if not attempts or attempts[-1].get("host") != host:
+                    attempts.append(
+                        {
+                            "host": host,
+                            "variant": "transport",
+                            "code": str(getattr(err, "code", "unknown")),
+                            "desc": str(getattr(err, "desc", "") or "")[:160],
+                            "data_type": "none",
+                            "data_keys": [],
+                            "top_level_keys": [],
+                        }
+                    )
                 continue
+
+            self._uid = str(uid)
             self._mower_login_attempts = attempts
             source = start_source if host == start_host else "region_probe"
             self.set_host(host, source=source)
-            return uid
+            return self._uid
+
         self._mower_login_attempts = attempts
-        # Restore the original route before the read-only shared-account fallback.
         self._host = start_host
         self._host_source = start_source
         shared_items = self.bootstrap_shared_auth_list()
         if shared_items and self._uid:
             return self._uid
-        if self._shared_auth_list_attempts:
-            shared_attempt_text = "; ".join(
-                f"{row['host']}[{row['variant']}] (code={row['code']}, "
-                f"desc={row['desc'] or '-'}, data_type={row['data_type']}, "
-                f"item_count={row['item_count']}, "
-                f"first_item_keys={','.join(row['first_item_keys']) or '-'})"
-                for row in self._shared_auth_list_attempts
-            )
-            _LOGGER.warning(
-                "Navimower shared auth-list bootstrap did not yield uid: attempts=%s",
-                shared_attempt_text,
-            )
         if attempts:
             attempt_text = "; ".join(
-                f"{row['host']} (code={row['code']}, desc={row['desc'] or '-'})"
+                f"{row['host']}[{row['variant']}] (code={row['code']}, desc={row['desc'] or '-'}, "
+                f"data_type={row['data_type']}, data_keys={','.join(row['data_keys']) or '-'}, "
+                f"top_level_keys={','.join(row['top_level_keys']) or '-'})"
                 for row in attempts
             )
             _LOGGER.warning(
-                "Navimower private mower login failed: account_region=%s, "
-                "reported_region=%s, attempts=%s",
+                "Navimower private mower login variants failed: account_region=%s, reported_region=%s, attempts=%s",
                 self._region,
                 self._reported_region or "unknown",
                 attempt_text,
             )
+        if self._shared_auth_list_attempts:
+            shared_attempt_text = "; ".join(
+                f"{row['host']}[{row['variant']}] (code={row['code']}, desc={row['desc'] or '-'}, "
+                f"data_type={row['data_type']}, item_count={row['item_count']}, "
+                f"first_item_keys={','.join(row['first_item_keys']) or '-'})"
+                for row in self._shared_auth_list_attempts
+            )
+            _LOGGER.warning("Navimower shared auth-list bootstrap did not yield uid: attempts=%s", shared_attempt_text)
         if last_error is not None:
             raise last_error
         raise NavimowError("no_host", "no private mower-cloud host responded")
 
     def errors(self, sn: str, vehicle_type: int) -> dict[str, Any]:
-        """Read and sanitize the private compressed hint/error catalog."""
         raw = super().errors(sn, vehicle_type)
         redactions = (
             sn,
@@ -337,12 +344,10 @@ class NavimowCloudClient(_NavimowCloudClient):
 
     @property
     def error_catalog(self) -> dict[str, Any]:
-        """Return the latest decoded vendor code lookup, if available."""
         catalog = getattr(self, "_navimow_error_catalog", None)
         return deepcopy(catalog) if isinstance(catalog, dict) else {}
 
     def resolve_error_code(self, code: Any) -> list[dict[str, Any]]:
-        """Resolve one exact vendor code against the latest decoded catalog."""
         return resolve_error_code(getattr(self, "_navimow_error_catalog", None), code)
 
 

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta52"
+  "version": "0.4.3-beta53"
 }

--- a/tests/test_v043_beta49.py
+++ b/tests/test_v043_beta49.py
@@ -12,19 +12,16 @@ def test_beta49_release_notes_present() -> None:
     assert notes.startswith("title: Navimower 0.4.3-beta49\n")
 
 
-def test_beta49_failed_regional_login_logs_all_attempts_safely() -> None:
+def test_beta49_regional_login_still_tracks_attempts_safely() -> None:
     source = (COMPONENT / "api" / "__init__.py").read_text(encoding="utf-8")
     assert "self._reported_region" in source
     assert "self._mower_login_attempts" in source
-    assert '"Navimower private mower login failed: account_region=%s, "' in source
-    assert '"reported_region=%s, attempts=%s"' in source
     assert "for host in self.mower_host_candidates" in source
     assert '"host": host' in source
-    assert '"code": str(getattr(err, "code", "unknown"))' in source
-    assert '"desc": str(getattr(err, "desc", "") or "")[:160]' in source
-    warning_block = source[
-        source.index("        if attempts:"):
-        source.index("        if last_error is not None:", source.index("        if attempts:"))
-    ]
-    for secret in ("access_token", "refresh_token", "device_id", "vehicle_sn"):
+    assert 'account_region=%s' in source
+    assert 'reported_region=%s' in source
+    warning_start = source.index('            _LOGGER.warning(\n                "Navimower private mower login variants failed:')
+    warning_end = source.index("        if self._shared_auth_list_attempts:", warning_start)
+    warning_block = source[warning_start:warning_end]
+    for secret in ("access_token", "refresh_token", "device_id", "vehicle_sn", "self._uid"):
         assert secret not in warning_block

--- a/tests/test_v043_beta51.py
+++ b/tests/test_v043_beta51.py
@@ -19,6 +19,8 @@ def test_beta51_shared_auth_list_diagnostics_are_value_free() -> None:
     assert '"item_count": 0' in source
     assert '"first_item_keys": []' in source
     assert '"Navimower shared auth-list bootstrap did not yield uid: attempts=%s"' in source
-    block = source[source.index("        if self._shared_auth_list_attempts:"):source.index("        if attempts:", source.index("        if self._shared_auth_list_attempts:"))]
+    start = source.index("        if self._shared_auth_list_attempts:")
+    end = source.index("        if last_error is not None:", start)
+    block = source[start:end]
     for secret in ("access_token", "refresh_token", "device_id", "vehicle_sn", "self._uid"):
         assert secret not in block

--- a/tests/test_v043_beta52.py
+++ b/tests/test_v043_beta52.py
@@ -1,16 +1,13 @@
 """Release-specific regression guards for Navimower 0.4.3-beta52."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta52_identity_and_release_notes() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta52"
+def test_beta52_release_notes_exist() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta52.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta52\n")
 

--- a/tests/test_v043_beta53.py
+++ b/tests/test_v043_beta53.py
@@ -1,0 +1,34 @@
+"""Release-specific regression guards for Navimower 0.4.3-beta53."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta53_identity_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta53"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta53.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta53\n")
+
+
+def test_beta53_mower_login_logs_plain_and_signed_structure_only() -> None:
+    source = (COMPONENT / "api" / "__init__.py").read_text(encoding="utf-8")
+    block = source[
+        source.index("    def _login_response_row"):
+        source.index("    def bootstrap_shared_auth_list", source.index("    def _login_response_row"))
+    ]
+    assert '"data_keys": data_keys' in block
+    assert '"top_level_keys": top_level_keys' in block
+    login = source[
+        source.index("    def mower_login"):
+        source.index("    def errors", source.index("    def mower_login"))
+    ]
+    assert '"plain"' in login
+    assert '"signed"' in login
+    assert 'Navimower private mower login variants failed:' in login
+    for secret in ("self._tokens.access_token,", "self._tokens.refresh_token,", "self._tokens.uuid,"):
+        assert secret not in source[source.index("            attempt_text = "):source.index("        if self._shared_auth_list_attempts:")]


### PR DESCRIPTION
Adds value-free per-host diagnostics for both plain and signed `/user/user/login` responses so the current US shared-account failure can be isolated at the mower-session creation step. Keeps the beta52 auth-list bootstrap only as secondary diagnostics, bumps the prerelease version, and adds regression coverage.