### PR TITLE
Navimower 0.4.3-beta54: preserve raw US passport region

### DIFF
--- a/.github/release-notes/0.4.3-beta54.md
+++ b/.github/release-notes/0.4.3-beta54.md
@@ -1,0 +1,8 @@
+title: Navimower 0.4.3-beta54
+
+Fixes US private-cloud login by preserving the raw Passport region code for mower-cloud authentication.
+
+- US accounts report `ore` from Passport. Host routing still canonicalizes that to `us`, so the existing US/Oregon host selection remains unchanged.
+- `/user/user/login` now receives the raw Passport region (`ore`) instead of the routing alias (`us`). A live US account test in upstream PR #8 confirmed `us` returns `340001 / 4200` while `ore` returns `code=1` and a uid.
+- The raw Passport region is persisted with the private session so later refresh/re-auth after a restart continues to send the correct vendor region code.
+- Existing EU/Asia/China accounts are unaffected because their raw and routing region codes are already identical.

--- a/custom_components/navimower/api/__init__.py
+++ b/custom_components/navimower/api/__init__.py
@@ -109,7 +109,9 @@ class NavimowCloudClient(_NavimowCloudClient):
         state = super().session_state()
         return {
             **state,
-            "region": canonical_region(state.get("region") or self._region),
+            # Persist Passport's raw region (not the routing alias) so a future
+            # re-auth still sends e.g. `ore` to /user/user/login.
+            "region": self._tokens.region or self._reported_region or state.get("region") or self._region,
             "host": self._host,
             "host_source": self._host_source,
         }
@@ -162,11 +164,12 @@ class NavimowCloudClient(_NavimowCloudClient):
         start_source = self._host_source
         attempts: list[dict[str, Any]] = []
         self._shared_auth_list_attempts = []
+        raw_region = self._tokens.region or self._reported_region or self._region
         login_fields = {
             "uuid": self._tokens.uuid,
             "token": self._tokens.access_token,
             "refresh_token": self._tokens.refresh_token,
-            "region": self._region,
+            "region": raw_region,
         }
         for host in self.mower_host_candidates:
             self._host = host
@@ -245,11 +248,12 @@ class NavimowCloudClient(_NavimowCloudClient):
         last_error: NavimowError | None = None
         attempts: list[dict[str, Any]] = []
         self._mower_login_attempts = []
+        raw_region = self._tokens.region or self._reported_region or self._region
         field4 = {
             "uuid": self._tokens.uuid,
             "token": self._tokens.access_token,
             "refresh_token": self._tokens.refresh_token,
-            "region": self._region,
+            "region": raw_region,
         }
         for host in self.mower_host_candidates:
             self._host = host

--- a/custom_components/navimower/api/passport.py
+++ b/custom_components/navimower/api/passport.py
@@ -56,7 +56,12 @@ class PassportAuthError(PassportError):
 
 @dataclass
 class Tokens:
-    """Passport session tokens."""
+    """Passport session tokens.
+
+    ``region`` intentionally keeps the raw code returned by Passport. Host
+    selection canonicalizes aliases separately (for example ``ore -> us``), but
+    mower-cloud login must receive the vendor's raw code.
+    """
 
     access_token: str
     refresh_token: str
@@ -143,12 +148,12 @@ def _extract_tokens(data: dict) -> Tokens:
         access_token=str(data.get("access_token", "")),
         refresh_token=str(data.get("refresh_token", "")),
         uuid=str(data.get("uuid") or ""),
-        region=canonical_region(raw_region) if raw_region else "",
+        region=str(raw_region) if raw_region else "",
     )
 
 
 def lookup_region(email: str, hosts: tuple[str, ...] | None = None) -> str | None:
-    """Return the region that owns an account, without sending its password."""
+    """Return the raw region code that owns an account, without its password."""
     params = {"account": email, "device": DEVICE}
     last_transport_error: PassportError | None = None
     for host in hosts or ALL_PASSPORT_HOSTS:
@@ -160,10 +165,13 @@ def lookup_region(email: str, hosts: tuple[str, ...] | None = None) -> str | Non
             continue
         code = str(result.get("resultCode"))
         if code == _RESULT_OK:
-            raw_region = (result.get("data") or {}).get("region")
-            region = canonical_region(raw_region)
-            _LOGGER.debug("Navimow private account region resolved to %s", region)
-            return region
+            raw_region = str((result.get("data") or {}).get("region") or "")
+            _LOGGER.debug(
+                "Navimow private account region resolved: raw=%s routing=%s",
+                raw_region or "unknown",
+                canonical_region(raw_region),
+            )
+            return raw_region or None
         if code != RESULT_ACCOUNT_NOT_EXISTS:
             _LOGGER.debug("Navimow region lookup returned code %s", code)
     if last_transport_error is not None:
@@ -174,18 +182,18 @@ def lookup_region(email: str, hosts: tuple[str, ...] | None = None) -> str | Non
 
 
 def login(username: str, password: str, region: str | None = None) -> Tokens:
-    """Log in on the account's owning region and return refreshable tokens."""
+    """Log in on the account's owning region and keep its raw region code."""
     discovered = region is None
     if region is None:
-        resolved = lookup_region(username)
-        if resolved is None:
+        account_region = lookup_region(username)
+        if account_region is None:
             raise PassportAuthError(
                 RESULT_ACCOUNT_NOT_EXISTS,
                 "account not found on any known regional passport service",
             )
-        selected_region = canonical_region(resolved)
     else:
-        selected_region = canonical_region(region)
+        account_region = str(region)
+    selected_region = canonical_region(account_region)
     params = {"username": username, "password": password, "device": DEVICE}
     last_error: PassportAuthError | None = None
     last_transport_error: PassportError | None = None
@@ -199,8 +207,12 @@ def login(username: str, password: str, region: str | None = None) -> Tokens:
         code = str(result.get("resultCode"))
         if code == _RESULT_OK:
             tokens = _extract_tokens(result.get("data") or {})
-            tokens.region = canonical_region(tokens.region or selected_region)
-            _LOGGER.debug("Navimow passport login ok: %s", tokens.redacted())
+            tokens.region = tokens.region or account_region
+            _LOGGER.debug(
+                "Navimow passport login ok: %s routing_region=%s",
+                tokens.redacted(),
+                canonical_region(tokens.region),
+            )
             return tokens
         last_error = PassportAuthError(code, str(result.get("resultDesc", "")))
         # Wrong server is retryable. Wrong credentials or another business error
@@ -222,8 +234,9 @@ def login(username: str, password: str, region: str | None = None) -> Tokens:
 
 
 def refresh(tokens: Tokens, region: str | None = None) -> Tokens:
-    """Refresh passport tokens through the known owning region."""
-    selected_region = canonical_region(region or tokens.region or DEFAULT_REGION)
+    """Refresh tokens while retaining Passport's raw account region code."""
+    raw_region = tokens.region or str(region or DEFAULT_REGION)
+    selected_region = canonical_region(region or raw_region or DEFAULT_REGION)
     params = {
         "access_token": tokens.access_token,
         "refresh_token": tokens.refresh_token,
@@ -243,8 +256,12 @@ def refresh(tokens: Tokens, region: str | None = None) -> Tokens:
         if not new.uuid:
             new.uuid = tokens.uuid
         if not new.region:
-            new.region = selected_region
-        _LOGGER.debug("Navimow passport refresh ok: %s", new.redacted())
+            new.region = raw_region
+        _LOGGER.debug(
+            "Navimow passport refresh ok: %s routing_region=%s",
+            new.redacted(),
+            canonical_region(new.region),
+        )
         return new
     if last_error is not None:
         raise last_error

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta53"
+  "version": "0.4.3-beta54"
 }

--- a/tests/test_v043_beta52.py
+++ b/tests/test_v043_beta52.py
@@ -18,8 +18,9 @@ def test_beta52_shared_bootstrap_tries_login_style_credentials() -> None:
         source.index("    def bootstrap_shared_auth_list"):
         source.index("    def mower_login", source.index("    def bootstrap_shared_auth_list"))
     ]
-    for field in ('"uuid": self._tokens.uuid', '"token": self._tokens.access_token', '"refresh_token": self._tokens.refresh_token', '"region": self._region'):
+    for field in ('"uuid": self._tokens.uuid', '"token": self._tokens.access_token', '"refresh_token": self._tokens.refresh_token'):
         assert field in block
+    assert '"region":' in block
     assert '"login_style"' in block
     assert '"login_style_plus_access_token"' in block
     assert 'access_token="", uid=""' in block

--- a/tests/test_v043_beta53.py
+++ b/tests/test_v043_beta53.py
@@ -1,16 +1,13 @@
 """Release-specific regression guards for Navimower 0.4.3-beta53."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta53_identity_and_release_notes() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3-beta53"
+def test_beta53_release_notes_exist() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta53.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta53\n")
 
@@ -30,5 +27,6 @@ def test_beta53_mower_login_logs_plain_and_signed_structure_only() -> None:
     assert '"plain"' in login
     assert '"signed"' in login
     assert 'Navimower private mower login variants failed:' in login
+    warning = source[source.index("            attempt_text = "):source.index("        if self._shared_auth_list_attempts:")]
     for secret in ("self._tokens.access_token,", "self._tokens.refresh_token,", "self._tokens.uuid,"):
-        assert secret not in source[source.index("            attempt_text = "):source.index("        if self._shared_auth_list_attempts:")]
+        assert secret not in warning

--- a/tests/test_v043_beta54.py
+++ b/tests/test_v043_beta54.py
@@ -1,0 +1,31 @@
+"""Regression guards for Navimower 0.4.3-beta54."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta54_release_metadata() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta54"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta54.md").read_text(encoding="utf-8")
+    assert notes.startswith("title: Navimower 0.4.3-beta54\n")
+
+
+def test_beta54_passport_keeps_raw_region() -> None:
+    source = (COMPONENT / "api" / "passport.py").read_text(encoding="utf-8")
+    assert 'region=str(raw_region) if raw_region else ""' in source
+    assert 'return raw_region or None' in source
+    assert 'tokens.region = tokens.region or account_region' in source
+    assert 'new.region = raw_region' in source
+
+
+def test_beta54_mower_login_uses_raw_region_but_routes_canonically() -> None:
+    source = (COMPONENT / "api" / "__init__.py").read_text(encoding="utf-8")
+    assert 'self._region = canonical_region(reported)' in source
+    assert 'raw_region = self._tokens.region or self._reported_region or self._region' in source
+    assert '"region": raw_region' in source
+    assert '"region": self._tokens.region or self._reported_region or state.get("region") or self._region' in source


### PR DESCRIPTION
Fixes the US private-cloud mower login by keeping Passport's raw region code (`ore`) for `/user/user/login` while continuing to canonicalize it to `us` only for host routing. Persists the raw region for future refresh/re-auth, adds regression coverage, and cites the upstream live verification from navimow_pro PR #8.