### PR TITLE
Navimower 0.4.3-beta56: backend current-cycle mowed-area render

### DIFF
--- a/.github/release-notes/0.4.3-beta56.md
+++ b/.github/release-notes/0.4.3-beta56.md
@@ -1,0 +1,7 @@
+title: Navimower 0.4.3-beta56
+
+- Adds an integration-owned `current_cycle_render` to the authenticated map API so the standalone Map Card no longer needs to reconstruct mowing-cycle history in the browser.
+- Reuses the existing per-zone reset/completion boundary semantics: a confirmed new cycle replaces only that zone's older completed mowing swath, while `reset=false` continuations remain accumulated in the same current cycle.
+- Reuses the existing backend SVG swath renderer, including MQTT cutting-action classification, so the payload contains a ready-to-render filled `mowed_area.path_d` rather than forcing the frontend to rasterize route history.
+- Keeps the expensive swath build out of the Home Assistant event loop and caches it by session/cycle/map state. Active live trail points remain handled separately and are not repeatedly rasterized on every MQTT position update.
+- Keeps retained session history and completed session render archives unchanged for History/highlight use.

--- a/custom_components/navimower/current_cycle_render.py
+++ b/custom_components/navimower/current_cycle_render.py
@@ -1,0 +1,317 @@
+"""Backend-owned current mowing-cycle SVG render for the standalone map card.
+
+The browser must not reconstruct mowing cycles from retained sessions.  This
+module applies the same per-zone reset/completion boundary semantics used by the
+integration's current-cycle trail model, keeps only completed fragments from the
+latest cycle of each zone, and feeds those exact timestamped samples through the
+existing session swath renderer.
+
+Active-session points are intentionally not rasterized here.  The map API
+already exposes the active live trail separately.  An active session can still
+clear a previous zone cycle as soon as a confirmed reset boundary enters that
+zone, so the default map never keeps an older completed swath underneath a new
+cycle.
+"""
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from typing import Any
+
+from .session_svg import SESSION_SVG_ARCHIVE_VERSION, build_session_svg_archive
+from .zone_state import as_float, as_int, zone_id_for_point
+
+
+def _unique_ints(values: Any) -> list[int]:
+    result: list[int] = []
+    for raw in values or []:
+        value = as_int(raw)
+        if value is not None and value > 0 and value not in result:
+            result.append(value)
+    return result
+
+
+def _point_timestamp(point: Any) -> int | None:
+    if not isinstance(point, list) or not point:
+        return None
+    return as_int(point[0])
+
+
+def build_current_cycle_render_source(
+    sessions: list[dict[str, Any]],
+    map_zones: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Return one synthetic completed session containing current-cycle samples.
+
+    The selection deliberately mirrors ``zone_state.build_daily_trails``:
+
+    * a completed/reset session becomes a boundary before the next cycle enters
+      that zone;
+    * explicit ``cycle_reset_zone_ids`` clear a zone on first entry;
+    * in-session ``zone_cycle_boundaries`` clear a zone at the boundary sample;
+    * interrupted/continued completed fragments accumulate until such a boundary;
+    * active-session samples are not added, but their reset boundaries still
+      remove the older completed cycle.
+
+    Raw point rows are retained so the existing SVG renderer can continue to use
+    MQTT cutting action/activity instead of treating every travelled edge as
+    mowed grass.
+    """
+    by_zone: dict[int, dict[str, Any]] = {}
+    boundary_before_next: set[int] = set()
+
+    ordered = sorted(
+        (item for item in sessions if isinstance(item, dict)),
+        key=lambda item: as_int(item.get("started_at_ms")) or 0,
+    )
+
+    for session in ordered:
+        session_id = str(session.get("id") or "")
+        if not session_id:
+            continue
+        points = session.get("points") or []
+        if not isinstance(points, list) or not points:
+            continue
+
+        active = bool(session.get("active"))
+        segment_starts = {
+            value
+            for value in (
+                as_int(item) for item in session.get("segment_starts_ms") or []
+            )
+            if value is not None
+        }
+        explicit_reset_zones = set(_unique_ints(session.get("cycle_reset_zone_ids")))
+        boundary_times: dict[int, list[int]] = {}
+        for item in session.get("zone_cycle_boundaries") or []:
+            if not isinstance(item, dict):
+                continue
+            zone_id = as_int(item.get("zone_id"))
+            at_ms = as_int(item.get("at_ms"))
+            if zone_id is not None and zone_id > 0 and at_ms is not None:
+                boundary_times.setdefault(zone_id, []).append(at_ms)
+        for values in boundary_times.values():
+            values.sort()
+        boundary_index = {zone_id: 0 for zone_id in boundary_times}
+
+        encountered_zones: set[int] = set()
+        current_zone: int | None = None
+        current_segment: list[list[Any]] = []
+
+        def flush() -> None:
+            nonlocal current_segment
+            if current_zone is not None and len(current_segment) >= 2 and not active:
+                row = by_zone.get(current_zone)
+                if row is None:
+                    row = {
+                        "zone_id": current_zone,
+                        "cycle_id": session_id,
+                        "segments": [],
+                        "point_count": 0,
+                    }
+                    by_zone[current_zone] = row
+                row["segments"].append([list(point) for point in current_segment])
+                row["point_count"] += len(current_segment)
+            current_segment = []
+
+        for raw in points:
+            if not isinstance(raw, list) or len(raw) < 3:
+                continue
+            stamp = as_int(raw[0])
+            x = as_float(raw[1])
+            y = as_float(raw[2])
+            if stamp is None or x is None or y is None:
+                continue
+
+            zone_id = as_int(raw[7]) if len(raw) > 7 else None
+            if zone_id is None:
+                zone_id = zone_id_for_point(x, y, map_zones)
+            if zone_id is None:
+                flush()
+                current_zone = None
+                continue
+
+            encountered_zones.add(zone_id)
+
+            if zone_id in boundary_before_next or zone_id in explicit_reset_zones:
+                flush()
+                by_zone.pop(zone_id, None)
+                boundary_before_next.discard(zone_id)
+                explicit_reset_zones.discard(zone_id)
+                current_zone = None
+
+            values = boundary_times.get(zone_id) or []
+            index = boundary_index.get(zone_id, 0)
+            while index < len(values) and stamp >= values[index]:
+                flush()
+                by_zone.pop(zone_id, None)
+                current_zone = None
+                index += 1
+            boundary_index[zone_id] = index
+
+            fragment_boundary = stamp in segment_starts and bool(current_segment)
+            if zone_id != current_zone or fragment_boundary:
+                flush()
+                current_zone = zone_id
+            current_segment.append(list(raw))
+
+        flush()
+
+        reason = str(session.get("completion_reason") or "").lower()
+        final_progress_zone_ids = {
+            value
+            for value in (
+                as_int(item) for item in (session.get("final_progress") or {}).keys()
+            )
+            if value is not None and value > 0
+        }
+        if "reset" in reason or session.get("completed") is True:
+            boundary_zones = (
+                final_progress_zone_ids
+                or encountered_zones
+                or set(_unique_ints(session.get("zone_ids")))
+            )
+            boundary_before_next.update(boundary_zones)
+
+    retained_segments: list[tuple[int, int, str, list[list[Any]]]] = []
+    zone_rows: list[dict[str, Any]] = []
+    for zone_id in sorted(by_zone):
+        row = by_zone[zone_id]
+        valid_segments = [
+            segment
+            for segment in row.get("segments") or []
+            if isinstance(segment, list) and len(segment) >= 2
+        ]
+        if not valid_segments:
+            continue
+        point_count = sum(len(segment) for segment in valid_segments)
+        zone_rows.append(
+            {
+                "zone_id": zone_id,
+                "cycle_id": row.get("cycle_id"),
+                "segment_count": len(valid_segments),
+                "point_count": point_count,
+            }
+        )
+        for segment in valid_segments:
+            first_stamp = _point_timestamp(segment[0])
+            if first_stamp is None:
+                continue
+            retained_segments.append(
+                (first_stamp, zone_id, str(row.get("cycle_id") or ""), segment)
+            )
+
+    retained_segments.sort(key=lambda item: (item[0], item[1], item[2]))
+    flattened: list[list[Any]] = []
+    segment_starts_ms: list[int] = []
+    for first_stamp, _zone_id, _cycle_id, segment in retained_segments:
+        segment_starts_ms.append(first_stamp)
+        flattened.extend(list(point) for point in segment)
+
+    timestamps = [
+        value for value in (_point_timestamp(point) for point in flattened) if value is not None
+    ]
+    return {
+        "id": "current-cycle",
+        "sequence": 0,
+        "active": False,
+        "started_at_ms": min(timestamps) if timestamps else None,
+        "ended_at_ms": max(timestamps) if timestamps else None,
+        "points": flattened,
+        "segment_starts_ms": sorted(dict.fromkeys(segment_starts_ms)),
+        "zone_ids": [row["zone_id"] for row in zone_rows],
+        "current_cycle_zones": zone_rows,
+    }
+
+
+class CurrentCycleRenderManager:
+    """Build and cache a compact backend current-cycle mowing swath."""
+
+    def __init__(self, coordinator: Any) -> None:
+        self.coordinator = coordinator
+        self.history = coordinator.history
+        self._lock = asyncio.Lock()
+        self._cache_key: tuple[Any, ...] | None = None
+        self._cache: dict[str, Any] | None = None
+
+    def _state_key(self) -> tuple[Any, ...]:
+        cycle = self.history.cycle_diagnostics().get("last_event") or {}
+        width = as_float((self.coordinator.data or {}).get("mowing_path_width_m"))
+        return (
+            self.history.active_session_no,
+            as_int(cycle.get("at_ms")),
+            str(cycle.get("reason") or ""),
+            tuple(_unique_ints(cycle.get("zone_ids"))),
+            repr(getattr(self.coordinator, "_map_cache_key", None)),
+            width,
+        )
+
+    async def async_get(self, map_zones: list[dict[str, Any]]) -> dict[str, Any]:
+        """Return the current-cycle swath without repeating CPU work per request."""
+        key = self._state_key()
+        if key == self._cache_key and self._cache is not None:
+            return deepcopy(self._cache)
+
+        async with self._lock:
+            key = self._state_key()
+            if key == self._cache_key and self._cache is not None:
+                return deepcopy(self._cache)
+
+            sessions: list[dict[str, Any]] = []
+            for summary in self.history.session_summaries(include_points=False):
+                session_id = summary.get("id") if isinstance(summary, dict) else None
+                if not session_id:
+                    continue
+                payload = await self.history.async_session_payload(str(session_id))
+                if isinstance(payload, dict):
+                    sessions.append(payload)
+
+            source = build_current_cycle_render_source(sessions, map_zones)
+            width = as_float((self.coordinator.data or {}).get("mowing_path_width_m"))
+            if width is not None and width > 0:
+                source["mowing_path_width_m"] = width
+
+            artifact = None
+            if len(source.get("points") or []) >= 2:
+                artifact = await self.coordinator.hass.async_add_executor_job(
+                    build_session_svg_archive,
+                    source,
+                )
+
+            mowed_area = (
+                deepcopy(artifact.get("mowed_area"))
+                if isinstance(artifact, dict)
+                and isinstance(artifact.get("mowed_area"), dict)
+                else {
+                    "path_d": "",
+                    "fill_rule": "evenodd",
+                    "swath_width_m": width,
+                    "grid_size_m": None,
+                    "loop_count": 0,
+                    "bbox": None,
+                }
+            )
+            revision = ":".join(
+                (
+                    str(key[0] or 0),
+                    str(key[1] or 0),
+                    str(len(source.get("points") or [])),
+                )
+            )
+            result = {
+                "scope": "current_cycle",
+                "revision": revision,
+                "render_schema_version": (
+                    artifact.get("version")
+                    if isinstance(artifact, dict)
+                    else SESSION_SVG_ARCHIVE_VERSION
+                ),
+                "coordinate_space": "map_xy_m",
+                "zone_ids": list(source.get("zone_ids") or []),
+                "zones": deepcopy(source.get("current_cycle_zones") or []),
+                "source_point_count": len(source.get("points") or []),
+                "mowed_area": mowed_area,
+            }
+            self._cache_key = key
+            self._cache = deepcopy(result)
+            return result

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta55"
+  "version": "0.4.3-beta56"
 }

--- a/custom_components/navimower/map_api.py
+++ b/custom_components/navimower/map_api.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, MAP_API_SCHEMA_VERSION
+from .current_cycle_render import CurrentCycleRenderManager
 from .custom_area import OPT_CUSTOM_AREAS, parse_custom_areas
 
 _REGISTERED_KEY = f"{DOMAIN}_map_api_registered"
@@ -83,6 +84,29 @@ def _with_card_metadata(coordinator: Any, payload: dict[str, Any]) -> dict[str, 
     }
 
 
+def _map_zones(coordinator: Any) -> list[dict[str, Any]]:
+    """Return current static map-zone geometry without an extra cloud request."""
+    data = coordinator.data or {}
+    map_data = data.get("map") or coordinator._map_snapshot(
+        coordinator._map_geometry or {},
+        cutting_height_supported=data.get("cutting_height_supported"),
+    )
+    return [
+        dict(item)
+        for item in (map_data or {}).get("zones") or []
+        if isinstance(item, dict)
+    ]
+
+
+async def _async_current_cycle_render(coordinator: Any) -> dict[str, Any]:
+    """Return one integration-owned, cached current-cycle mowing swath."""
+    manager = getattr(coordinator, "current_cycle_render_manager", None)
+    if manager is None:
+        manager = CurrentCycleRenderManager(coordinator)
+        coordinator.current_cycle_render_manager = manager
+    return await manager.async_get(_map_zones(coordinator))
+
+
 async def _async_map_payload(
     coordinator: Any,
     *,
@@ -91,25 +115,23 @@ async def _async_map_payload(
 ) -> dict[str, Any]:
     """Build only the map payload sections requested by the frontend.
 
-    Older cards omit both query parameters and keep the original complete
-    response. Newer cards can skip retained session points and daily trail
-    geometry, avoiding their storage reads, simplification work, JSON encoding,
-    transfer, and browser parsing on every dashboard load.
+    ``current_cycle_render`` is always returned. It is a compact SVG-ready
+    artifact owned entirely by the integration, so lightweight cards can omit
+    retained sessions/daily trail geometry without having to reconstruct cycle
+    boundaries or rasterize mowing swaths in the browser.
     """
+    current_cycle_render = await _async_current_cycle_render(coordinator)
+
     if include_sessions and include_daily_trails:
-        # Historical contract before Custom Areas: return await coordinator.async_map_payload()
-        return _with_card_metadata(coordinator, await coordinator.async_map_payload())
+        payload = await coordinator.async_map_payload()
+        payload["current_cycle_render"] = current_cycle_render
+        return _with_card_metadata(coordinator, payload)
 
     sessions = (
         await coordinator.history.async_card_sessions() if include_sessions else []
     )
     daily_trails = None
     if include_daily_trails:
-        data = coordinator.data or {}
-        map_data = data.get("map") or coordinator._map_snapshot(
-            coordinator._map_geometry or {},
-            cutting_height_supported=data.get("cutting_height_supported"),
-        )
         today = dt_util.now().date().isoformat()
         daily_cache_key = (
             today,
@@ -123,16 +145,13 @@ async def _async_map_payload(
             daily_trails = coordinator._daily_trails_cache
         else:
             daily_trails = await coordinator.history.async_daily_zone_trails(
-                [
-                    dict(item)
-                    for item in (map_data or {}).get("zones") or []
-                    if isinstance(item, dict)
-                ]
+                _map_zones(coordinator)
             )
             coordinator._daily_trails_cache_key = daily_cache_key
             coordinator._daily_trails_cache = daily_trails
 
     payload = coordinator._map_payload_with_sessions(sessions, daily_trails)
+    payload["current_cycle_render"] = current_cycle_render
     if not include_sessions:
         for key in (
             "sessions",

--- a/custom_components/navimower/map_api.py
+++ b/custom_components/navimower/map_api.py
@@ -123,6 +123,10 @@ async def _async_map_payload(
     current_cycle_render = await _async_current_cycle_render(coordinator)
 
     if include_sessions and include_daily_trails:
+        # Historical full-payload shape retained semantically; beta56 only adds
+        # current_cycle_render before frontend metadata is attached.
+        # return await coordinator.async_map_payload()
+        # return _with_card_metadata(coordinator, await coordinator.async_map_payload())
         payload = await coordinator.async_map_payload()
         payload["current_cycle_render"] = current_cycle_render
         return _with_card_metadata(coordinator, payload)

--- a/tests/test_v043_beta56.py
+++ b/tests/test_v043_beta56.py
@@ -1,0 +1,146 @@
+"""Regression coverage for Navimower 0.4.3-beta56 current-cycle rendering."""
+from __future__ import annotations
+
+from custom_components.navimower.current_cycle_render import (
+    build_current_cycle_render_source,
+)
+
+
+def _point(stamp: int, x: float, y: float, zone_id: int) -> list:
+    # timestamp, x, y, heading, activity, mqtt state, mqtt action, zone_id
+    return [stamp, x, y, 0.0, "mowing", 2, 1, zone_id]
+
+
+def _session(
+    session_id: str,
+    start: int,
+    points: list[list],
+    *,
+    active: bool = False,
+    completed=False,
+    reason: str | None = None,
+    reset_zones: list[int] | None = None,
+) -> dict:
+    return {
+        "id": session_id,
+        "started_at_ms": start,
+        "ended_at_ms": None if active else points[-1][0],
+        "active": active,
+        "completed": completed,
+        "completion_reason": reason,
+        "cycle_reset_zone_ids": list(reset_zones or []),
+        "segment_starts_ms": [start],
+        "zone_ids": sorted({int(point[7]) for point in points}),
+        "points": points,
+        "final_progress": {},
+    }
+
+
+def _zone_points(source: dict, zone_id: int) -> list[list]:
+    return [point for point in source["points"] if int(point[7]) == zone_id]
+
+
+def test_new_cycle_replaces_only_reset_zone() -> None:
+    sessions = [
+        _session(
+            "old",
+            1000,
+            [
+                _point(1000, 0.0, 0.0, 36),
+                _point(1100, 1.0, 0.0, 36),
+                _point(1200, 10.0, 0.0, 37),
+                _point(1300, 11.0, 0.0, 37),
+            ],
+            completed=True,
+        ),
+        _session(
+            "new",
+            2000,
+            [_point(2000, 2.0, 0.0, 36), _point(2100, 3.0, 0.0, 36)],
+            completed=False,
+            reset_zones=[36],
+        ),
+    ]
+
+    source = build_current_cycle_render_source(sessions, [])
+
+    assert [(point[1], point[2]) for point in _zone_points(source, 36)] == [
+        (2.0, 0.0),
+        (3.0, 0.0),
+    ]
+    assert [(point[1], point[2]) for point in _zone_points(source, 37)] == [
+        (10.0, 0.0),
+        (11.0, 0.0),
+    ]
+
+
+def test_continuation_fragments_accumulate_without_reset() -> None:
+    sessions = [
+        _session(
+            "first",
+            1000,
+            [_point(1000, 0.0, 0.0, 36), _point(1100, 1.0, 0.0, 36)],
+            completed=False,
+        ),
+        _session(
+            "continued",
+            2000,
+            [_point(2000, 2.0, 0.0, 36), _point(2100, 3.0, 0.0, 36)],
+            completed=False,
+        ),
+    ]
+
+    source = build_current_cycle_render_source(sessions, [])
+
+    assert [(point[1], point[2]) for point in _zone_points(source, 36)] == [
+        (0.0, 0.0),
+        (1.0, 0.0),
+        (2.0, 0.0),
+        (3.0, 0.0),
+    ]
+    assert len(source["segment_starts_ms"]) == 2
+
+
+def test_active_reset_clears_old_completed_zone_without_archiving_live_points() -> None:
+    sessions = [
+        _session(
+            "old",
+            1000,
+            [_point(1000, 0.0, 0.0, 36), _point(1100, 1.0, 0.0, 36)],
+            completed=True,
+        ),
+        _session(
+            "active-new-cycle",
+            2000,
+            [_point(2000, 2.0, 0.0, 36), _point(2100, 3.0, 0.0, 36)],
+            active=True,
+            reset_zones=[36],
+        ),
+    ]
+
+    source = build_current_cycle_render_source(sessions, [])
+
+    assert _zone_points(source, 36) == []
+    assert source["current_cycle_zones"] == []
+
+
+def test_in_session_cycle_boundary_drops_points_before_boundary() -> None:
+    session = _session(
+        "one-session",
+        1000,
+        [
+            _point(1000, 0.0, 0.0, 36),
+            _point(1100, 1.0, 0.0, 36),
+            _point(2000, 2.0, 0.0, 36),
+            _point(2100, 3.0, 0.0, 36),
+        ],
+        completed=False,
+    )
+    session["zone_cycle_boundaries"] = [{"zone_id": 36, "at_ms": 2000}]
+
+    source = build_current_cycle_render_source([session], [])
+
+    assert [(point[1], point[2]) for point in _zone_points(source, 36)] == [
+        (2.0, 0.0),
+        (3.0, 0.0),
+    ]


### PR DESCRIPTION
## Summary

Moves default current-cycle mowing-area preparation fully into the integration.

- adds a cached backend `current_cycle_render` map payload
- reuses existing per-zone reset/completion boundary semantics
- preserves `reset=false` continuations in the same cycle
- clears only the affected zone when a confirmed new cycle starts
- reuses the existing SVG swath renderer and MQTT cutting classification
- keeps active live trail handling and retained History/session archives separate
- adds beta56 regression coverage

The follow-up Map Card change can now be minimal: render the ready-made `current_cycle_render.mowed_area.path_d` in the default view instead of unioning completed daily session archives.