### PR TITLE
Navimower 0.4.3-beta57: weather and Do Not Disturb naming

### DIFF
--- a/.github/release-notes/0.4.3-beta57.md
+++ b/.github/release-notes/0.4.3-beta57.md
@@ -1,0 +1,7 @@
+title: Navimower 0.4.3-beta57
+
+- Standardizes Home Assistant display names for weather-adaptive mowing controls to match their actual Navimow app/vendor semantics.
+- Renames the forecast-related controls to **Rain forecast** and **Rain forecast sensitivity**, and uses **Rain delay** / **Rain delay duration** for the two post-rain controls.
+- Uses **Frost detection** / **Frost delay**, **Snow detection** / **Snow delay**, **Max temp detection** / **Max temperature**, and **Wind detection** for the matching vendor settings.
+- Keeps **Do not disturb** for the toggle and renames the period endpoints to **Do not disturb start** and **Do not disturb end**.
+- Keeps all vendor keys, Navimower entity keys, unique IDs, read/write mappings and setting behavior unchanged; this release changes only the default Home Assistant display names.

--- a/custom_components/navimower/entity.py
+++ b/custom_components/navimower/entity.py
@@ -12,6 +12,29 @@ from .const import DOMAIN, MANUFACTURER
 from .coordinator import NavimowCoordinator
 
 
+# Canonical English display names for vendor settings whose historical entity
+# keys no longer describe the app-facing feature precisely. Keep the entity key
+# and unique ID stable; only the default Home Assistant display name changes.
+ENTITY_NAME_OVERRIDES: dict[str, str] = {
+    "frost_delay": "Frost detection",
+    "frost_delay_until": "Frost delay",
+    "high_temp_delay": "Max temp detection",
+    "maximum_mowing_temperature": "Max temperature",
+    "rain_detection": "Rain detection",
+    "rain_sensor": "Rain sensor",
+    "weather_rain": "Rain forecast",
+    "weather_sensitivity": "Rain forecast sensitivity",
+    "rain_delay_mode": "Rain delay",
+    "rain_delay_time": "Rain delay duration",
+    "snow_delay": "Snow detection",
+    "snow_delay_time": "Snow delay",
+    "storm_delay": "Wind detection",
+    "do_not_disturb": "Do not disturb",
+    "quiet_period_start": "Do not disturb start",
+    "quiet_period_end": "Do not disturb end",
+}
+
+
 class NavimowEntity(CoordinatorEntity[NavimowCoordinator]):
     """Base class: all entities live under one HA device."""
 
@@ -21,6 +44,8 @@ class NavimowEntity(CoordinatorEntity[NavimowCoordinator]):
         super().__init__(coordinator)
         self._sn = coordinator.sn
         self._attr_unique_id = f"{self._sn}_{key}"
+        if name := ENTITY_NAME_OVERRIDES.get(key):
+            self._attr_name = name
 
     @property
     def data(self) -> dict:

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3-beta56"
+  "version": "0.4.3-beta57"
 }

--- a/tests/test_v043_beta57.py
+++ b/tests/test_v043_beta57.py
@@ -1,0 +1,57 @@
+"""Regression coverage for 0.4.3-beta57 entity display names."""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENTITY_SOURCE = ROOT / "custom_components" / "navimower" / "entity.py"
+MANIFEST = ROOT / "custom_components" / "navimower" / "manifest.json"
+
+EXPECTED_NAMES = {
+    "frost_delay": "Frost detection",
+    "frost_delay_until": "Frost delay",
+    "high_temp_delay": "Max temp detection",
+    "maximum_mowing_temperature": "Max temperature",
+    "rain_detection": "Rain detection",
+    "rain_sensor": "Rain sensor",
+    "weather_rain": "Rain forecast",
+    "weather_sensitivity": "Rain forecast sensitivity",
+    "rain_delay_mode": "Rain delay",
+    "rain_delay_time": "Rain delay duration",
+    "snow_delay": "Snow detection",
+    "snow_delay_time": "Snow delay",
+    "storm_delay": "Wind detection",
+    "do_not_disturb": "Do not disturb",
+    "quiet_period_start": "Do not disturb start",
+    "quiet_period_end": "Do not disturb end",
+}
+
+
+def _entity_name_overrides() -> dict[str, str]:
+    module = ast.parse(ENTITY_SOURCE.read_text(encoding="utf-8"))
+    for node in module.body:
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.target.id == "ENTITY_NAME_OVERRIDES":
+                value = ast.literal_eval(node.value)
+                assert isinstance(value, dict)
+                return value
+    raise AssertionError("ENTITY_NAME_OVERRIDES not found")
+
+
+def test_beta57_canonical_weather_and_dnd_names() -> None:
+    assert _entity_name_overrides() == EXPECTED_NAMES
+
+
+def test_beta57_names_do_not_change_unique_id_construction() -> None:
+    source = ENTITY_SOURCE.read_text(encoding="utf-8")
+    assert 'self._attr_unique_id = f"{self._sn}_{key}"' in source
+    assert "ENTITY_NAME_OVERRIDES.get(key)" in source
+
+
+def test_beta57_manifest_version() -> None:
+    import json
+
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.3-beta57"


### PR DESCRIPTION
## Summary

- standardize weather-adaptive setting display names using the agreed Navimow terminology
- rename forecast controls to Rain forecast / Rain forecast sensitivity
- use Frost detection / Frost delay, Snow detection / Snow delay, Max temp detection / Max temperature, Wind detection, Rain delay / Rain delay duration
- keep Do not disturb and rename its period endpoints to Do not disturb start / Do not disturb end
- preserve vendor keys, entity keys, unique IDs and all read/write behavior
- add beta57 naming regression coverage and release notes
