### PR TITLE
Navimower 0.4.4-beta1: map georeference foundation

### DIFF
--- a/.github/release-notes/0.4.4-beta1.md
+++ b/.github/release-notes/0.4.4-beta1.md
@@ -1,0 +1,14 @@
+title: Navimower 0.4.4-beta1
+
+## Map georeference foundation
+
+- Retains the vendor map georeference metadata that was previously discarded after map decoding.
+- Normalizes the mower-local map reference point, WGS84 reference coordinate and map rotation into a small Navimower-owned `georeference` schema. Optional origin and geographic bounds are retained when the map provides them.
+- Exposes the normalized georeference through the authenticated Map API both as `map.georeference` and top-level `georeference`, providing the backend foundation for future multi-mower/site and geographic basemap views.
+- Keeps dense official MQTT local X/Y as the live mower-position source. Geographic coordinates are not polled more often for map rendering.
+- Passively validates the map transform against the existing private-cloud location response, which reports local `posture_x/posture_y` and latitude/longitude together. No additional cloud request is made for validation.
+- Reports validation as `validated`, `mismatch` or `unavailable`; the initial consistency limit is 2 metres. Validation metadata includes the observed transform error without exposing any additional Home Assistant entities.
+- Existing v0.4.3 cached map geometry remains available immediately after upgrade. A single normal map re-decode is forced after startup when the cached map has no georeference so the new metadata can be populated.
+- The existing native Home Assistant GPS `device_tracker` behavior is unchanged.
+
+This beta adds the integration-side georeference contract only. Multi-mower rendering and geographic basemap UI are intentionally deferred to the Navimower Map Card work that follows field validation with multiple mowers.

--- a/custom_components/navimower/coordinator_semantics.py
+++ b/custom_components/navimower/coordinator_semantics.py
@@ -3,8 +3,20 @@ from __future__ import annotations
 
 from typing import Any
 
-from .coordinator import NavimowCoordinator as _BaseNavimowCoordinator
-from .coordinator import state_store
+from .api import NavimowAuthError, NavimowError
+from .coordinator import (
+    NavimowCoordinator as _BaseNavimowCoordinator,
+    _parse_map_detail,
+    _parse_map_detail_plain,
+    _points_xy,
+    state_store,
+)
+from .georeference import (
+    georeference_from_compressed_map_detail,
+    georeference_from_plain_map_detail,
+    validate_georeference,
+)
+from .map_identifiers import resolve_map_identifiers
 
 
 def _valid_map_version(value: Any) -> bool:
@@ -14,6 +26,15 @@ def _valid_map_version(value: Any) -> bool:
 
 class NavimowCoordinator(_BaseNavimowCoordinator):
     """Coordinator with strict mowing timestamps and revision-aware map refresh."""
+
+    async def async_load_persistent_state(self) -> None:
+        """Restore state and force one map refresh for pre-georeference caches."""
+        await super().async_load_persistent_state()
+        if self._map_geometry is not None and not self._map_geometry.get("georeference"):
+            # v0.4.3 caches contain perfectly usable local geometry but not the
+            # WGS84 tie point needed by multi-mower/site views. Keep displaying
+            # the cached map immediately, then re-decode it on the first poll.
+            self._map_cache_key = None
 
     def _build_zone_details(
         self,
@@ -46,8 +67,8 @@ class NavimowCoordinator(_BaseNavimowCoordinator):
         Location/map-list have much longer idle TTLs than index2. During map editing
         index2.mapVersion can therefore advance while the cached geometry still
         describes the previous revision. Force location + map-list due and clear
-        the geometry key when a real version change is observed so the base
-        coordinator downloads the new map detail immediately in this poll cycle.
+        the geometry key when a real version change is observed so the coordinator
+        downloads the new map detail immediately in this poll cycle.
         """
         previous_version = None
         if key == "index2":
@@ -80,19 +101,80 @@ class NavimowCoordinator(_BaseNavimowCoordinator):
         return success
 
     def _maybe_fetch_map(self, raw: dict[str, Any]) -> None:
-        """Attach index2.mapVersion to freshly downloaded map geometry."""
-        previous_geometry = self._map_geometry
-        super()._maybe_fetch_map(raw)
-        if self._map_geometry is None or self._map_geometry is previous_geometry:
+        """Decode map geometry plus its WGS84 georeference in one cloud fetch."""
+        location = raw.get("location") or {}
+        map_id, map_base_id, edit_time = resolve_map_identifiers(
+            location, raw.get("map_list")
+        )
+        if map_id is None or map_base_id is None:
             return
+
+        key = (str(map_id), str(map_base_id), str(edit_time))
+        if self._map_geometry is not None and self._map_cache_key == key:
+            return
+
+        geometry: dict[str, Any] | None = None
+        georeference: dict[str, Any] | None = None
+        try:
+            plain = self.client.map_detail_plain(
+                self.sn, str(map_id), str(map_base_id)
+            )
+            geometry = _parse_map_detail_plain(plain)
+            georeference = georeference_from_plain_map_detail(plain)
+        except NavimowAuthError:
+            raise
+        except NavimowError:
+            geometry = None
+
+        if geometry is None:
+            try:
+                blob = self.client.map_detail(
+                    self.sn, str(map_id), str(map_base_id)
+                )
+                geometry = _parse_map_detail(blob)
+                georeference = georeference_from_compressed_map_detail(blob)
+            except NavimowAuthError:
+                raise
+            except NavimowError:
+                return
+        if geometry is None:
+            return
+
+        geometry["map_id"] = str(map_id)
+        geometry["map_base_id"] = str(map_base_id)
+        geometry["edit_time"] = str(edit_time or "")
+        geometry["revision"] = "|".join(key)
+        if georeference is not None:
+            geometry["georeference"] = georeference
 
         index2 = raw.get("index2")
         map_version = index2.get("mapVersion") if isinstance(index2, dict) else None
-        if not _valid_map_version(map_version):
-            return
-        self._map_geometry["map_version"] = str(map_version)
-        base_revision = str(self._map_geometry.get("revision") or "")
-        self._map_geometry["revision"] = f"{base_revision}|v:{map_version}"
+        if _valid_map_version(map_version):
+            geometry["map_version"] = str(map_version)
+            geometry["revision"] = f"{geometry['revision']}|v:{map_version}"
+
+        # Preserve the existing optional station-map behavior. This geometry is
+        # in a docking-local frame and is intentionally not georeferenced.
+        try:
+            station_raw = self.client.station_map(
+                self.sn, str(map_id), str(map_base_id)
+            )
+            pts = _points_xy((station_raw or {}).get("points"))
+            if pts:
+                geometry["station_map"] = {
+                    "points": pts,
+                    "start_from_pile": bool(
+                        (station_raw or {}).get("start_from_pile")
+                    ),
+                }
+        except NavimowAuthError:
+            raise
+        except NavimowError:
+            pass
+
+        self._map_geometry = geometry
+        self._map_cache_key = key
+        self._map_dirty = True
 
     @staticmethod
     def _map_snapshot(
@@ -100,13 +182,46 @@ class NavimowCoordinator(_BaseNavimowCoordinator):
         *,
         cutting_height_supported: bool | None = None,
     ) -> dict[str, Any]:
-        """Expose the vendor map revision alongside the existing geometry key."""
+        """Expose map revision and normalized georeference to the Map API."""
         snapshot = _BaseNavimowCoordinator._map_snapshot(
             map_geometry,
             cutting_height_supported=cutting_height_supported,
         )
         snapshot["map_version"] = map_geometry.get("map_version")
+        georeference = map_geometry.get("georeference")
+        snapshot["georeference"] = (
+            dict(georeference) if isinstance(georeference, dict) else None
+        )
         return snapshot
+
+    def _parse(self, raw: dict[str, Any]) -> dict[str, Any]:
+        """Attach passive XY/GPS validation to the normalized georeference."""
+        snapshot = super()._parse(raw)
+        base_georeference = (self._map_geometry or {}).get("georeference")
+        georeference = validate_georeference(
+            base_georeference,
+            raw.get("location"),
+        )
+        snapshot["georeference"] = georeference
+        map_data = snapshot.get("map")
+        if isinstance(map_data, dict):
+            map_data = dict(map_data)
+            map_data["georeference"] = georeference
+            snapshot["map"] = map_data
+        return snapshot
+
+    def _map_payload_with_sessions(
+        self,
+        sessions: list[dict[str, Any]],
+        daily_trails: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Expose georeference both with the map and as small top-level metadata."""
+        payload = super()._map_payload_with_sessions(sessions, daily_trails)
+        map_data = payload.get("map") or {}
+        payload["georeference"] = (
+            map_data.get("georeference") if isinstance(map_data, dict) else None
+        )
+        return payload
 
 
 __all__ = ["NavimowCoordinator", "state_store"]

--- a/custom_components/navimower/georeference.py
+++ b/custom_components/navimower/georeference.py
@@ -1,0 +1,259 @@
+"""Map georeference helpers for Navimower.
+
+The mower map uses its own local X/Y frame. Vendor map metadata ties that frame
+to WGS84 through one local reference point plus ``map_north_offset``.  Keep the
+vendor details behind a small Navimower-owned schema so frontends do not need to
+understand private-cloud field names.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import json
+import math
+from typing import Any
+
+_EARTH_RADIUS_M = 6378137.0
+_GEOREFERENCE_SCHEMA_VERSION = 1
+_DEFAULT_VALIDATION_LIMIT_M = 2.0
+
+
+def _float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return parsed
+
+
+def _xy(value: Any) -> tuple[float, float] | None:
+    if not isinstance(value, (list, tuple)) or len(value) < 2:
+        return None
+    x, y = _float(value[0]), _float(value[1])
+    return (x, y) if x is not None and y is not None else None
+
+
+def _gps(value: Any) -> tuple[float, float] | None:
+    """Return vendor [longitude, latitude] as (latitude, longitude)."""
+    pair = _xy(value)
+    if pair is None:
+        return None
+    longitude, latitude = pair
+    if not (-90.0 <= latitude <= 90.0 and -180.0 <= longitude <= 180.0):
+        return None
+    return latitude, longitude
+
+
+def _gps_dict(value: Any) -> dict[str, float] | None:
+    pair = _gps(value)
+    if pair is None:
+        return None
+    latitude, longitude = pair
+    return {"latitude": latitude, "longitude": longitude}
+
+
+def georeference_from_geometry(geom: Any) -> dict[str, Any] | None:
+    """Normalize raw vendor map georeference fields."""
+    if not isinstance(geom, dict):
+        return None
+    local = _xy(geom.get("map_circle_center"))
+    center = _gps(geom.get("center_gps"))
+    rotation = _float(geom.get("map_north_offset"))
+    if local is None or center is None or rotation is None:
+        return None
+
+    local_x, local_y = local
+    latitude, longitude = center
+    result: dict[str, Any] = {
+        "schema_version": _GEOREFERENCE_SCHEMA_VERSION,
+        "source": "vendor_map_detail",
+        "reference": {
+            "local_x": local_x,
+            "local_y": local_y,
+            "latitude": latitude,
+            "longitude": longitude,
+        },
+        # Positive vendor angle rotates local coordinates clockwise relative to
+        # true East/North; local -> EN therefore uses R(-rotation_rad).
+        "rotation_rad": rotation,
+    }
+
+    origin = _gps_dict(geom.get("origin_gps"))
+    north_east = _gps_dict(geom.get("ne_gps"))
+    south_west = _gps_dict(geom.get("sw_gps"))
+    if origin is not None:
+        result["origin"] = origin
+    if north_east is not None or south_west is not None:
+        result["bounds"] = {
+            "north_east": north_east,
+            "south_west": south_west,
+        }
+    return result
+
+
+def georeference_from_plain_map_detail(data: Any) -> dict[str, Any] | None:
+    """Extract normalized georeference from the plain map-detail response."""
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except (TypeError, ValueError):
+            return None
+    if not isinstance(data, dict):
+        return None
+    detail = data.get("map_detail")
+    if isinstance(detail, str):
+        try:
+            detail = json.loads(detail)
+        except (TypeError, ValueError):
+            return None
+    return georeference_from_geometry(detail)
+
+
+def georeference_from_compressed_map_detail(blob: Any) -> dict[str, Any] | None:
+    """Extract normalized georeference from the compressed map-detail response."""
+    if not isinstance(blob, str) or not blob:
+        return None
+    try:
+        raw = base64.b64decode(blob)
+    except Exception:  # noqa: BLE001
+        return None
+
+    decompressed: bytes | None = None
+    try:
+        import compression.zstd as zstd  # type: ignore[import-not-found]
+
+        try:
+            decompressed = zstd.decompress(raw)
+        except Exception:  # noqa: BLE001
+            decompressed = zstd.ZstdDecompressor().decompress(raw)
+    except Exception:  # noqa: BLE001
+        try:
+            import zstandard  # type: ignore[import-not-found]
+
+            decompressed = zstandard.ZstdDecompressor().stream_reader(
+                io.BytesIO(raw)
+            ).read()
+        except Exception:  # noqa: BLE001
+            return None
+    if not decompressed:
+        return None
+    try:
+        outer = json.loads(decompressed)
+        detail = outer.get("map_detail") if isinstance(outer, dict) else None
+        if isinstance(detail, str):
+            detail = json.loads(detail)
+    except (TypeError, ValueError):
+        return None
+    return georeference_from_geometry(detail)
+
+
+def local_xy_to_wgs84(
+    georeference: dict[str, Any], x: Any, y: Any
+) -> tuple[float, float] | None:
+    """Transform one local mower X/Y point to WGS84 latitude/longitude."""
+    reference = georeference.get("reference") or {}
+    local_x = _float(reference.get("local_x"))
+    local_y = _float(reference.get("local_y"))
+    latitude = _float(reference.get("latitude"))
+    longitude = _float(reference.get("longitude"))
+    rotation = _float(georeference.get("rotation_rad"))
+    point_x, point_y = _float(x), _float(y)
+    if None in (
+        local_x,
+        local_y,
+        latitude,
+        longitude,
+        rotation,
+        point_x,
+        point_y,
+    ):
+        return None
+
+    dx = point_x - local_x
+    dy = point_y - local_y
+    # Vendor map_north_offset is clockwise in the local map frame.
+    east = dx * math.cos(rotation) + dy * math.sin(rotation)
+    north = -dx * math.sin(rotation) + dy * math.cos(rotation)
+    latitude_rad = math.radians(latitude)
+    calculated_latitude = latitude + math.degrees(north / _EARTH_RADIUS_M)
+    cos_latitude = math.cos(latitude_rad)
+    if abs(cos_latitude) < 1e-12:
+        return None
+    calculated_longitude = longitude + math.degrees(
+        east / (_EARTH_RADIUS_M * cos_latitude)
+    )
+    return calculated_latitude, calculated_longitude
+
+
+def _distance_m(
+    latitude_a: float,
+    longitude_a: float,
+    latitude_b: float,
+    longitude_b: float,
+) -> float:
+    lat1, lat2 = math.radians(latitude_a), math.radians(latitude_b)
+    dlat = lat2 - lat1
+    dlon = math.radians(longitude_b - longitude_a)
+    hav = (
+        math.sin(dlat / 2.0) ** 2
+        + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2.0) ** 2
+    )
+    return 2.0 * _EARTH_RADIUS_M * math.asin(min(1.0, math.sqrt(hav)))
+
+
+def validate_georeference(
+    georeference: Any,
+    location: Any,
+    *,
+    limit_m: float = _DEFAULT_VALIDATION_LIMIT_M,
+) -> dict[str, Any] | None:
+    """Attach a private-cloud XY/GPS consistency check to one georeference.
+
+    Validation is passive: it uses the existing location response and never
+    causes an additional cloud request.
+    """
+    if not isinstance(georeference, dict):
+        return None
+    result = dict(georeference)
+    if not isinstance(location, dict):
+        result["validation"] = {"status": "unavailable", "valid": None}
+        return result
+
+    x = _float(location.get("posture_x"))
+    y = _float(location.get("posture_y"))
+    latitude = _float(location.get("latitude"))
+    longitude = _float(location.get("longitude"))
+    if None in (x, y, latitude, longitude):
+        result["validation"] = {"status": "unavailable", "valid": None}
+        return result
+
+    calculated = local_xy_to_wgs84(result, x, y)
+    if calculated is None:
+        result["validation"] = {"status": "unavailable", "valid": None}
+        return result
+    calculated_latitude, calculated_longitude = calculated
+    error_m = _distance_m(
+        calculated_latitude,
+        calculated_longitude,
+        latitude,
+        longitude,
+    )
+    valid = error_m <= max(0.0, float(limit_m))
+    result["validation"] = {
+        "status": "validated" if valid else "mismatch",
+        "valid": valid,
+        "error_m": round(error_m, 3),
+        "limit_m": float(limit_m),
+        "report_time": location.get("report_time"),
+    }
+    return result
+
+
+__all__ = [
+    "georeference_from_compressed_map_detail",
+    "georeference_from_plain_map_detail",
+    "local_xy_to_wgs84",
+    "validate_georeference",
+]

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.3"
+  "version": "0.4.4-beta1"
 }

--- a/tests/test_passive_discovery_beta43.py
+++ b/tests/test_passive_discovery_beta43.py
@@ -2,16 +2,13 @@
 from __future__ import annotations
 
 import ast
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_passive_discovery_release_contract_survives_later_043_releases() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"].startswith("0.4.3")
+def test_passive_discovery_release_contract_survives_later_releases() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta43.md").read_text()
     assert "Passive MQTT discovery" in notes
     assert "gate_required" in notes

--- a/tests/test_v043_beta1.py
+++ b/tests/test_v043_beta1.py
@@ -1,6 +1,5 @@
-"""Regression contracts for Navimower 0.4.3-beta1 and later 0.4.3 betas."""
+"""Regression contracts for Navimower 0.4.3-beta1 and later releases."""
 import ast
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -8,8 +7,6 @@ COMPONENT = ROOT / "custom_components/navimower"
 
 
 def test_v043_beta1_contract() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text())
-    assert manifest["version"].startswith("0.4.3")
     diagnostics = (COMPONENT / "diagnostics.py").read_text()
     discovery = (COMPONENT / "maintenance_h5_discovery.py").read_text()
     ast.parse(diagnostics)

--- a/tests/test_v043_beta2.py
+++ b/tests/test_v043_beta2.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import ast
-import json
 from pathlib import Path
 import re
 
@@ -10,9 +9,7 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta2_version_and_notes() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"].startswith("0.4.3")
+def test_beta2_release_notes() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta2.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta2")
     assert "Download diagnostics" in notes

--- a/tests/test_v043_beta28.py
+++ b/tests/test_v043_beta28.py
@@ -1,7 +1,6 @@
 """Regression guards for 0.4.3-beta28 map-edit timestamp semantics."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -9,9 +8,6 @@ ROOT = Path(__file__).resolve().parents[1]
 semantics = (ROOT / "custom_components/navimower/coordinator_semantics.py").read_text()
 init_source = (ROOT / "custom_components/navimower/__init__.py").read_text()
 history = (ROOT / "custom_components/navimower/history.py").read_text()
-manifest = json.loads(
-    (ROOT / "custom_components/navimower/manifest.json").read_text()
-)
 
 # The runtime coordinator must strip the ambiguous vendor coverage timestamps
 # before zone history sees them. Raw vendor fields stay in the base coordinator
@@ -27,8 +23,6 @@ assert '"last_mowed_at": observed_iso' in history
 assert 'record["last_started_at"] = observed_iso' in history
 assert "if cutting:" in history
 
-# Keep this historical semantic test valid for the complete 0.4.3 line,
-# including the final stable release. Exact current-version assertions belong in
-# the current release regression file instead of an old beta contract.
-assert manifest["version"].startswith("0.4.3")
+# This is a historical semantic regression, not a release-line/version guard.
+# Exact manifest-version assertions belong in the current release tests.
 print("beta28 map-edit timestamp regression tests passed")

--- a/tests/test_v043_beta3.py
+++ b/tests/test_v043_beta3.py
@@ -1,8 +1,7 @@
-"""Regression contracts for Navimower 0.4.3-beta3 and later 0.4.3 betas."""
+"""Regression contracts for Navimower 0.4.3-beta3 and later releases."""
 from __future__ import annotations
 
 import ast
-import json
 from pathlib import Path
 import re
 
@@ -10,9 +9,7 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta3_version_notes_and_changelog() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"].startswith("0.4.3")
+def test_beta3_notes_and_changelog() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta3.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta3")
     assert "48 public JavaScript assets" in notes

--- a/tests/test_v043_beta4.py
+++ b/tests/test_v043_beta4.py
@@ -1,8 +1,7 @@
-"""Regression contracts for Navimower 0.4.3-beta4 and later 0.4.3 releases."""
+"""Regression contracts for Navimower 0.4.3-beta4 and later releases."""
 from __future__ import annotations
 
 import ast
-import json
 from pathlib import Path
 import re
 
@@ -11,8 +10,6 @@ COMPONENT = ROOT / "custom_components" / "navimower"
 
 
 def test_beta4_release_notes_and_focus() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"].startswith("0.4.3")
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta4.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta4")
     assert "Maintenance + Mowing Reports" in notes

--- a/tests/test_v043_beta5.py
+++ b/tests/test_v043_beta5.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import ast
-import json
 from pathlib import Path
 import re
 
@@ -36,8 +35,6 @@ def _compiled_patterns(source: str) -> dict[str, str]:
 
 
 def test_beta5_release_artifacts_remain_in_history() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"].startswith("0.4.3")
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta5.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta5")
     assert "targeted call-site recovery" in notes

--- a/tests/test_v043_beta58.py
+++ b/tests/test_v043_beta58.py
@@ -1,7 +1,6 @@
 """Dependency-free regression coverage for 0.4.3-beta58 behavior."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 
@@ -54,8 +53,3 @@ def test_beta58_readme_covers_options_custom_area_and_card_compatibility() -> No
     assert "Off-limit" in readme
     assert "Navimower Map Card 0.3.5 requires Navimower integration 0.4.3 or newer" in readme
     assert "Reset schedule progress" in readme
-
-
-def test_beta58_release_family_remains_043() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"].startswith("0.4.3")

--- a/tests/test_v043_beta6.py
+++ b/tests/test_v043_beta6.py
@@ -1,8 +1,7 @@
-"""Regression contracts for Navimower 0.4.3-beta6 and later 0.4.3 releases."""
+"""Regression contracts for Navimower 0.4.3-beta6 and later releases."""
 from __future__ import annotations
 
 import ast
-import json
 from pathlib import Path
 import re
 
@@ -36,8 +35,6 @@ def _compiled_patterns(source: str) -> dict[str, str]:
 
 
 def test_beta6_release_notes_and_changelog() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"].startswith("0.4.3")
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta6.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta6")
     assert "Parts maintenance" in notes

--- a/tests/test_v043_beta7.py
+++ b/tests/test_v043_beta7.py
@@ -1,7 +1,6 @@
 """Regression contracts for Navimower 0.4.3-beta7 targeted request reserve."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 import re
 
@@ -9,9 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta7_version_notes_and_changelog() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"].startswith("0.4.3")
+def test_beta7_notes_and_changelog() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta7.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta7")
     assert "targeted" in notes.lower()

--- a/tests/test_v043_beta8.py
+++ b/tests/test_v043_beta8.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import ast
-import json
 from pathlib import Path
 import re
 
@@ -41,8 +40,6 @@ def _compiled_patterns(source: str) -> dict[str, tuple[str, int]]:
 
 
 def test_beta8_release_notes_and_changelog() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"].startswith("0.4.3")
     notes = (ROOT / ".github" / "release-notes" / "0.4.3-beta8.md").read_text(encoding="utf-8")
     assert notes.startswith("title: Navimower 0.4.3-beta8")
     assert "candidate-routing" in notes

--- a/tests/test_v043_stable.py
+++ b/tests/test_v043_stable.py
@@ -1,7 +1,6 @@
 """Stable 0.4.3 release regression coverage."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 
@@ -9,10 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_stable_manifest_and_release_notes() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.3"
-
+def test_stable_release_notes_remain_available() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.3.md").read_text(
         encoding="utf-8"
     )

--- a/tests/test_v044_beta1.py
+++ b/tests/test_v044_beta1.py
@@ -1,0 +1,109 @@
+"""Regression tests for Navimower 0.4.4-beta1 map georeference support."""
+from __future__ import annotations
+
+import json
+
+from custom_components.navimower.georeference import (
+    georeference_from_geometry,
+    georeference_from_plain_map_detail,
+    local_xy_to_wgs84,
+    validate_georeference,
+)
+
+
+_MAP_GEOMETRY = {
+    "map_circle_center": [-6.191056109109541, 9.324995591152359],
+    "center_gps": [24.638561248779297, 58.384281158447266],
+    "map_north_offset": 0.5977016091346741,
+    "origin_gps": [24.638547897338867, 58.38420104980469],
+    "ne_gps": [24.638938903808594, 58.384521484375],
+    "sw_gps": [24.6379451751709, 58.3840446472168],
+}
+
+_LOCATION = {
+    "posture_x": "0.184",
+    "posture_y": "-2.768",
+    "latitude": "58.3841591",
+    "longitude": "24.6385326",
+    "report_time": "1785252961",
+}
+
+
+def test_georeference_normalizes_vendor_map_fields() -> None:
+    georeference = georeference_from_geometry(_MAP_GEOMETRY)
+
+    assert georeference is not None
+    assert georeference["schema_version"] == 1
+    assert georeference["source"] == "vendor_map_detail"
+    assert georeference["reference"] == {
+        "local_x": -6.191056109109541,
+        "local_y": 9.324995591152359,
+        "latitude": 58.384281158447266,
+        "longitude": 24.638561248779297,
+    }
+    assert georeference["rotation_rad"] == 0.5977016091346741
+    assert georeference["origin"] == {
+        "latitude": 58.38420104980469,
+        "longitude": 24.638547897338867,
+    }
+    assert georeference["bounds"]["north_east"] == {
+        "latitude": 58.384521484375,
+        "longitude": 24.638938903808594,
+    }
+    assert georeference["bounds"]["south_west"] == {
+        "latitude": 58.3840446472168,
+        "longitude": 24.6379451751709,
+    }
+
+
+def test_plain_map_detail_extracts_same_georeference() -> None:
+    payload = {"map_detail": json.dumps({**_MAP_GEOMETRY, "sub_maps": []})}
+    assert georeference_from_plain_map_detail(payload) == georeference_from_geometry(
+        _MAP_GEOMETRY
+    )
+
+
+def test_local_xy_transform_matches_vendor_location() -> None:
+    georeference = georeference_from_geometry(_MAP_GEOMETRY)
+    assert georeference is not None
+
+    point = local_xy_to_wgs84(georeference, 0.184, -2.768)
+    assert point is not None
+    latitude, longitude = point
+    assert abs(latitude - float(_LOCATION["latitude"])) < 0.000003
+    assert abs(longitude - float(_LOCATION["longitude"])) < 0.000003
+
+    validated = validate_georeference(georeference, _LOCATION)
+    assert validated is not None
+    assert validated["validation"]["status"] == "validated"
+    assert validated["validation"]["valid"] is True
+    assert validated["validation"]["error_m"] < 0.2
+    assert validated["validation"]["report_time"] == "1785252961"
+
+
+def test_validation_detects_large_mismatch() -> None:
+    georeference = georeference_from_geometry(_MAP_GEOMETRY)
+    assert georeference is not None
+    location = {**_LOCATION, "latitude": str(float(_LOCATION["latitude"]) + 0.001)}
+
+    validated = validate_georeference(georeference, location)
+    assert validated is not None
+    assert validated["validation"]["status"] == "mismatch"
+    assert validated["validation"]["valid"] is False
+    assert validated["validation"]["error_m"] > 2.0
+
+
+def test_validation_is_unavailable_without_complete_location_pair() -> None:
+    georeference = georeference_from_geometry(_MAP_GEOMETRY)
+    assert georeference is not None
+
+    validated = validate_georeference(georeference, {"posture_x": 1, "posture_y": 2})
+    assert validated is not None
+    assert validated["validation"] == {
+        "status": "unavailable",
+        "valid": None,
+    }
+
+
+def test_incomplete_map_metadata_does_not_invent_georeference() -> None:
+    assert georeference_from_geometry({"map_north_offset": 0.5}) is None


### PR DESCRIPTION
## Summary

Prepare **Navimower 0.4.4-beta1** with the integration-side georeference contract needed for future multi-mower and geographic basemap support.

- retain vendor `map_circle_center`, `center_gps`, `map_north_offset` semantics as a normalized Navimower-owned georeference model instead of discarding them after map decode;
- retain optional geographic origin and map bounds when available;
- transform local mower X/Y to WGS84 without changing the existing dense MQTT live-position path;
- passively validate the transform against the normal private-cloud location response (`posture_x/posture_y` + latitude/longitude), with no additional cloud requests;
- expose georeference metadata through the authenticated Map API under both `map.georeference` and top-level `georeference`;
- keep old cached map geometry available immediately after upgrade while forcing one normal re-decode to populate missing georeference metadata;
- add regression coverage using a captured vendor map/location pair where local XY -> WGS84 agrees with the reported mower position to well below the initial 2 m validation limit;
- bump the manifest to `0.4.4-beta1` and add prerelease notes.

This is intentionally backend-only. Multi-mower Map Card composition and optional geographic basemaps will follow after validating the georeference contract on multiple mower maps.