### PR TITLE
Navimower 0.4.4-beta2: expose georeference in diagnostics

### DIFF
--- a/.github/release-notes/0.4.4-beta2.md
+++ b/.github/release-notes/0.4.4-beta2.md
@@ -1,0 +1,10 @@
+title: Navimower 0.4.4-beta2
+
+## Georeference diagnostics
+
+- Adds the normalized map `georeference` block to Home Assistant Download diagnostics so field validation can be checked without opening the Map API.
+- Keeps the useful non-sensitive transform data visible, including local reference X/Y, map rotation, source/schema information and passive validation metadata such as `status`, `valid`, `error_m`, `limit_m` and `report_time`.
+- GPS latitude/longitude values inside the georeference remain redacted by the existing diagnostics sanitizer.
+- Download diagnostics remain cached-only and do not trigger any additional vendor or H5 requests.
+
+This beta is a diagnostics-only follow-up to 0.4.4-beta1. The runtime georeference transform, MQTT live-position path and Map API contract are unchanged.

--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -311,6 +311,7 @@ async def async_get_config_entry_diagnostics(
         ),
         "settings": sanitize(deepcopy(settings)),
         "navimower_schedule": sanitize(deepcopy(navimower_schedule_diagnostics)),
+        "georeference": sanitize(deepcopy(data.get("georeference"))),
         "map_edit": sanitize(
             {
                 "state_code": data.get("state_code"),
@@ -404,6 +405,7 @@ async def async_get_config_entry_diagnostics(
         "notes": [
             "0.4.3-beta42 adds cached MQTT navigation fields and passive MQTT discovery output for controlled gate-transition research.",
             "Download diagnostics remain cached-only and make no extra vendor or H5 requests.",
+            "Georeference diagnostics expose local map transform and validation metadata while physical GPS coordinates remain redacted.",
             "Enable Passive MQTT discovery temporarily when raw event/location samples are needed; samples are sanitized by the existing discovery pipeline.",
             "Clear/Resume/Reboot discovery, Mowing Reports research and Maintenance research payloads are retired from normal diagnostics.",
             "index2.mapVersion is the fast vendor map revision signal; a change forces location/map-list and map geometry refresh in the same private-cloud poll.",

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta1"
+  "version": "0.4.4-beta2"
 }

--- a/tests/test_v044_beta2.py
+++ b/tests/test_v044_beta2.py
@@ -1,0 +1,81 @@
+"""Regression tests for Navimower 0.4.4-beta2 georeference diagnostics."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from custom_components.navimower.diagnostics_sanitize import sanitize
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_beta2_version_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.4-beta2"
+
+    notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta2.md").read_text(
+        encoding="utf-8"
+    )
+    assert notes.startswith("title: Navimower 0.4.4-beta2")
+    assert "Georeference diagnostics" in notes
+    assert "cached-only" in notes
+    assert "redacted" in notes
+
+
+def test_beta2_download_diagnostics_exports_runtime_georeference() -> None:
+    source = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
+    assert '"georeference": sanitize(deepcopy(data.get("georeference")))' in source
+    assert "physical GPS coordinates remain redacted" in source
+
+
+def test_georeference_sanitizer_keeps_transform_and_validation_but_redacts_gps() -> None:
+    georeference = {
+        "schema_version": 1,
+        "source": "vendor_map_detail",
+        "reference": {
+            "local_x": -6.191056109109541,
+            "local_y": 9.324995591152359,
+            "latitude": 58.384281158447266,
+            "longitude": 24.638561248779297,
+        },
+        "rotation_rad": 0.5977016091346741,
+        "origin": {
+            "latitude": 58.38420104980469,
+            "longitude": 24.638547897338867,
+        },
+        "bounds": {
+            "north_east": {
+                "latitude": 58.384521484375,
+                "longitude": 24.638938903808594,
+            },
+            "south_west": {
+                "latitude": 58.3840446472168,
+                "longitude": 24.6379451751709,
+            },
+        },
+        "validation": {
+            "status": "validated",
+            "valid": True,
+            "error_m": 0.14,
+            "limit_m": 2.0,
+            "report_time": "1785252961",
+        },
+    }
+
+    result = sanitize(georeference)
+
+    assert result["schema_version"] == 1
+    assert result["source"] == "vendor_map_detail"
+    assert result["reference"]["local_x"] == georeference["reference"]["local_x"]
+    assert result["reference"]["local_y"] == georeference["reference"]["local_y"]
+    assert result["rotation_rad"] == georeference["rotation_rad"]
+    assert result["validation"] == georeference["validation"]
+    assert result["reference"]["latitude"] == "<redacted>"
+    assert result["reference"]["longitude"] == "<redacted>"
+    assert result["origin"]["latitude"] == "<redacted>"
+    assert result["origin"]["longitude"] == "<redacted>"
+    assert result["bounds"]["north_east"]["latitude"] == "<redacted>"
+    assert result["bounds"]["north_east"]["longitude"] == "<redacted>"
+    assert result["bounds"]["south_west"]["latitude"] == "<redacted>"
+    assert result["bounds"]["south_west"]["longitude"] == "<redacted>"


### PR DESCRIPTION
## Summary

Prepare **Navimower 0.4.4-beta2** as a diagnostics-only follow-up to beta1.

- expose the normalized runtime `georeference` block in Home Assistant Download diagnostics;
- retain local reference X/Y, rotation, schema/source and passive validation metadata including `status`, `valid`, `error_m`, `limit_m` and `report_time`;
- keep latitude/longitude and other physical GPS coordinates redacted through the existing diagnostics sanitizer;
- keep diagnostics cached-only with no extra vendor/H5 requests;
- leave the runtime transform, MQTT live-position path and Map API contract unchanged;
- add regression coverage for both export wiring and GPS redaction;
- bump the manifest to `0.4.4-beta2` and add prerelease notes.