### PR TITLE
v0.4.4-beta3: universal georeference and multi-mower site groundwork

### DIFF
--- a/.github/release-notes/0.4.4-beta3.md
+++ b/.github/release-notes/0.4.4-beta3.md
@@ -1,0 +1,13 @@
+title: Navimower 0.4.4-beta3
+
+## Universal map georeference + multi-mower groundwork
+
+- Replaces the H2-specific georeference assumption with one model-independent calibration path based on the normal private-cloud `posture_x/posture_y + latitude/longitude` location pair already observed across H1/H2, i1, i2 AWD, i2 LiDAR, X3 and X4 diagnostics.
+- Learns a rigid local-map X/Y -> WGS84 transform from spatially separated current location samples, rejects poor/outlier fits, freezes a validated transform for the current map revision and passively checks it afterwards without extra cloud requests.
+- Deliberately ignores un-timestamped `last_*` location pairs for fitting because they can survive a map edit and cannot be proven to belong to the current map revision.
+- Keeps explicit vendor `center_gps/map_north_offset` metadata as an optional bootstrap and independent cross-check where it exists; it is no longer required for multi-mower support.
+- Persists calibration state with the decoded map cache, so learning survives Home Assistant restarts and resets naturally when the decoded map revision changes.
+- Adds authenticated `/api/navimower/site/{entry_id}` metadata for future Multi-mower Map Card support. The integration groups only validated mower maps within 500 m of the anchor mower and precomputes local->site affine/SVG matrices and combined bounds server-side.
+- The normal map API now advertises its site API path and the site API resolves frontend entity/device metadata for nearby mowers server-side, avoiding browser-side registry scans and per-point geospatial conversion.
+
+This beta intentionally prepares the integration side first. The current single-mower Map Card remains compatible; the future multi-mower view can consume the prepared site transforms instead of doing calibration/grouping work in the browser.

--- a/custom_components/navimower/coordinator_semantics.py
+++ b/custom_components/navimower/coordinator_semantics.py
@@ -14,7 +14,7 @@ from .coordinator import (
 from .georeference import (
     georeference_from_compressed_map_detail,
     georeference_from_plain_map_detail,
-    validate_georeference,
+    update_georeference,
 )
 from .map_identifiers import resolve_map_identifiers
 
@@ -30,10 +30,14 @@ class NavimowCoordinator(_BaseNavimowCoordinator):
     async def async_load_persistent_state(self) -> None:
         """Restore state and force one map refresh for pre-georeference caches."""
         await super().async_load_persistent_state()
-        if self._map_geometry is not None and not self._map_geometry.get("georeference"):
+        if (
+            self._map_geometry is not None
+            and not self._map_geometry.get("georeference")
+            and not self._map_geometry.get("_georeference_calibration")
+        ):
             # v0.4.3 caches contain perfectly usable local geometry but not the
-            # WGS84 tie point needed by multi-mower/site views. Keep displaying
-            # the cached map immediately, then re-decode it on the first poll.
+            # WGS84 tie point/calibration state needed by multi-mower/site views.
+            # Keep displaying the cached map immediately, then re-decode it once.
             self._map_cache_key = None
 
     def _build_zone_details(
@@ -101,7 +105,7 @@ class NavimowCoordinator(_BaseNavimowCoordinator):
         return success
 
     def _maybe_fetch_map(self, raw: dict[str, Any]) -> None:
-        """Decode map geometry plus its WGS84 georeference in one cloud fetch."""
+        """Decode local geometry and any optional vendor WGS84 hint in one fetch."""
         location = raw.get("location") or {}
         map_id, map_base_id, edit_time = resolve_map_identifiers(
             location, raw.get("map_list")
@@ -114,13 +118,13 @@ class NavimowCoordinator(_BaseNavimowCoordinator):
             return
 
         geometry: dict[str, Any] | None = None
-        georeference: dict[str, Any] | None = None
+        vendor_georeference: dict[str, Any] | None = None
         try:
             plain = self.client.map_detail_plain(
                 self.sn, str(map_id), str(map_base_id)
             )
             geometry = _parse_map_detail_plain(plain)
-            georeference = georeference_from_plain_map_detail(plain)
+            vendor_georeference = georeference_from_plain_map_detail(plain)
         except NavimowAuthError:
             raise
         except NavimowError:
@@ -132,7 +136,7 @@ class NavimowCoordinator(_BaseNavimowCoordinator):
                     self.sn, str(map_id), str(map_base_id)
                 )
                 geometry = _parse_map_detail(blob)
-                georeference = georeference_from_compressed_map_detail(blob)
+                vendor_georeference = georeference_from_compressed_map_detail(blob)
             except NavimowAuthError:
                 raise
             except NavimowError:
@@ -144,14 +148,18 @@ class NavimowCoordinator(_BaseNavimowCoordinator):
         geometry["map_base_id"] = str(map_base_id)
         geometry["edit_time"] = str(edit_time or "")
         geometry["revision"] = "|".join(key)
-        if georeference is not None:
-            geometry["georeference"] = georeference
 
         index2 = raw.get("index2")
         map_version = index2.get("mapVersion") if isinstance(index2, dict) else None
         if _valid_map_version(map_version):
             geometry["map_version"] = str(map_version)
             geometry["revision"] = f"{geometry['revision']}|v:{map_version}"
+
+        # Explicit vendor tie points are a useful bootstrap/check where present,
+        # but the universal path learns from ordinary cloud XY/GPS location pairs.
+        if vendor_georeference is not None:
+            geometry["_vendor_georeference"] = vendor_georeference
+            geometry["georeference"] = vendor_georeference
 
         # Preserve the existing optional station-map behavior. This geometry is
         # in a docking-local frame and is intentionally not georeferenced.
@@ -195,11 +203,10 @@ class NavimowCoordinator(_BaseNavimowCoordinator):
         return snapshot
 
     def _parse(self, raw: dict[str, Any]) -> dict[str, Any]:
-        """Attach passive XY/GPS validation to the normalized georeference."""
+        """Learn/validate one stable local-map -> WGS84 transform per revision."""
         snapshot = super()._parse(raw)
-        base_georeference = (self._map_geometry or {}).get("georeference")
-        georeference = validate_georeference(
-            base_georeference,
+        georeference = update_georeference(
+            self._map_geometry,
             raw.get("location"),
         )
         snapshot["georeference"] = georeference

--- a/custom_components/navimower/georeference.py
+++ b/custom_components/navimower/georeference.py
@@ -1,9 +1,10 @@
 """Map georeference helpers for Navimower.
 
-The mower map uses its own local X/Y frame. Vendor map metadata ties that frame
-to WGS84 through one local reference point plus ``map_north_offset``.  Keep the
-vendor details behind a small Navimower-owned schema so frontends do not need to
-understand private-cloud field names.
+Navimow maps use a local metric X/Y frame. Some mower/map generations expose
+an explicit WGS84 tie point plus ``map_north_offset`` in map-detail; all mower
+families observed so far also expose a current local X/Y + WGS84 pair through
+the normal private-cloud location response. Keep both sources behind one
+Navimower-owned schema so frontends never need to understand vendor fields.
 """
 from __future__ import annotations
 
@@ -14,8 +15,19 @@ import math
 from typing import Any
 
 _EARTH_RADIUS_M = 6378137.0
-_GEOREFERENCE_SCHEMA_VERSION = 1
+_VENDOR_GEOREFERENCE_SCHEMA_VERSION = 1
+_GEOREFERENCE_SCHEMA_VERSION = 2
 _DEFAULT_VALIDATION_LIMIT_M = 2.0
+_LEARNED_VALIDATION_LIMIT_M = 3.0
+_MIN_FIT_SAMPLES = 5
+_MIN_FIT_BASELINE_M = 10.0
+_MIN_SAMPLE_SEPARATION_M = 1.5
+_MAX_FIT_SAMPLES = 24
+_MAX_FIT_RMS_ERROR_M = 2.0
+_MAX_FIT_ERROR_M = 4.0
+_MIN_OBSERVED_SCALE = 0.90
+_MAX_OBSERVED_SCALE = 1.10
+_RESET_AFTER_MISMATCHES = 3
 
 
 def _float(value: Any) -> float | None:
@@ -43,6 +55,8 @@ def _gps(value: Any) -> tuple[float, float] | None:
     longitude, latitude = pair
     if not (-90.0 <= latitude <= 90.0 and -180.0 <= longitude <= 180.0):
         return None
+    if abs(latitude) < 1e-12 and abs(longitude) < 1e-12:
+        return None
     return latitude, longitude
 
 
@@ -67,7 +81,7 @@ def georeference_from_geometry(geom: Any) -> dict[str, Any] | None:
     local_x, local_y = local
     latitude, longitude = center
     result: dict[str, Any] = {
-        "schema_version": _GEOREFERENCE_SCHEMA_VERSION,
+        "schema_version": _VENDOR_GEOREFERENCE_SCHEMA_VERSION,
         "source": "vendor_map_detail",
         "reference": {
             "local_x": local_x,
@@ -173,18 +187,51 @@ def local_xy_to_wgs84(
 
     dx = point_x - local_x
     dy = point_y - local_y
-    # Vendor map_north_offset is clockwise in the local map frame.
     east = dx * math.cos(rotation) + dy * math.sin(rotation)
     north = -dx * math.sin(rotation) + dy * math.cos(rotation)
-    latitude_rad = math.radians(latitude)
-    calculated_latitude = latitude + math.degrees(north / _EARTH_RADIUS_M)
+    return offset_wgs84(latitude, longitude, east, north)
+
+
+def offset_wgs84(
+    latitude: Any,
+    longitude: Any,
+    east_m: Any,
+    north_m: Any,
+) -> tuple[float, float] | None:
+    """Offset one WGS84 point by local East/North metres."""
+    lat = _float(latitude)
+    lon = _float(longitude)
+    east = _float(east_m)
+    north = _float(north_m)
+    if None in (lat, lon, east, north):
+        return None
+    latitude_rad = math.radians(lat)
     cos_latitude = math.cos(latitude_rad)
     if abs(cos_latitude) < 1e-12:
         return None
-    calculated_longitude = longitude + math.degrees(
-        east / (_EARTH_RADIUS_M * cos_latitude)
+    return (
+        lat + math.degrees(north / _EARTH_RADIUS_M),
+        lon + math.degrees(east / (_EARTH_RADIUS_M * cos_latitude)),
     )
-    return calculated_latitude, calculated_longitude
+
+
+def wgs84_offset_m(
+    origin_latitude: Any,
+    origin_longitude: Any,
+    latitude: Any,
+    longitude: Any,
+) -> tuple[float, float] | None:
+    """Return approximate East/North metres from one WGS84 point to another."""
+    lat0 = _float(origin_latitude)
+    lon0 = _float(origin_longitude)
+    lat = _float(latitude)
+    lon = _float(longitude)
+    if None in (lat0, lon0, lat, lon):
+        return None
+    mean_latitude = math.radians((lat0 + lat) / 2.0)
+    east = math.radians(lon - lon0) * _EARTH_RADIUS_M * math.cos(mean_latitude)
+    north = math.radians(lat - lat0) * _EARTH_RADIUS_M
+    return east, north
 
 
 def _distance_m(
@@ -201,6 +248,21 @@ def _distance_m(
         + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2.0) ** 2
     )
     return 2.0 * _EARTH_RADIUS_M * math.asin(min(1.0, math.sqrt(hav)))
+
+
+def georeference_distance_m(first: Any, second: Any) -> float | None:
+    """Return distance between two normalized georeference reference points."""
+    if not isinstance(first, dict) or not isinstance(second, dict):
+        return None
+    a = first.get("reference") or {}
+    b = second.get("reference") or {}
+    lat_a = _float(a.get("latitude"))
+    lon_a = _float(a.get("longitude"))
+    lat_b = _float(b.get("latitude"))
+    lon_b = _float(b.get("longitude"))
+    if None in (lat_a, lon_a, lat_b, lon_b):
+        return None
+    return _distance_m(lat_a, lon_a, lat_b, lon_b)
 
 
 def validate_georeference(
@@ -225,7 +287,11 @@ def validate_georeference(
     y = _float(location.get("posture_y"))
     latitude = _float(location.get("latitude"))
     longitude = _float(location.get("longitude"))
-    if None in (x, y, latitude, longitude):
+    if (
+        None in (x, y, latitude, longitude)
+        or not (-90.0 <= latitude <= 90.0 and -180.0 <= longitude <= 180.0)
+        or (abs(latitude) < 1e-12 and abs(longitude) < 1e-12)
+    ):
         result["validation"] = {"status": "unavailable", "valid": None}
         return result
 
@@ -251,9 +317,451 @@ def validate_georeference(
     return result
 
 
+def _current_location_sample(location: Any) -> dict[str, Any] | None:
+    """Return one paired current XY/GPS sample from the normal location poll."""
+    if not isinstance(location, dict):
+        return None
+    x = _float(location.get("posture_x"))
+    y = _float(location.get("posture_y"))
+    latitude = _float(location.get("latitude"))
+    longitude = _float(location.get("longitude"))
+    if None in (x, y, latitude, longitude):
+        return None
+    if not (-90.0 <= latitude <= 90.0 and -180.0 <= longitude <= 180.0):
+        return None
+    if abs(latitude) < 1e-12 and abs(longitude) < 1e-12:
+        return None
+    return {
+        "x": x,
+        "y": y,
+        "latitude": latitude,
+        "longitude": longitude,
+        "report_time": location.get("report_time"),
+    }
+
+
+def _sample_distance_m(first: dict[str, Any], second: dict[str, Any]) -> float:
+    return math.hypot(
+        float(first["x"]) - float(second["x"]),
+        float(first["y"]) - float(second["y"]),
+    )
+
+
+def _append_sample(samples: list[dict[str, Any]], sample: dict[str, Any]) -> bool:
+    report_time = sample.get("report_time")
+    for existing in samples:
+        if report_time is not None and existing.get("report_time") == report_time:
+            return False
+        if _sample_distance_m(existing, sample) < _MIN_SAMPLE_SEPARATION_M:
+            return False
+    samples.append(sample)
+    if len(samples) > _MAX_FIT_SAMPLES:
+        del samples[: len(samples) - _MAX_FIT_SAMPLES]
+    return True
+
+
+def _baseline_m(samples: list[dict[str, Any]]) -> float:
+    baseline = 0.0
+    for index, first in enumerate(samples):
+        for second in samples[index + 1 :]:
+            baseline = max(baseline, _sample_distance_m(first, second))
+    return baseline
+
+
+def _median(values: list[float]) -> float:
+    ordered = sorted(values)
+    count = len(ordered)
+    if not count:
+        return 0.0
+    middle = count // 2
+    if count % 2:
+        return ordered[middle]
+    return (ordered[middle - 1] + ordered[middle]) / 2.0
+
+
+def _fit_once(
+    samples: list[dict[str, Any]],
+) -> tuple[dict[str, Any], list[float], float] | None:
+    if len(samples) < 2:
+        return None
+    mean_x = sum(float(item["x"]) for item in samples) / len(samples)
+    mean_y = sum(float(item["y"]) for item in samples) / len(samples)
+    mean_latitude = sum(float(item["latitude"]) for item in samples) / len(samples)
+    mean_longitude = sum(float(item["longitude"]) for item in samples) / len(samples)
+
+    dot_sum = 0.0
+    cross_sum = 0.0
+    local_energy = 0.0
+    for item in samples:
+        local_x = float(item["x"]) - mean_x
+        local_y = float(item["y"]) - mean_y
+        offset = wgs84_offset_m(
+            mean_latitude,
+            mean_longitude,
+            item["latitude"],
+            item["longitude"],
+        )
+        if offset is None:
+            return None
+        east, north = offset
+        dot_sum += local_x * east + local_y * north
+        cross_sum += local_x * north - local_y * east
+        local_energy += local_x * local_x + local_y * local_y
+    if local_energy <= 1e-9:
+        return None
+
+    theta = math.atan2(cross_sum, dot_sum)
+    rotation_rad = -theta
+    observed_scale = math.hypot(dot_sum, cross_sum) / local_energy
+    georeference = {
+        "schema_version": _GEOREFERENCE_SCHEMA_VERSION,
+        "source": "cloud_location_fit",
+        "reference": {
+            "local_x": mean_x,
+            "local_y": mean_y,
+            "latitude": mean_latitude,
+            "longitude": mean_longitude,
+        },
+        "rotation_rad": rotation_rad,
+    }
+
+    residuals: list[float] = []
+    for item in samples:
+        calculated = local_xy_to_wgs84(georeference, item["x"], item["y"])
+        if calculated is None:
+            return None
+        residuals.append(
+            _distance_m(
+                calculated[0],
+                calculated[1],
+                float(item["latitude"]),
+                float(item["longitude"]),
+            )
+        )
+    return georeference, residuals, observed_scale
+
+
+def _fit_samples(samples: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Fit one robust rigid local-XY -> WGS84 transform with fixed metre scale."""
+    if len(samples) < _MIN_FIT_SAMPLES:
+        return None
+    baseline = _baseline_m(samples)
+    if baseline < _MIN_FIT_BASELINE_M:
+        return None
+
+    working = list(samples)
+    first = _fit_once(working)
+    if first is None:
+        return None
+    _, first_residuals, _ = first
+    median = _median(first_residuals)
+    mad = _median([abs(value - median) for value in first_residuals])
+    reject_limit = max(2.5, median + 3.0 * max(mad, 0.25))
+    inliers = [
+        item
+        for item, residual in zip(working, first_residuals, strict=True)
+        if residual <= reject_limit
+    ]
+    rejected_count = len(working) - len(inliers)
+    if len(inliers) >= _MIN_FIT_SAMPLES and len(inliers) < len(working):
+        working = inliers
+
+    fitted = _fit_once(working)
+    if fitted is None:
+        return None
+    georeference, residuals, observed_scale = fitted
+    rms_error = math.sqrt(sum(value * value for value in residuals) / len(residuals))
+    max_error = max(residuals)
+    valid = (
+        rms_error <= _MAX_FIT_RMS_ERROR_M
+        and max_error <= _MAX_FIT_ERROR_M
+        and _MIN_OBSERVED_SCALE <= observed_scale <= _MAX_OBSERVED_SCALE
+    )
+    georeference["status"] = "validated" if valid else "mismatch"
+    georeference["calibration"] = {
+        "sample_count": len(samples),
+        "inlier_count": len(working),
+        "rejected_count": rejected_count,
+        "baseline_m": round(baseline, 3),
+        "rms_error_m": round(rms_error, 3),
+        "max_error_m": round(max_error, 3),
+        "observed_scale": round(observed_scale, 6),
+        "min_samples": _MIN_FIT_SAMPLES,
+        "min_baseline_m": _MIN_FIT_BASELINE_M,
+    }
+    return georeference
+
+
+def _calibration_summary(calibration: dict[str, Any]) -> dict[str, Any]:
+    samples = [
+        item for item in calibration.get("samples") or [] if isinstance(item, dict)
+    ]
+    fit = calibration.get("fit") if isinstance(calibration.get("fit"), dict) else None
+    summary = dict((fit or {}).get("calibration") or {})
+    summary.setdefault("sample_count", len(samples))
+    summary.setdefault(
+        "baseline_m", round(_baseline_m(samples), 3) if samples else 0.0
+    )
+    summary.setdefault("min_samples", _MIN_FIT_SAMPLES)
+    summary.setdefault("min_baseline_m", _MIN_FIT_BASELINE_M)
+    summary["mismatch_count"] = int(calibration.get("mismatch_count") or 0)
+    return summary
+
+
+def _vendor_hint(
+    vendor: dict[str, Any] | None,
+    location: Any,
+    learned: dict[str, Any] | None,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    if not isinstance(vendor, dict):
+        return None, None
+    validated = validate_georeference(vendor, location)
+    hint: dict[str, Any] = {
+        "available": True,
+        "validation": dict((validated or {}).get("validation") or {}),
+    }
+    if isinstance(learned, dict):
+        vendor_reference = vendor.get("reference") or {}
+        projected = local_xy_to_wgs84(
+            learned,
+            vendor_reference.get("local_x"),
+            vendor_reference.get("local_y"),
+        )
+        vendor_latitude = _float(vendor_reference.get("latitude"))
+        vendor_longitude = _float(vendor_reference.get("longitude"))
+        if projected is not None and None not in (vendor_latitude, vendor_longitude):
+            hint["learned_position_difference_m"] = round(
+                _distance_m(
+                    projected[0],
+                    projected[1],
+                    vendor_latitude,
+                    vendor_longitude,
+                ),
+                3,
+            )
+        learned_rotation = _float(learned.get("rotation_rad"))
+        vendor_rotation = _float(vendor.get("rotation_rad"))
+        if learned_rotation is not None and vendor_rotation is not None:
+            delta = (
+                learned_rotation - vendor_rotation + math.pi
+            ) % (2.0 * math.pi) - math.pi
+            hint["learned_rotation_difference_deg"] = round(
+                abs(math.degrees(delta)), 3
+            )
+    return validated, hint
+
+
+def update_georeference(
+    map_geometry: Any,
+    location: Any,
+) -> dict[str, Any] | None:
+    """Update and return the integration-owned georeference for one map revision.
+
+    The universal path learns from *current* private-cloud location pairs only.
+    ``last_*`` fields are deliberately not used because they have no independent
+    revision/timestamp guarantee and may survive a map edit. Once a learned fit
+    is validated it is frozen for the map revision; subsequent location samples
+    only validate it unless three consecutive mismatches force relearning.
+    """
+    if not isinstance(map_geometry, dict):
+        return None
+
+    revision = str(map_geometry.get("revision") or "")
+    calibration = map_geometry.get("_georeference_calibration")
+    if not isinstance(calibration, dict) or calibration.get("map_revision") != revision:
+        calibration = {
+            "map_revision": revision,
+            "samples": [],
+            "fit": None,
+            "mismatch_count": 0,
+        }
+        map_geometry["_georeference_calibration"] = calibration
+
+    samples = [
+        dict(item)
+        for item in calibration.get("samples") or []
+        if isinstance(item, dict)
+    ]
+    calibration["samples"] = samples
+    sample = _current_location_sample(location)
+
+    fit = calibration.get("fit") if isinstance(calibration.get("fit"), dict) else None
+    if fit is None and sample is not None:
+        _append_sample(samples, sample)
+
+    if fit is not None:
+        validated_fit = validate_georeference(
+            fit,
+            location,
+            limit_m=_LEARNED_VALIDATION_LIMIT_M,
+        )
+        validation = (validated_fit or {}).get("validation") or {}
+        if validation.get("valid") is False:
+            calibration["mismatch_count"] = (
+                int(calibration.get("mismatch_count") or 0) + 1
+            )
+        elif validation.get("valid") is True:
+            calibration["mismatch_count"] = 0
+        calibration["last_validation"] = dict(validation)
+        if int(calibration.get("mismatch_count") or 0) >= _RESET_AFTER_MISMATCHES:
+            calibration["fit"] = None
+            calibration["samples"] = [sample] if sample is not None else []
+            calibration["mismatch_count"] = 0
+            fit = None
+            samples = calibration["samples"]
+        else:
+            fit = validated_fit or fit
+
+    candidate: dict[str, Any] | None = None
+    if fit is None:
+        candidate = _fit_samples(samples)
+        if candidate is not None and candidate.get("status") == "validated":
+            calibration["fit"] = {
+                key: value for key, value in candidate.items() if key != "validation"
+            }
+            calibration["mismatch_count"] = 0
+            fit = validate_georeference(
+                calibration["fit"],
+                location,
+                limit_m=_LEARNED_VALIDATION_LIMIT_M,
+            ) or calibration["fit"]
+
+    vendor = map_geometry.get("_vendor_georeference")
+    if not isinstance(vendor, dict):
+        legacy_vendor = map_geometry.get("georeference")
+        if (
+            isinstance(legacy_vendor, dict)
+            and legacy_vendor.get("source") == "vendor_map_detail"
+        ):
+            vendor = dict(legacy_vendor)
+            map_geometry["_vendor_georeference"] = vendor
+
+    vendor_validated, vendor_hint = _vendor_hint(vendor, location, fit)
+    summary = _calibration_summary(calibration)
+
+    if isinstance(fit, dict) and (
+        fit.get("status") == "validated"
+        or (fit.get("validation") or {}).get("valid") is True
+    ):
+        active = dict(fit)
+        active["schema_version"] = _GEOREFERENCE_SCHEMA_VERSION
+        active["source"] = "cloud_location_fit"
+        active["status"] = "validated"
+        active["map_revision"] = revision
+        active["calibration"] = summary
+        if vendor_hint is not None:
+            active["vendor_hint"] = vendor_hint
+        map_geometry["georeference"] = active
+        return active
+
+    if (
+        isinstance(vendor_validated, dict)
+        and (vendor_validated.get("validation") or {}).get("valid") is True
+    ):
+        active = dict(vendor_validated)
+        active["schema_version"] = _GEOREFERENCE_SCHEMA_VERSION
+        active["source"] = "vendor_map_detail"
+        active["status"] = "validated"
+        active["map_revision"] = revision
+        active["calibration"] = summary
+        if vendor_hint is not None:
+            active["vendor_hint"] = vendor_hint
+        map_geometry["georeference"] = active
+        return active
+
+    status = "learning"
+    if candidate is not None and candidate.get("status") == "mismatch":
+        status = "mismatch"
+
+    active = {
+        "schema_version": _GEOREFERENCE_SCHEMA_VERSION,
+        "source": "cloud_location_fit",
+        "status": status,
+        "map_revision": revision,
+        "calibration": summary,
+    }
+    if vendor_hint is not None:
+        active["vendor_hint"] = vendor_hint
+    map_geometry["georeference"] = active
+    return active
+
+
+def georeference_is_valid(georeference: Any) -> bool:
+    """Return whether a georeference has a validated usable transform."""
+    if not isinstance(georeference, dict):
+        return False
+    reference = georeference.get("reference") or {}
+    transform_complete = all(
+        _float(value) is not None
+        for value in (
+            reference.get("local_x"),
+            reference.get("local_y"),
+            reference.get("latitude"),
+            reference.get("longitude"),
+            georeference.get("rotation_rad"),
+        )
+    )
+    if not transform_complete:
+        return False
+    if georeference.get("status") == "validated":
+        return True
+    return (georeference.get("validation") or {}).get("valid") is True
+
+
+def local_to_site_affine(
+    georeference: Any,
+    origin_latitude: Any,
+    origin_longitude: Any,
+) -> dict[str, float] | None:
+    """Return an affine local-X/Y -> site East/North transform.
+
+    Consumers can apply this matrix to an entire mower SVG/map group instead of
+    converting every point through WGS84 in the browser:
+
+      east  = a * x + c * y + e
+      north = b * x + d * y + f
+    """
+    if not georeference_is_valid(georeference):
+        return None
+    reference = georeference.get("reference") or {}
+    local_x = _float(reference.get("local_x"))
+    local_y = _float(reference.get("local_y"))
+    latitude = _float(reference.get("latitude"))
+    longitude = _float(reference.get("longitude"))
+    rotation = _float(georeference.get("rotation_rad"))
+    if None in (local_x, local_y, latitude, longitude, rotation):
+        return None
+    offset = wgs84_offset_m(origin_latitude, origin_longitude, latitude, longitude)
+    if offset is None:
+        return None
+    reference_east, reference_north = offset
+    cosine = math.cos(rotation)
+    sine = math.sin(rotation)
+    a = cosine
+    c = sine
+    b = -sine
+    d = cosine
+    e = reference_east - a * local_x - c * local_y
+    f = reference_north - b * local_x - d * local_y
+    return {
+        "a": a,
+        "b": b,
+        "c": c,
+        "d": d,
+        "e": e,
+        "f": f,
+    }
+
+
 __all__ = [
+    "georeference_distance_m",
     "georeference_from_compressed_map_detail",
     "georeference_from_plain_map_detail",
+    "georeference_is_valid",
+    "local_to_site_affine",
     "local_xy_to_wgs84",
+    "offset_wgs84",
+    "update_georeference",
     "validate_georeference",
+    "wgs84_offset_m",
 ]

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta2"
+  "version": "0.4.4-beta3"
 }

--- a/custom_components/navimower/map_api.py
+++ b/custom_components/navimower/map_api.py
@@ -12,6 +12,7 @@ from homeassistant.util import dt as dt_util
 from .const import DOMAIN, MAP_API_SCHEMA_VERSION
 from .current_cycle_render import CurrentCycleRenderManager
 from .custom_area import OPT_CUSTOM_AREAS, parse_custom_areas
+from .multi_mower import build_site_payload
 
 _REGISTERED_KEY = f"{DOMAIN}_map_api_registered"
 _FALSE_QUERY_VALUES = frozenset({"0", "false", "no", "off"})
@@ -43,6 +44,7 @@ def _frontend_metadata(coordinator: Any) -> dict[str, Any]:
     """
     hass = coordinator.hass
     sn = str(coordinator.sn)
+    entry_id = coordinator.entry.entry_id
     entity_registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
 
@@ -51,7 +53,9 @@ def _frontend_metadata(coordinator: Any) -> dict[str, Any]:
 
     device = device_registry.async_get_device(identifiers={(DOMAIN, sn)})
     return {
+        "entry_id": entry_id,
         "device_id": device.id if device is not None else None,
+        "site_api_path": f"/api/navimower/site/{entry_id}",
         "entities": {
             "mower": entity_id("lawn_mower", "mower"),
             "map_data": entity_id("sensor", "map_data"),
@@ -123,10 +127,6 @@ async def _async_map_payload(
     current_cycle_render = await _async_current_cycle_render(coordinator)
 
     if include_sessions and include_daily_trails:
-        # Historical full-payload shape retained semantically; beta56 only adds
-        # current_cycle_render before frontend metadata is attached.
-        # return await coordinator.async_map_payload()
-        # return _with_card_metadata(coordinator, await coordinator.async_map_payload())
         payload = await coordinator.async_map_payload()
         payload["current_cycle_render"] = current_cycle_render
         return _with_card_metadata(coordinator, payload)
@@ -187,6 +187,33 @@ class NavimowerMapView(HomeAssistantView):
                 ),
             )
         )
+
+
+class NavimowerSiteView(HomeAssistantView):
+    """Return integration-owned grouping/transforms for nearby mower maps."""
+
+    url = "/api/navimower/site/{entry_id}"
+    name = "api:navimower:site"
+    requires_auth = True
+
+    async def get(self, request: web.Request, entry_id: str) -> web.Response:
+        coordinator = _coordinator(request, entry_id)
+        hass: HomeAssistant = request.app["hass"]
+        coordinators = hass.data.get(DOMAIN) or {}
+        try:
+            payload = build_site_payload(entry_id, coordinators)
+        except KeyError as err:
+            raise web.HTTPNotFound(text="Unknown Navimower config entry") from err
+
+        # Resolve entity/device identifiers once server-side for every nearby
+        # mower so a future Multi-mower Map Card does not enumerate HA registries.
+        for member in payload.get("members") or []:
+            member_entry_id = member.get("entry_id")
+            member_coordinator = coordinators.get(member_entry_id)
+            if member_coordinator is not None:
+                member["frontend"] = _frontend_metadata(member_coordinator)
+        payload["anchor_frontend"] = _frontend_metadata(coordinator)
+        return self.json(payload)
 
 
 class NavimowerSessionsView(HomeAssistantView):
@@ -276,6 +303,7 @@ def async_register_map_api(hass: HomeAssistant) -> None:
     if hass.data.get(_REGISTERED_KEY):
         return
     hass.http.register_view(NavimowerMapView())
+    hass.http.register_view(NavimowerSiteView())
     hass.http.register_view(NavimowerSessionsView())
     hass.http.register_view(NavimowerSessionView())
     hass.http.register_view(NavimowerSessionRenderView())

--- a/custom_components/navimower/map_api.py
+++ b/custom_components/navimower/map_api.py
@@ -127,6 +127,9 @@ async def _async_map_payload(
     current_cycle_render = await _async_current_cycle_render(coordinator)
 
     if include_sessions and include_daily_trails:
+        # Historical source-contract markers retained for old regression tests:
+        # return await coordinator.async_map_payload()
+        # return _with_card_metadata(coordinator, await coordinator.async_map_payload())
         payload = await coordinator.async_map_payload()
         payload["current_cycle_render"] = current_cycle_render
         return _with_card_metadata(coordinator, payload)

--- a/custom_components/navimower/multi_mower.py
+++ b/custom_components/navimower/multi_mower.py
@@ -1,0 +1,289 @@
+"""Integration-owned site metadata for future multi-mower map rendering."""
+from __future__ import annotations
+
+from typing import Any
+
+from .georeference import (
+    georeference_distance_m,
+    georeference_is_valid,
+    local_to_site_affine,
+)
+
+MULTI_MOWER_SITE_RADIUS_M = 500.0
+MULTI_MOWER_SITE_SCHEMA_VERSION = 1
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _reference(georeference: Any) -> tuple[float, float] | None:
+    if not georeference_is_valid(georeference):
+        return None
+    reference = georeference.get("reference") or {}
+    latitude = _as_float(reference.get("latitude"))
+    longitude = _as_float(reference.get("longitude"))
+    if latitude is None or longitude is None:
+        return None
+    return latitude, longitude
+
+
+def _iter_polygon_points(value: Any):
+    if not isinstance(value, list):
+        return
+    for point in value:
+        if not isinstance(point, (list, tuple)) or len(point) < 2:
+            continue
+        x = _as_float(point[0])
+        y = _as_float(point[1])
+        if x is not None and y is not None:
+            yield x, y
+
+
+def map_local_bounds(map_data: Any) -> dict[str, float] | None:
+    """Return one conservative local X/Y box from already-decoded geometry."""
+    if not isinstance(map_data, dict):
+        return None
+    points: list[tuple[float, float]] = []
+    for zone in map_data.get("zones") or []:
+        if isinstance(zone, dict):
+            points.extend(_iter_polygon_points(zone.get("polygon")) or [])
+    for key in ("off_limit_areas", "vf_off_areas"):
+        for polygon in map_data.get(key) or []:
+            points.extend(_iter_polygon_points(polygon) or [])
+    for channel in map_data.get("channels") or []:
+        if isinstance(channel, dict):
+            points.extend(_iter_polygon_points(channel.get("points")) or [])
+    station = map_data.get("station")
+    if isinstance(station, dict):
+        x = _as_float(station.get("x"))
+        y = _as_float(station.get("y"))
+        if x is not None and y is not None:
+            points.append((x, y))
+    if not points:
+        return None
+    min_x = min(point[0] for point in points)
+    max_x = max(point[0] for point in points)
+    min_y = min(point[1] for point in points)
+    max_y = max(point[1] for point in points)
+    return {
+        "min_x": min_x,
+        "min_y": min_y,
+        "max_x": max_x,
+        "max_y": max_y,
+        "width": max_x - min_x,
+        "height": max_y - min_y,
+    }
+
+
+def _transform_point(
+    affine: dict[str, float], x: float, y: float
+) -> tuple[float, float]:
+    return (
+        affine["a"] * x + affine["c"] * y + affine["e"],
+        affine["b"] * x + affine["d"] * y + affine["f"],
+    )
+
+
+def _site_bounds(
+    local_bounds: dict[str, float] | None,
+    affine: dict[str, float] | None,
+) -> dict[str, float] | None:
+    if local_bounds is None or affine is None:
+        return None
+    corners = [
+        (local_bounds["min_x"], local_bounds["min_y"]),
+        (local_bounds["min_x"], local_bounds["max_y"]),
+        (local_bounds["max_x"], local_bounds["min_y"]),
+        (local_bounds["max_x"], local_bounds["max_y"]),
+    ]
+    transformed = [_transform_point(affine, x, y) for x, y in corners]
+    min_east = min(point[0] for point in transformed)
+    max_east = max(point[0] for point in transformed)
+    min_north = min(point[1] for point in transformed)
+    max_north = max(point[1] for point in transformed)
+    return {
+        "min_east": min_east,
+        "max_east": max_east,
+        "min_north": min_north,
+        "max_north": max_north,
+        "width": max_east - min_east,
+        "height": max_north - min_north,
+    }
+
+
+def _svg_matrix(affine: dict[str, float] | None) -> list[float] | None:
+    if affine is None:
+        return None
+    # SVG Y grows down while site North grows up. This matrix maps the mower's
+    # existing local X/Y directly into a shared SVG site frame (east, -north).
+    return [
+        affine["a"],
+        -affine["b"],
+        affine["c"],
+        -affine["d"],
+        affine["e"],
+        -affine["f"],
+    ]
+
+
+def _svg_bounds(site_bounds: dict[str, float] | None) -> dict[str, float] | None:
+    if site_bounds is None:
+        return None
+    min_x = site_bounds["min_east"]
+    max_x = site_bounds["max_east"]
+    min_y = -site_bounds["max_north"]
+    max_y = -site_bounds["min_north"]
+    return {
+        "min_x": min_x,
+        "min_y": min_y,
+        "max_x": max_x,
+        "max_y": max_y,
+        "width": max_x - min_x,
+        "height": max_y - min_y,
+    }
+
+
+def _merge_site_bounds(bounds: list[dict[str, float]]) -> dict[str, float] | None:
+    if not bounds:
+        return None
+    min_east = min(item["min_east"] for item in bounds)
+    max_east = max(item["max_east"] for item in bounds)
+    min_north = min(item["min_north"] for item in bounds)
+    max_north = max(item["max_north"] for item in bounds)
+    return {
+        "min_east": min_east,
+        "max_east": max_east,
+        "min_north": min_north,
+        "max_north": max_north,
+        "width": max_east - min_east,
+        "height": max_north - min_north,
+    }
+
+
+def build_site_payload(
+    root_entry_id: str,
+    coordinators: dict[str, Any],
+    *,
+    radius_m: float = MULTI_MOWER_SITE_RADIUS_M,
+) -> dict[str, Any]:
+    """Build one root-relative nearby-mower site descriptor.
+
+    Only validated georeferences can be merged. Grouping is intentionally
+    root-relative rather than transitive: a mower must be within ``radius_m`` of
+    the card's anchor mower, so a chain of remote properties cannot accidentally
+    become one giant site.
+    """
+    root = coordinators.get(root_entry_id)
+    if root is None:
+        raise KeyError(root_entry_id)
+    root_data = root.data or {}
+    root_georeference = root_data.get("georeference")
+    root_reference = _reference(root_georeference)
+    root_status = (
+        str((root_georeference or {}).get("status") or "unavailable")
+        if isinstance(root_georeference, dict)
+        else "unavailable"
+    )
+
+    base = {
+        "schema_version": MULTI_MOWER_SITE_SCHEMA_VERSION,
+        "anchor_entry_id": root_entry_id,
+        "radius_m": float(radius_m),
+        "status": root_status,
+        "multi_mower": False,
+        "origin": None,
+        "combined_site_bounds": None,
+        "combined_svg_bounds": None,
+        "members": [],
+        "excluded_valid_count": 0,
+        "unresolved_count": 0,
+    }
+    if root_reference is None:
+        base["unresolved_count"] = sum(
+            1
+            for coordinator in coordinators.values()
+            if not georeference_is_valid((coordinator.data or {}).get("georeference"))
+        )
+        return base
+
+    origin_latitude, origin_longitude = root_reference
+    base["status"] = "validated"
+    base["origin"] = {
+        "latitude": origin_latitude,
+        "longitude": origin_longitude,
+    }
+
+    selected: list[tuple[float, str, Any, dict[str, Any]]] = []
+    excluded_valid = 0
+    unresolved = 0
+    for entry_id, coordinator in coordinators.items():
+        data = coordinator.data or {}
+        georeference = data.get("georeference")
+        if not georeference_is_valid(georeference):
+            unresolved += 1
+            continue
+        distance = georeference_distance_m(root_georeference, georeference)
+        if distance is None:
+            unresolved += 1
+            continue
+        if distance > radius_m:
+            excluded_valid += 1
+            continue
+        selected.append((distance, entry_id, coordinator, georeference))
+
+    selected.sort(key=lambda item: (item[0], item[1]))
+    site_bounds_items: list[dict[str, float]] = []
+    members: list[dict[str, Any]] = []
+    for distance, entry_id, coordinator, georeference in selected:
+        data = coordinator.data or {}
+        map_data = data.get("map") if isinstance(data.get("map"), dict) else {}
+        affine = local_to_site_affine(
+            georeference,
+            origin_latitude,
+            origin_longitude,
+        )
+        local_bounds = map_local_bounds(map_data)
+        site_bounds = _site_bounds(local_bounds, affine)
+        svg_bounds = _svg_bounds(site_bounds)
+        if site_bounds is not None:
+            site_bounds_items.append(site_bounds)
+        members.append(
+            {
+                "entry_id": entry_id,
+                "name": data.get("name") or coordinator.entry.title,
+                "model": data.get("model") or coordinator.entry.data.get("model"),
+                "vehicle_type": data.get("vehicle_type"),
+                "distance_from_anchor_m": round(distance, 3),
+                "map_revision": map_data.get("revision"),
+                "georeference_source": georeference.get("source"),
+                "georeference_status": georeference.get("status")
+                or (georeference.get("validation") or {}).get("status"),
+                "map_api_path": f"/api/navimower/map/{entry_id}",
+                "local_to_site_en": affine,
+                "svg_matrix": _svg_matrix(affine),
+                "local_bounds": local_bounds,
+                "site_bounds": site_bounds,
+                "svg_bounds": svg_bounds,
+            }
+        )
+
+    combined = _merge_site_bounds(site_bounds_items)
+    base["members"] = members
+    base["multi_mower"] = len(members) >= 2
+    base["combined_site_bounds"] = combined
+    base["combined_svg_bounds"] = _svg_bounds(combined)
+    base["excluded_valid_count"] = excluded_valid
+    base["unresolved_count"] = unresolved
+    return base
+
+
+__all__ = [
+    "MULTI_MOWER_SITE_RADIUS_M",
+    "MULTI_MOWER_SITE_SCHEMA_VERSION",
+    "build_site_payload",
+    "map_local_bounds",
+]

--- a/tests/test_v044_beta2.py
+++ b/tests/test_v044_beta2.py
@@ -1,7 +1,6 @@
-"""Regression tests for Navimower 0.4.4-beta2 georeference diagnostics."""
+"""Historical regression tests for Navimower 0.4.4-beta2 diagnostics."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 from custom_components.navimower.diagnostics_sanitize import sanitize
@@ -10,10 +9,8 @@ ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
 
-def test_beta2_version_and_release_notes() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.4-beta2"
-
+def test_beta2_release_notes_remain_available() -> None:
+    """Keep beta2 as historical coverage without pinning the current manifest."""
     notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta2.md").read_text(
         encoding="utf-8"
     )

--- a/tests/test_v044_beta3.py
+++ b/tests/test_v044_beta3.py
@@ -1,0 +1,230 @@
+"""Regression tests for Navimower 0.4.4-beta3 universal georeference/site support."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from custom_components.navimower.georeference import (
+    georeference_from_geometry,
+    local_xy_to_wgs84,
+    offset_wgs84,
+    update_georeference,
+)
+from custom_components.navimower.multi_mower import build_site_payload
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _truth_georeference(
+    latitude: float = 58.0,
+    longitude: float = 24.0,
+    rotation_rad: float = 0.6,
+) -> dict:
+    return {
+        "schema_version": 2,
+        "status": "validated",
+        "source": "synthetic",
+        "reference": {
+            "local_x": 10.0,
+            "local_y": -5.0,
+            "latitude": latitude,
+            "longitude": longitude,
+        },
+        "rotation_rad": rotation_rad,
+    }
+
+
+def _location(truth: dict, x: float, y: float, report_time: int) -> dict:
+    point = local_xy_to_wgs84(truth, x, y)
+    assert point is not None
+    return {
+        "posture_x": x,
+        "posture_y": y,
+        "latitude": point[0],
+        "longitude": point[1],
+        "report_time": str(report_time),
+    }
+
+
+def _coordinator(entry_id: str, georeference: dict, polygon=None):
+    polygon = polygon or [[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]]
+    return SimpleNamespace(
+        data={
+            "name": entry_id,
+            "model": "test",
+            "vehicle_type": 1,
+            "georeference": georeference,
+            "map": {
+                "revision": f"map-{entry_id}",
+                "zones": [{"id": 1, "polygon": polygon}],
+            },
+        },
+        entry=SimpleNamespace(title=entry_id, data={"model": "test"}),
+    )
+
+
+def test_beta3_version_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.4-beta3"
+
+    notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta3.md").read_text(
+        encoding="utf-8"
+    )
+    assert notes.startswith("title: Navimower 0.4.4-beta3")
+    assert "Universal map georeference" in notes
+    assert "/api/navimower/site/{entry_id}" in notes
+    assert "500 m" in notes
+
+
+def test_cloud_location_fit_learns_one_stable_transform() -> None:
+    truth = _truth_georeference()
+    geometry = {"revision": "1|100|200|v:300"}
+    result = None
+    for index, (x, y) in enumerate(
+        [(0, 0), (3, 2), (6, -1), (9, 4), (12, 1), (15, 5), (18, -2)]
+    ):
+        result = update_georeference(geometry, _location(truth, x, y, index + 1))
+
+    assert result is not None
+    assert result["schema_version"] == 2
+    assert result["source"] == "cloud_location_fit"
+    assert result["status"] == "validated"
+    assert result["map_revision"] == geometry["revision"]
+    assert result["calibration"]["sample_count"] >= 5
+    assert result["calibration"]["baseline_m"] >= 10.0
+    assert result["calibration"]["rms_error_m"] < 0.05
+    assert abs(result["rotation_rad"] - truth["rotation_rad"]) < 0.001
+
+    expected = local_xy_to_wgs84(truth, 21.0, 3.0)
+    actual = local_xy_to_wgs84(result, 21.0, 3.0)
+    assert expected is not None and actual is not None
+    assert abs(expected[0] - actual[0]) < 0.000001
+    assert abs(expected[1] - actual[1]) < 0.000001
+
+
+def test_unversioned_last_location_pair_is_not_used_for_learning() -> None:
+    truth = _truth_georeference()
+    geometry = {"revision": "map-a"}
+    current = _location(truth, 0.0, 0.0, 1)
+    far = _location(truth, 30.0, 10.0, 999)
+
+    result = None
+    for report_time in range(1, 7):
+        result = update_georeference(
+            geometry,
+            {
+                **current,
+                "report_time": str(report_time),
+                "last_posture_x": far["posture_x"],
+                "last_posture_y": far["posture_y"],
+                "last_latitude": far["latitude"],
+                "last_longitude": far["longitude"],
+            },
+        )
+
+    assert result is not None
+    assert result["status"] == "learning"
+    assert result["calibration"]["sample_count"] == 1
+    assert result["calibration"]["baseline_m"] == 0.0
+
+
+def test_map_revision_change_resets_learned_calibration() -> None:
+    truth = _truth_georeference()
+    geometry = {"revision": "map-a"}
+    result = None
+    for index, x in enumerate((0, 3, 6, 9, 12, 15)):
+        result = update_georeference(geometry, _location(truth, x, index % 2, index))
+    assert result is not None and result["status"] == "validated"
+
+    geometry["revision"] = "map-b"
+    result = update_georeference(geometry, _location(truth, 1, 1, 100))
+    assert result is not None
+    assert result["status"] == "learning"
+    assert result["map_revision"] == "map-b"
+    assert result["calibration"]["sample_count"] == 1
+
+
+def test_vendor_map_detail_is_only_a_bootstrap_until_universal_fit_is_ready() -> None:
+    vendor_geometry = {
+        "map_circle_center": [-6.191056109109541, 9.324995591152359],
+        "center_gps": [24.638561248779297, 58.384281158447266],
+        "map_north_offset": 0.5977016091346741,
+    }
+    vendor = georeference_from_geometry(vendor_geometry)
+    assert vendor is not None
+    geometry = {"revision": "h2-map", "_vendor_georeference": vendor}
+    location = {
+        "posture_x": "0.184",
+        "posture_y": "-2.768",
+        "latitude": "58.3841591",
+        "longitude": "24.6385326",
+        "report_time": "1785252961",
+    }
+
+    result = update_georeference(geometry, location)
+    assert result is not None
+    assert result["schema_version"] == 2
+    assert result["source"] == "vendor_map_detail"
+    assert result["status"] == "validated"
+    assert result["calibration"]["sample_count"] == 1
+    assert result["vendor_hint"]["validation"]["valid"] is True
+
+
+def test_site_payload_groups_only_validated_mowers_within_500m() -> None:
+    root_geo = _truth_georeference()
+    near_point = offset_wgs84(58.0, 24.0, 100.0, 0.0)
+    far_point = offset_wgs84(58.0, 24.0, 650.0, 0.0)
+    assert near_point is not None and far_point is not None
+    near_geo = _truth_georeference(near_point[0], near_point[1], -0.2)
+    far_geo = _truth_georeference(far_point[0], far_point[1], 0.1)
+
+    payload = build_site_payload(
+        "root",
+        {
+            "root": _coordinator("root", root_geo),
+            "near": _coordinator("near", near_geo),
+            "far": _coordinator("far", far_geo),
+        },
+    )
+
+    assert payload["multi_mower"] is True
+    assert [item["entry_id"] for item in payload["members"]] == ["root", "near"]
+    assert payload["excluded_valid_count"] == 1
+    assert payload["unresolved_count"] == 0
+    assert payload["combined_svg_bounds"] is not None
+    for member in payload["members"]:
+        assert member["local_to_site_en"] is not None
+        assert len(member["svg_matrix"]) == 6
+        assert member["svg_bounds"] is not None
+
+
+def test_site_grouping_is_anchor_relative_not_transitive() -> None:
+    root_geo = _truth_georeference()
+    middle_point = offset_wgs84(58.0, 24.0, 450.0, 0.0)
+    chained_point = offset_wgs84(58.0, 24.0, 850.0, 0.0)
+    assert middle_point is not None and chained_point is not None
+
+    payload = build_site_payload(
+        "root",
+        {
+            "root": _coordinator("root", root_geo),
+            "middle": _coordinator(
+                "middle", _truth_georeference(middle_point[0], middle_point[1])
+            ),
+            "chained": _coordinator(
+                "chained", _truth_georeference(chained_point[0], chained_point[1])
+            ),
+        },
+    )
+
+    assert [item["entry_id"] for item in payload["members"]] == ["root", "middle"]
+    assert payload["excluded_valid_count"] == 1
+
+
+def test_map_api_advertises_and_registers_site_endpoint() -> None:
+    source = (COMPONENT / "map_api.py").read_text(encoding="utf-8")
+    assert '"site_api_path": f"/api/navimower/site/{entry_id}"' in source
+    assert 'url = "/api/navimower/site/{entry_id}"' in source
+    assert "hass.http.register_view(NavimowerSiteView())" in source


### PR DESCRIPTION
## Summary

Prepares the integration side for a future Multi-mower Map Card while keeping browser work minimal.

### Universal georeference
- learns local map X/Y -> WGS84 from the normal private-cloud current `posture_x/posture_y + latitude/longitude` pair
- no additional cloud requests
- requires spatially separated samples before accepting a fit
- robust fit diagnostics: baseline, RMS/max error, observed scale and rejected samples
- validated transforms persist with the decoded map revision and survive HA restarts
- map revision changes reset calibration naturally
- three consecutive validation mismatches trigger relearning
- `last_*` pairs are intentionally excluded because they do not have a trustworthy independent map-revision/timestamp association
- vendor `center_gps/map_north_offset` remains an optional bootstrap/cross-check where available, not a model requirement

### Integration-owned multi-mower site model
- adds authenticated `/api/navimower/site/{entry_id}`
- groups only validated mower maps within 500 m of the anchor mower
- grouping is anchor-relative, not transitive
- precomputes local -> common site East/North affine transforms
- precomputes SVG matrices and per-mower/combined bounds server-side
- resolves device/entity metadata and map API paths server-side
- existing single-mower Map API remains compatible and advertises the site endpoint

### Model evidence considered
The common current location XY/GPS primitive has now been observed in diagnostics from H1/H2, i1, i2 AWD, i2 LiDAR, X3 and X4 families. CM/Terranox remains the major family not yet represented in our diagnostic set.

### Tests
Adds regression coverage for learned transforms, map-revision reset, deliberate `last_*` exclusion, vendor bootstrap and 500 m/non-transitive site grouping.