### PR TITLE
Navimower 0.4.4-beta4: multi-mower frontend handoff

### DIFF
--- a/.github/release-notes/0.4.4-beta4.md
+++ b/.github/release-notes/0.4.4-beta4.md
@@ -1,0 +1,12 @@
+title: Navimower 0.4.4-beta4
+
+## Multi-mower Map Card handoff metadata
+
+- Extends the authenticated Map/Site API frontend metadata so every mower member exposes its resolved Home Assistant mower/device identifiers plus direct `map_api_path`, `sessions_api_path`, `session_render_api_path_template` and `site_api_path` values.
+- Adds the mower's resolved `notification` sensor to the same server-side metadata. A future Multi-mower Map Card can merge notifications from multiple mower devices without scanning the Home Assistant entity registry in the browser.
+- Adds a stable `site_center` for every validated site member and returns site members in deterministic west-to-east order. Each member now includes `display_order`, while the payload advertises `member_order: west_to_east`.
+- West/east ordering is based on the mower map footprint in the common site coordinate system, not on the mower's changing live position. If decoded geometry is temporarily unavailable, the georeference reference point is used as the fallback ordering anchor.
+- Keeps the beta3 grouping rule unchanged: only validated mower maps within 500 m of the selected anchor mower are members of the site, and grouping remains anchor-relative rather than transitive.
+- Keeps all multi-mower behavior opt-in at the frontend layer. This integration beta does not force the current single-mower Map Card into a combined view.
+
+This beta finishes the backend handoff needed for the first Multi-mower Map Card beta: the card can render members using the precomputed site transforms, place mower-specific controls/Schedule/session rows in west-to-east order and combine notification feeds while keeping commands targeted to the correct mower device.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta3"
+  "version": "0.4.4-beta4"
 }

--- a/custom_components/navimower/map_api.py
+++ b/custom_components/navimower/map_api.py
@@ -55,6 +55,11 @@ def _frontend_metadata(coordinator: Any) -> dict[str, Any]:
     return {
         "entry_id": entry_id,
         "device_id": device.id if device is not None else None,
+        "map_api_path": f"/api/navimower/map/{entry_id}",
+        "sessions_api_path": f"/api/navimower/sessions/{entry_id}",
+        "session_render_api_path_template": (
+            f"/api/navimower/session-render/{entry_id}/{{session_id}}"
+        ),
         "site_api_path": f"/api/navimower/site/{entry_id}",
         "entities": {
             "mower": entity_id("lawn_mower", "mower"),
@@ -64,6 +69,7 @@ def _frontend_metadata(coordinator: Any) -> dict[str, Any]:
             "heading": entity_id("sensor", "heading"),
             "battery": entity_id("sensor", "battery"),
             "current_physical_zone": entity_id("sensor", "current_physical_zone"),
+            "notification": entity_id("sensor", "notification"),
             "native_schedule_data": entity_id("sensor", "schedule"),
             "schedule_status": entity_id("sensor", "navimower_schedule_status"),
             "managed_schedule": entity_id("switch", "navimower_schedule"),

--- a/custom_components/navimower/multi_mower.py
+++ b/custom_components/navimower/multi_mower.py
@@ -115,6 +115,33 @@ def _site_bounds(
     }
 
 
+def _site_center(
+    site_bounds: dict[str, float] | None,
+    affine: dict[str, float] | None,
+    georeference: dict[str, Any],
+) -> dict[str, float] | None:
+    """Return one stable site-space point for west/east UI ordering.
+
+    Prefer the decoded map footprint center so controls follow the map's actual
+    placement. If geometry is temporarily unavailable, fall back to the
+    georeference reference point transformed into the common site frame.
+    """
+    if site_bounds is not None:
+        return {
+            "east": (site_bounds["min_east"] + site_bounds["max_east"]) / 2.0,
+            "north": (site_bounds["min_north"] + site_bounds["max_north"]) / 2.0,
+        }
+    if affine is None:
+        return None
+    reference = georeference.get("reference") or {}
+    local_x = _as_float(reference.get("local_x"))
+    local_y = _as_float(reference.get("local_y"))
+    if local_x is None or local_y is None:
+        return None
+    east, north = _transform_point(affine, local_x, local_y)
+    return {"east": east, "north": north}
+
+
 def _svg_matrix(affine: dict[str, float] | None) -> list[float] | None:
     if affine is None:
         return None
@@ -164,6 +191,27 @@ def _merge_site_bounds(bounds: list[dict[str, float]]) -> dict[str, float] | Non
     }
 
 
+def _member_order_key(member: dict[str, Any]) -> tuple[Any, ...]:
+    """Sort members west-to-east without relying on live mower position."""
+    center = member.get("site_center")
+    if isinstance(center, dict):
+        east = _as_float(center.get("east"))
+        north = _as_float(center.get("north"))
+        if east is not None:
+            return (
+                0,
+                east,
+                north if north is not None else 0.0,
+                str(member.get("entry_id") or ""),
+            )
+    return (
+        1,
+        _as_float(member.get("distance_from_anchor_m")) or 0.0,
+        0.0,
+        str(member.get("entry_id") or ""),
+    )
+
+
 def build_site_payload(
     root_entry_id: str,
     coordinators: dict[str, Any],
@@ -195,6 +243,7 @@ def build_site_payload(
         "radius_m": float(radius_m),
         "status": root_status,
         "multi_mower": False,
+        "member_order": "west_to_east",
         "origin": None,
         "combined_site_bounds": None,
         "combined_svg_bounds": None,
@@ -248,6 +297,7 @@ def build_site_payload(
         )
         local_bounds = map_local_bounds(map_data)
         site_bounds = _site_bounds(local_bounds, affine)
+        site_center = _site_center(site_bounds, affine, georeference)
         svg_bounds = _svg_bounds(site_bounds)
         if site_bounds is not None:
             site_bounds_items.append(site_bounds)
@@ -267,9 +317,14 @@ def build_site_payload(
                 "svg_matrix": _svg_matrix(affine),
                 "local_bounds": local_bounds,
                 "site_bounds": site_bounds,
+                "site_center": site_center,
                 "svg_bounds": svg_bounds,
             }
         )
+
+    members.sort(key=_member_order_key)
+    for display_order, member in enumerate(members):
+        member["display_order"] = display_order
 
     combined = _merge_site_bounds(site_bounds_items)
     base["members"] = members

--- a/tests/test_v044_beta3.py
+++ b/tests/test_v044_beta3.py
@@ -1,7 +1,6 @@
 """Regression tests for Navimower 0.4.4-beta3 universal georeference/site support."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -65,10 +64,7 @@ def _coordinator(entry_id: str, georeference: dict, polygon=None):
     )
 
 
-def test_beta3_version_and_release_notes() -> None:
-    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.4-beta3"
-
+def test_beta3_release_notes_remain_available() -> None:
     notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta3.md").read_text(
         encoding="utf-8"
     )

--- a/tests/test_v044_beta4.py
+++ b/tests/test_v044_beta4.py
@@ -1,0 +1,99 @@
+"""Regression tests for Navimower 0.4.4-beta4 multi-mower frontend metadata."""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from custom_components.navimower.georeference import offset_wgs84
+from custom_components.navimower.multi_mower import build_site_payload
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _georeference(latitude: float, longitude: float) -> dict:
+    return {
+        "schema_version": 2,
+        "status": "validated",
+        "source": "synthetic",
+        "reference": {
+            "local_x": 0.0,
+            "local_y": 0.0,
+            "latitude": latitude,
+            "longitude": longitude,
+        },
+        "rotation_rad": 0.0,
+    }
+
+
+def _coordinator(entry_id: str, georeference: dict):
+    return SimpleNamespace(
+        data={
+            "name": entry_id,
+            "model": "test",
+            "vehicle_type": 1,
+            "georeference": georeference,
+            "map": {
+                "revision": f"map-{entry_id}",
+                "zones": [
+                    {
+                        "id": 1,
+                        "polygon": [
+                            [0.0, 0.0],
+                            [10.0, 0.0],
+                            [10.0, 10.0],
+                            [0.0, 10.0],
+                        ],
+                    }
+                ],
+            },
+        },
+        entry=SimpleNamespace(title=entry_id, data={"model": "test"}),
+    )
+
+
+def test_beta4_release_notes_remain_available() -> None:
+    notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta4.md").read_text(
+        encoding="utf-8"
+    )
+    assert notes.startswith("title: Navimower 0.4.4-beta4")
+    assert "west-to-east" in notes
+    assert "notification" in notes.lower()
+    assert "sessions_api_path" in notes
+
+
+def test_site_members_are_preordered_west_to_east() -> None:
+    root = (58.0, 24.0)
+    west = offset_wgs84(root[0], root[1], -80.0, 0.0)
+    east = offset_wgs84(root[0], root[1], 100.0, 0.0)
+    assert west is not None and east is not None
+
+    payload = build_site_payload(
+        "root",
+        {
+            "east": _coordinator("east", _georeference(east[0], east[1])),
+            "root": _coordinator("root", _georeference(root[0], root[1])),
+            "west": _coordinator("west", _georeference(west[0], west[1])),
+        },
+    )
+
+    assert payload["multi_mower"] is True
+    assert payload["member_order"] == "west_to_east"
+    assert [member["entry_id"] for member in payload["members"]] == [
+        "west",
+        "root",
+        "east",
+    ]
+    assert [member["display_order"] for member in payload["members"]] == [0, 1, 2]
+    centers = [member["site_center"]["east"] for member in payload["members"]]
+    assert centers == sorted(centers)
+
+
+def test_frontend_metadata_exposes_multi_mower_fast_paths() -> None:
+    source = (COMPONENT / "map_api.py").read_text(encoding="utf-8")
+
+    assert '"map_api_path": f"/api/navimower/map/{entry_id}"' in source
+    assert '"sessions_api_path": f"/api/navimower/sessions/{entry_id}"' in source
+    assert '"session_render_api_path_template": (' in source
+    assert '"notification": entity_id("sensor", "notification")' in source
+    assert '"site_api_path": f"/api/navimower/site/{entry_id}"' in source


### PR DESCRIPTION
## Summary

Prepare the integration-side handoff for the first Multi-mower Map Card beta.

- expose direct Map/Sessions/Session-render/Site API paths per mower
- expose the resolved notification sensor in frontend metadata
- precompute a stable site-space center for every site member
- return members in deterministic west-to-east order with `display_order`
- keep grouping anchor-relative and 500 m bounded
- keep multi-mower activation frontend opt-in; no automatic mode switch
- add beta4 regression coverage and release notes

The universal georeference logic from beta3 is unchanged.