### PR TITLE
Navimower 0.4.4-beta5: capability hardening and stable georeference

### DIFF
--- a/.github/release-notes/0.4.4-beta5.md
+++ b/.github/release-notes/0.4.4-beta5.md
@@ -1,0 +1,16 @@
+title: Navimower 0.4.4-beta5
+
+## Capability hardening and stable georeference calibration
+
+- Freezes a validated learned local-map -> WGS84 transform for the lifetime of the same decoded map revision. Repeated cloud-GPS mismatches remain visible as validation diagnostics but no longer erase a good multi-point fit while the mower is stationary or docked.
+- Keeps map revision changes as the authoritative automatic relearn trigger. A mower whose map really changes still starts a fresh calibration; ordinary GPS drift can no longer make a working Multi-mower site silently fall back to Single view.
+- Adds a central model-family capability layer for the observed H1, H2, i1, i2 AWD, i2 LiDAR, X3 and X4 families, with conservative Terranox placeholders for documented features that still lack private-cloud field captures.
+- Treats shared vendor `set-list` fields as reported schema, not automatic proof that a user-facing setting is supported or writable on that mower family.
+- Corrects i1 cutting-height semantics: the reported 20-60 mm range remains useful metadata, but the current `set_list.height` value is not presented as the physical manual-knob position and no remote cutting-height writer is exposed until a before/after knob test proves it is readable.
+- Keeps device-reported `mowingHeightList` as the preferred range/step source for electronically adjustable models. Family ranges are metadata fallbacks rather than hard-coded slider limits.
+- Restores broad safe battery-number fallback ranges when `batteryConfig` does not provide bounds. Exact charging/return-battery limits are used only when the mower supplies `nonstandardVehicleConfig.batteryConfig` min/max metadata.
+- Separates Mowing speed (`mode`) from Grass pattern enhancement. Enhancement is exposed only for X4/Terranox family evidence; dormant `grassPatternEnhancement` fields on H/i/X3 families no longer create a switch.
+- Gates TCS to i2 AWD/X4/Terranox, Terrain adapt to H2, and Edge sense to H2/i2 LiDAR. Unverified i2-AWD investigation controls such as positioning mode, advanced slope, narrow-zone adapt, headlight/night-animal and progress-retention controls remain hidden pending field evidence.
+- Capability diagnostics now expose schema v2 model-family and per-setting evidence (`reported`, `documented_for_family`, `readable`, `writable`, ranges/options and pending-validation markers) while preserving the raw vendor key inventory for future firmware discoveries.
+
+This beta is intentionally conservative: new firmware can add capabilities at any time, but a dormant/default vendor field alone will not make Home Assistant advertise a control until documentation or a controlled field test confirms it.

--- a/custom_components/navimower/capability_semantics.py
+++ b/custom_components/navimower/capability_semantics.py
@@ -109,6 +109,10 @@ def _strip_untrusted_i1_height(snapshot: dict[str, Any]) -> None:
         detail["cutting_height_mm"] = None
         detail["inherits_global_height"] = None
 
+    for state in snapshot.get("zone_states") or []:
+        if isinstance(state, dict):
+            state["cutting_height_mm"] = None
+
     map_data = snapshot.get("map")
     if isinstance(map_data, dict):
         for zone in map_data.get("zones") or []:
@@ -224,6 +228,10 @@ def _harden_capability_profile(
             if isinstance(item, dict):
                 item["reported"] = True
                 item["supported"] = None
+        height_item = observed.get("cutting_height")
+        if isinstance(height_item, dict) and not family.cutting_height_readable:
+            height_item["reported"] = True
+            height_item["supported"] = False
 
     settings = _set_list(snapshot)
     hardened["settings"] = {

--- a/custom_components/navimower/capability_semantics.py
+++ b/custom_components/navimower/capability_semantics.py
@@ -1,0 +1,400 @@
+"""Model-aware capability hardening layered over the shared vendor schema.
+
+Navimow returns many dormant/default ``set-list`` keys on models that do not
+actually expose the corresponding app feature.  Keep raw discovery available in
+diagnostics, but gate user-facing controls with documented/model-tested evidence.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import replace
+from typing import Any
+
+from . import coordinator as _coordinator
+from .model_capabilities import (
+    FAMILY_H2,
+    FAMILY_I1,
+    FAMILY_X3,
+    capability_profile,
+    model_family,
+)
+
+_REPORTED_ONLY_GROUPS = {
+    "schedule_control",
+    "battery_limits",
+    "weather_settings",
+    "vision_settings",
+    "lighting_settings",
+    "terrain_settings",
+    "anti_theft_settings",
+}
+
+# These i2-AWD controls were originally exposed from field presence while we
+# were investigating the family.  Keep them hidden until a manual/app capture or
+# safe before/after write test proves the feature and its exact semantics.
+_WAIT_FOR_FIELD_EVIDENCE_SWITCHES = {
+    "advanced_slope_mode",
+    "headlight",
+    "narrow_zone_adapt",
+    "night_animal_protection",
+    "progress_retention",
+}
+_WAIT_FOR_FIELD_EVIDENCE_NUMBERS = {"progress_retention_duration"}
+_WAIT_FOR_FIELD_EVIDENCE_SELECTS = {"positioning_mode"}
+
+
+def _raw(data: dict[str, Any]) -> dict[str, Any]:
+    value = data.get("raw")
+    return value if isinstance(value, dict) else {}
+
+
+def _set_list(data: dict[str, Any]) -> dict[str, Any]:
+    value = _raw(data).get("set_list")
+    return value if isinstance(value, dict) else {}
+
+
+def _device_info(data: dict[str, Any]) -> dict[str, Any]:
+    value = _raw(data).get("device_info")
+    return value if isinstance(value, dict) else {}
+
+
+def _battery_config(data: dict[str, Any]) -> dict[str, Any]:
+    nonstandard = _device_info(data).get("nonstandardVehicleConfig")
+    if not isinstance(nonstandard, dict):
+        return {}
+    config = nonstandard.get("batteryConfig")
+    return config if isinstance(config, dict) else {}
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _height_options(data: dict[str, Any]) -> list[int]:
+    values = _device_info(data).get("mowingHeightList")
+    result: list[int] = []
+    for value in values if isinstance(values, list) else []:
+        parsed = _as_int(value)
+        if parsed is not None and 10 <= parsed <= 150 and parsed not in result:
+            result.append(parsed)
+    return sorted(result)
+
+
+def _family_profile(data: dict[str, Any]):
+    return capability_profile(data.get("model"), _as_int(data.get("vehicle_type")))
+
+
+def _strip_untrusted_i1_height(snapshot: dict[str, Any]) -> None:
+    """Keep i1 physical range metadata without claiming knob position is known."""
+    if model_family(snapshot.get("model"), _as_int(snapshot.get("vehicle_type"))) != FAMILY_I1:
+        return
+
+    snapshot["cutting_height_supported"] = False
+    snapshot["active_cutting_height_mm"] = None
+    settings = dict(snapshot.get("settings") or {})
+    settings["cut_height"] = None
+    settings["cutting_height_supported"] = False
+    # Preserve cut_height_raw for diagnostics: it is exactly the evidence we
+    # still want to compare with a future physical-knob before/after test.
+    snapshot["settings"] = settings
+
+    for detail in snapshot.get("zone_details") or []:
+        if not isinstance(detail, dict):
+            continue
+        detail["cutting_height_supported"] = False
+        detail["configured_height_mm"] = None
+        detail["cutting_height_mm"] = None
+        detail["inherits_global_height"] = None
+
+    map_data = snapshot.get("map")
+    if isinstance(map_data, dict):
+        for zone in map_data.get("zones") or []:
+            if not isinstance(zone, dict):
+                continue
+            boundary = zone.get("boundary")
+            if isinstance(boundary, dict):
+                boundary.pop("height_set", None)
+
+    for session in snapshot.get("sessions") or []:
+        if isinstance(session, dict):
+            session["cutting_height_mm"] = None
+
+
+def _feature_entry(
+    data: dict[str, Any],
+    *,
+    vendor_field: str,
+    documented: bool,
+) -> dict[str, Any]:
+    settings = _set_list(data)
+    reported = vendor_field in settings
+    return {
+        "vendor_field": vendor_field,
+        "reported": reported,
+        "documented_for_family": documented,
+        "readable": bool(documented and reported),
+        "writable": bool(documented and reported),
+        "reported_value": settings.get(vendor_field) if reported else None,
+        "waiting_for_firmware_or_field_evidence": bool(reported and not documented),
+    }
+
+
+def _height_capability(data: dict[str, Any]) -> dict[str, Any]:
+    family = _family_profile(data)
+    options = _height_options(data)
+    raw_height = _as_int(_set_list(data).get("height"))
+    if options:
+        physical_range = [min(options), max(options)]
+        range_source = "device_info.mowingHeightList"
+    elif family.cutting_height_range_mm is not None:
+        physical_range = list(family.cutting_height_range_mm)
+        range_source = "official_family_fallback"
+    else:
+        physical_range = None
+        range_source = None
+    return {
+        "adjustment": family.cutting_height_adjustment,
+        "physical_range_mm": physical_range,
+        "range_source": range_source,
+        "reported_options_mm": options,
+        "reported_current_value": raw_height,
+        "readable_current_value": bool(
+            family.cutting_height_readable and raw_height is not None
+        ),
+        "writable": bool(family.cutting_height_writable and options),
+        "global_control": bool(family.cutting_height_writable and options),
+        "manual_current_value_pending_validation": family.family == FAMILY_I1,
+        "evidence": [
+            value
+            for value in (
+                "official_family_behavior" if family.cutting_height_adjustment else None,
+                "device_info.mowingHeightList" if options else None,
+                "set_list.height" if raw_height is not None else None,
+            )
+            if value is not None
+        ],
+    }
+
+
+def _battery_limits_capability(data: dict[str, Any]) -> dict[str, Any]:
+    settings = _set_list(data)
+    config = _battery_config(data)
+    return_min = _as_int(config.get("returnBatteryLevelMin"))
+    return_max = _as_int(config.get("returnBatteryLevelMax"))
+    charge_min = _as_int(config.get("chargingLimitMin"))
+    charge_max = _as_int(config.get("chargingLimitMax"))
+    bounds_available = None not in (return_min, return_max, charge_min, charge_max)
+    return {
+        "reported": bool(
+            "returnBatteryLevel" in settings or "chargingLimit" in settings
+        ),
+        "current_return_level": _as_int(settings.get("returnBatteryLevel")),
+        "current_charging_limit": _as_int(settings.get("chargingLimit")),
+        "vendor_bounds_available": bounds_available,
+        "return_range_pct": (
+            [return_min, return_max] if None not in (return_min, return_max) else None
+        ),
+        "charging_range_pct": (
+            [charge_min, charge_max] if None not in (charge_min, charge_max) else None
+        ),
+        "range_source": (
+            "device_info.nonstandardVehicleConfig.batteryConfig"
+            if bounds_available
+            else "entity_safe_fallback_not_vendor_claim"
+        ),
+    }
+
+
+def _harden_capability_profile(
+    snapshot: dict[str, Any], profile: dict[str, Any] | None
+) -> dict[str, Any]:
+    hardened = deepcopy(profile) if isinstance(profile, dict) else {}
+    family = _family_profile(snapshot)
+    hardened["schema_version"] = 2
+    hardened["policy"] = "reported_fields_are_not_remote_capability_proof"
+    hardened["model_family"] = family.family
+
+    observed = hardened.get("observed")
+    if isinstance(observed, dict):
+        for name in _REPORTED_ONLY_GROUPS:
+            item = observed.get(name)
+            if isinstance(item, dict):
+                item["reported"] = True
+                item["supported"] = None
+
+    settings = _set_list(snapshot)
+    hardened["settings"] = {
+        "cutting_height": _height_capability(snapshot),
+        "battery_limits": _battery_limits_capability(snapshot),
+        "mowing_speed": {
+            "vendor_field": "mode",
+            "reported": "mode" in settings,
+            "readable": "mode" in settings,
+            "writable": "mode" in settings,
+            "reported_value": settings.get("mode"),
+            "meaning": "mower_movement_speed_during_mowing",
+        },
+        "lawn_mowing_efficiency": {
+            "vendor_field": "lawnMowingEfficiency",
+            "reported": "lawnMowingEfficiency" in settings,
+            "reported_value": settings.get("lawnMowingEfficiency"),
+            "relationship_to_mowing_speed_pending_validation": True,
+        },
+        "grass_pattern_enhancement": _feature_entry(
+            snapshot,
+            vendor_field="grassPatternEnhancement",
+            documented=family.grass_pattern_enhancement,
+        ),
+        "traction_control": _feature_entry(
+            snapshot,
+            vendor_field="tcsSwitch",
+            documented=family.traction_control,
+        ),
+        "terrain_adapt": _feature_entry(
+            snapshot,
+            vendor_field="terrainAdaptSwitch",
+            documented=family.terrain_adapt,
+        ),
+        "edge_sense": _feature_entry(
+            snapshot,
+            vendor_field="edgeSense",
+            documented=family.edge_sense,
+        ),
+    }
+    return hardened
+
+
+def _install_snapshot_semantics() -> None:
+    cls = _coordinator.NavimowCoordinator
+    if getattr(cls, "_model_capability_semantics_installed", False):
+        return
+    original_parse = cls._parse
+
+    def parse(self: Any, raw: dict[str, Any]) -> dict[str, Any]:
+        snapshot = original_parse(self, raw)
+        snapshot["model_family"] = model_family(
+            snapshot.get("model"), _as_int(snapshot.get("vehicle_type"))
+        )
+        _strip_untrusted_i1_height(snapshot)
+        hardened = _harden_capability_profile(snapshot, snapshot.get("capabilities"))
+        snapshot["capabilities"] = hardened
+        self._capability_profile = deepcopy(hardened)
+        return snapshot
+
+    cls._parse = parse
+    cls._model_capability_semantics_installed = True
+
+
+def _install_switch_semantics() -> None:
+    from . import switch as platform
+
+    original_model_supported = platform._model_supported
+
+    def model_supported(description: Any, data: dict[str, Any]) -> bool:
+        family = _family_profile(data)
+        key = description.key
+        if key == "traction_control":
+            return family.traction_control
+        if key == "terrain_adapt":
+            return family.terrain_adapt
+        if key == "edge_sense":
+            return family.edge_sense
+        if key == "grass_pattern_enhancement":
+            return family.grass_pattern_enhancement
+        if key in _WAIT_FOR_FIELD_EVIDENCE_SWITCHES:
+            return False
+        return original_model_supported(description, data)
+
+    platform._model_supported = model_supported
+
+
+def _install_select_semantics() -> None:
+    from . import select as platform
+
+    rewritten = []
+    for description in platform.SETTING_SELECTS:
+        if description.key == "work_mode":
+            description = replace(
+                description,
+                name="Mowing speed",
+                translation_key=None,
+                icon="mdi:speedometer",
+            )
+        rewritten.append(description)
+    platform.SETTING_SELECTS = tuple(rewritten)
+
+    original_model_supported = platform._model_supported
+
+    def model_supported(description: Any, data: dict[str, Any]) -> bool:
+        family = _family_profile(data)
+        key = description.key
+        if key == "night_light_level":
+            return family.family == FAMILY_H2
+        if key == "light_brightness":
+            return family.family == FAMILY_X3
+        if key == "edge_sense_mode":
+            return family.edge_sense
+        if key in _WAIT_FOR_FIELD_EVIDENCE_SELECTS:
+            return False
+        return original_model_supported(description, data)
+
+    platform._model_supported = model_supported
+
+
+def _install_number_semantics() -> None:
+    from . import number as platform
+
+    # capability_extensions intentionally tightened these while i2 AWD was under
+    # investigation.  When batteryConfig is absent that would falsely present a
+    # vendor-defined range.  Restore the broad safe entity fallback; the existing
+    # entity initializer still replaces it with exact batteryConfig bounds when
+    # the mower supplies them.
+    rewritten = []
+    for description in platform.NUMBERS:
+        if description.key == "return_battery_level":
+            description = replace(
+                description,
+                native_min_value=5,
+                native_max_value=50,
+                native_step=5,
+            )
+        elif description.key == "charging_limit":
+            description = replace(
+                description,
+                native_min_value=50,
+                native_max_value=100,
+                native_step=5,
+            )
+        rewritten.append(description)
+    platform.NUMBERS = tuple(rewritten)
+
+    original_wire_value = platform._wire_value
+
+    def wire_value(description: Any, data: dict[str, Any]) -> int | None:
+        if description.key == "cutting_height":
+            family = _family_profile(data)
+            if not family.cutting_height_writable or not _height_options(data):
+                return None
+        if description.key in _WAIT_FOR_FIELD_EVIDENCE_NUMBERS:
+            return None
+        return original_wire_value(description, data)
+
+    platform._wire_value = wire_value
+
+
+def install_capability_semantics() -> None:
+    """Install conservative model-family gates after legacy capability patches."""
+    cls = _coordinator.NavimowCoordinator
+    if getattr(cls, "_capability_semantics_installed", False):
+        return
+    _install_snapshot_semantics()
+    _install_switch_semantics()
+    _install_select_semantics()
+    _install_number_semantics()
+    cls._capability_semantics_installed = True
+
+
+__all__ = ["install_capability_semantics"]

--- a/custom_components/navimower/capability_semantics.py
+++ b/custom_components/navimower/capability_semantics.py
@@ -10,7 +10,6 @@ from copy import deepcopy
 from dataclasses import replace
 from typing import Any
 
-from . import coordinator as _coordinator
 from .model_capabilities import (
     FAMILY_H2,
     FAMILY_I1,
@@ -276,6 +275,8 @@ def _harden_capability_profile(
 
 
 def _install_snapshot_semantics() -> None:
+    from . import coordinator as _coordinator
+
     cls = _coordinator.NavimowCoordinator
     if getattr(cls, "_model_capability_semantics_installed", False):
         return
@@ -395,6 +396,8 @@ def _install_number_semantics() -> None:
 
 def install_capability_semantics() -> None:
     """Install conservative model-family gates after legacy capability patches."""
+    from . import coordinator as _coordinator
+
     cls = _coordinator.NavimowCoordinator
     if getattr(cls, "_capability_semantics_installed", False):
         return

--- a/custom_components/navimower/georeference_semantics.py
+++ b/custom_components/navimower/georeference_semantics.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
-from . import coordinator_semantics as _coordinator_semantics
 from . import georeference as _georeference
 
 _LEARNED_VALIDATION_LIMIT_M = 3.0
+_ORIGINAL_UPDATE_GEOREFERENCE = _georeference.update_georeference
 
 
 def _validated_fit(calibration: Any, revision: str) -> dict[str, Any] | None:
@@ -25,76 +25,78 @@ def _validated_fit(calibration: Any, revision: str) -> dict[str, Any] | None:
     return fit
 
 
+def stable_update_georeference(
+    map_geometry: Any, location: Any
+) -> dict[str, Any] | None:
+    """Update georeference while freezing a good fit for the same map revision."""
+    if not isinstance(map_geometry, dict):
+        return _ORIGINAL_UPDATE_GEOREFERENCE(map_geometry, location)
+
+    revision = str(map_geometry.get("revision") or "")
+    calibration_before = map_geometry.get("_georeference_calibration")
+    frozen_fit = _validated_fit(calibration_before, revision)
+    frozen_state = deepcopy(calibration_before) if frozen_fit is not None else None
+    frozen_fit_copy = deepcopy(frozen_fit) if frozen_fit is not None else None
+
+    result = _ORIGINAL_UPDATE_GEOREFERENCE(map_geometry, location)
+    if frozen_state is None or frozen_fit_copy is None:
+        return result
+
+    # The old learner reset after three consecutive >3 m cloud-GPS mismatches.
+    # A stationary mower can produce exactly that while the already fitted local
+    # map remains correct. Preserve the fit/samples and only update diagnostics.
+    validated = _georeference.validate_georeference(
+        frozen_fit_copy,
+        location,
+        limit_m=_LEARNED_VALIDATION_LIMIT_M,
+    ) or frozen_fit_copy
+    validation = dict((validated.get("validation") or {}))
+    previous_mismatches = int(frozen_state.get("mismatch_count") or 0)
+    if validation.get("valid") is False:
+        frozen_state["mismatch_count"] = previous_mismatches + 1
+    elif validation.get("valid") is True:
+        frozen_state["mismatch_count"] = 0
+    else:
+        frozen_state["mismatch_count"] = previous_mismatches
+    frozen_state["last_validation"] = validation
+    frozen_state["fit"] = frozen_fit_copy
+    map_geometry["_georeference_calibration"] = frozen_state
+
+    active = dict(validated)
+    active["schema_version"] = 2
+    active["source"] = "cloud_location_fit"
+    active["status"] = "validated"
+    active["map_revision"] = revision
+    active["calibration"] = _georeference._calibration_summary(  # noqa: SLF001
+        frozen_state
+    )
+
+    vendor = map_geometry.get("_vendor_georeference")
+    _, vendor_hint = _georeference._vendor_hint(  # noqa: SLF001
+        vendor if isinstance(vendor, dict) else None,
+        location,
+        active,
+    )
+    if vendor_hint is not None:
+        active["vendor_hint"] = vendor_hint
+
+    map_geometry["georeference"] = active
+    return active
+
+
 def install_georeference_semantics() -> None:
-    """Freeze a validated fit until the decoded map revision actually changes."""
+    """Route the coordinator through the revision-stable update policy once."""
     if getattr(_georeference, "_stable_revision_fit_installed", False):
         return
 
-    original_update = _georeference.update_georeference
+    # Coordinator semantics imports update_georeference directly, so update both
+    # the source module and that bound runtime reference. Import the HA-dependent
+    # coordinator lazily so the pure policy remains usable in lightweight tests.
+    from . import coordinator_semantics as _coordinator_semantics
 
-    def update_georeference(map_geometry: Any, location: Any) -> dict[str, Any] | None:
-        if not isinstance(map_geometry, dict):
-            return original_update(map_geometry, location)
-
-        revision = str(map_geometry.get("revision") or "")
-        calibration_before = map_geometry.get("_georeference_calibration")
-        frozen_fit = _validated_fit(calibration_before, revision)
-        frozen_state = (
-            deepcopy(calibration_before) if frozen_fit is not None else None
-        )
-        frozen_fit_copy = deepcopy(frozen_fit) if frozen_fit is not None else None
-
-        result = original_update(map_geometry, location)
-        if frozen_state is None or frozen_fit_copy is None:
-            return result
-
-        # The old learner reset after three consecutive >3 m cloud-GPS
-        # mismatches.  A stationary mower can produce exactly that while the
-        # already fitted local map remains perfectly correct.  Preserve the fit
-        # and samples; only update passive validation diagnostics.
-        validated = _georeference.validate_georeference(
-            frozen_fit_copy,
-            location,
-            limit_m=_LEARNED_VALIDATION_LIMIT_M,
-        ) or frozen_fit_copy
-        validation = dict((validated.get("validation") or {}))
-        previous_mismatches = int(frozen_state.get("mismatch_count") or 0)
-        if validation.get("valid") is False:
-            frozen_state["mismatch_count"] = previous_mismatches + 1
-        elif validation.get("valid") is True:
-            frozen_state["mismatch_count"] = 0
-        else:
-            frozen_state["mismatch_count"] = previous_mismatches
-        frozen_state["last_validation"] = validation
-        frozen_state["fit"] = frozen_fit_copy
-        map_geometry["_georeference_calibration"] = frozen_state
-
-        active = dict(validated)
-        active["schema_version"] = 2
-        active["source"] = "cloud_location_fit"
-        active["status"] = "validated"
-        active["map_revision"] = revision
-        active["calibration"] = _georeference._calibration_summary(  # noqa: SLF001
-            frozen_state
-        )
-
-        vendor = map_geometry.get("_vendor_georeference")
-        _, vendor_hint = _georeference._vendor_hint(  # noqa: SLF001
-            vendor if isinstance(vendor, dict) else None,
-            location,
-            active,
-        )
-        if vendor_hint is not None:
-            active["vendor_hint"] = vendor_hint
-
-        map_geometry["georeference"] = active
-        return active
-
-    # Coordinator semantics imported the helper directly, so update both the
-    # source module and that bound runtime reference.
-    _georeference.update_georeference = update_georeference
-    _coordinator_semantics.update_georeference = update_georeference
+    _georeference.update_georeference = stable_update_georeference
+    _coordinator_semantics.update_georeference = stable_update_georeference
     _georeference._stable_revision_fit_installed = True
 
 
-__all__ = ["install_georeference_semantics"]
+__all__ = ["install_georeference_semantics", "stable_update_georeference"]

--- a/custom_components/navimower/georeference_semantics.py
+++ b/custom_components/navimower/georeference_semantics.py
@@ -1,0 +1,100 @@
+"""Protect a validated map transform from stationary cloud-GPS drift.
+
+The learned transform is tied to the decoded map revision.  Once that transform
+has passed the multi-point fit, repeated GPS validation mismatches are useful
+diagnostics but are not sufficient evidence that the map frame changed.  The
+map revision is the authoritative relearn trigger.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from . import coordinator_semantics as _coordinator_semantics
+from . import georeference as _georeference
+
+_LEARNED_VALIDATION_LIMIT_M = 3.0
+
+
+def _validated_fit(calibration: Any, revision: str) -> dict[str, Any] | None:
+    if not isinstance(calibration, dict) or calibration.get("map_revision") != revision:
+        return None
+    fit = calibration.get("fit")
+    if not isinstance(fit, dict) or not _georeference.georeference_is_valid(fit):
+        return None
+    return fit
+
+
+def install_georeference_semantics() -> None:
+    """Freeze a validated fit until the decoded map revision actually changes."""
+    if getattr(_georeference, "_stable_revision_fit_installed", False):
+        return
+
+    original_update = _georeference.update_georeference
+
+    def update_georeference(map_geometry: Any, location: Any) -> dict[str, Any] | None:
+        if not isinstance(map_geometry, dict):
+            return original_update(map_geometry, location)
+
+        revision = str(map_geometry.get("revision") or "")
+        calibration_before = map_geometry.get("_georeference_calibration")
+        frozen_fit = _validated_fit(calibration_before, revision)
+        frozen_state = (
+            deepcopy(calibration_before) if frozen_fit is not None else None
+        )
+        frozen_fit_copy = deepcopy(frozen_fit) if frozen_fit is not None else None
+
+        result = original_update(map_geometry, location)
+        if frozen_state is None or frozen_fit_copy is None:
+            return result
+
+        # The old learner reset after three consecutive >3 m cloud-GPS
+        # mismatches.  A stationary mower can produce exactly that while the
+        # already fitted local map remains perfectly correct.  Preserve the fit
+        # and samples; only update passive validation diagnostics.
+        validated = _georeference.validate_georeference(
+            frozen_fit_copy,
+            location,
+            limit_m=_LEARNED_VALIDATION_LIMIT_M,
+        ) or frozen_fit_copy
+        validation = dict((validated.get("validation") or {}))
+        previous_mismatches = int(frozen_state.get("mismatch_count") or 0)
+        if validation.get("valid") is False:
+            frozen_state["mismatch_count"] = previous_mismatches + 1
+        elif validation.get("valid") is True:
+            frozen_state["mismatch_count"] = 0
+        else:
+            frozen_state["mismatch_count"] = previous_mismatches
+        frozen_state["last_validation"] = validation
+        frozen_state["fit"] = frozen_fit_copy
+        map_geometry["_georeference_calibration"] = frozen_state
+
+        active = dict(validated)
+        active["schema_version"] = 2
+        active["source"] = "cloud_location_fit"
+        active["status"] = "validated"
+        active["map_revision"] = revision
+        active["calibration"] = _georeference._calibration_summary(  # noqa: SLF001
+            frozen_state
+        )
+
+        vendor = map_geometry.get("_vendor_georeference")
+        _, vendor_hint = _georeference._vendor_hint(  # noqa: SLF001
+            vendor if isinstance(vendor, dict) else None,
+            location,
+            active,
+        )
+        if vendor_hint is not None:
+            active["vendor_hint"] = vendor_hint
+
+        map_geometry["georeference"] = active
+        return active
+
+    # Coordinator semantics imported the helper directly, so update both the
+    # source module and that bound runtime reference.
+    _georeference.update_georeference = update_georeference
+    _coordinator_semantics.update_georeference = update_georeference
+    _georeference._stable_revision_fit_installed = True
+
+
+__all__ = ["install_georeference_semantics"]

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta4"
+  "version": "0.4.4-beta5"
 }

--- a/custom_components/navimower/model_capabilities.py
+++ b/custom_components/navimower/model_capabilities.py
@@ -1,0 +1,165 @@
+"""Conservative model-family capabilities backed by manuals and field evidence.
+
+Vendor ``set-list`` uses a broad shared schema and therefore cannot by itself prove
+that a setting is user-facing on a particular mower.  This module records the
+small set of family differences that we can currently defend from official model
+behavior plus Navimower field tests.  Device-reported option/range metadata still
+wins whenever it is available.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from .model_support import is_h1_generation
+
+FAMILY_H1: Final = "h1"
+FAMILY_H2: Final = "h2"
+FAMILY_I1: Final = "i1"
+FAMILY_I2_AWD: Final = "i2_awd"
+FAMILY_I2_LIDAR: Final = "i2_lidar"
+FAMILY_I2_UNKNOWN: Final = "i2_unknown"
+FAMILY_X3: Final = "x3"
+FAMILY_X4: Final = "x4"
+FAMILY_TERRANOX: Final = "terranox"
+FAMILY_UNKNOWN: Final = "unknown"
+
+
+@dataclass(frozen=True)
+class ModelCapabilityProfile:
+    """Known family behavior; ``False`` means do not expose remote control yet."""
+
+    family: str
+    cutting_height_adjustment: str | None = None
+    cutting_height_range_mm: tuple[int, int] | None = None
+    cutting_height_readable: bool = False
+    cutting_height_writable: bool = False
+    traction_control: bool = False
+    terrain_adapt: bool = False
+    edge_sense: bool = False
+    grass_pattern_enhancement: bool = False
+
+
+_PROFILES: Final[dict[str, ModelCapabilityProfile]] = {
+    FAMILY_H1: ModelCapabilityProfile(
+        family=FAMILY_H1,
+        cutting_height_adjustment="electronic",
+        cutting_height_range_mm=(30, 60),
+        cutting_height_readable=True,
+        cutting_height_writable=True,
+    ),
+    FAMILY_H2: ModelCapabilityProfile(
+        family=FAMILY_H2,
+        cutting_height_adjustment="electronic",
+        cutting_height_range_mm=(20, 70),
+        cutting_height_readable=True,
+        cutting_height_writable=True,
+        terrain_adapt=True,
+        edge_sense=True,
+    ),
+    # i1 exposes the physical 20-60 mm range in device metadata, but the user
+    # adjusts the deck with the mower's manual knob.  Until a knob-position
+    # sensor is proven by before/after diagnostics, do not treat set-list.height
+    # as the current deck height and never expose a remote height writer.
+    FAMILY_I1: ModelCapabilityProfile(
+        family=FAMILY_I1,
+        cutting_height_adjustment="manual",
+        cutting_height_range_mm=(20, 60),
+    ),
+    FAMILY_I2_AWD: ModelCapabilityProfile(
+        family=FAMILY_I2_AWD,
+        cutting_height_adjustment="electronic",
+        cutting_height_range_mm=(20, 60),
+        cutting_height_readable=True,
+        cutting_height_writable=True,
+        traction_control=True,
+    ),
+    FAMILY_I2_LIDAR: ModelCapabilityProfile(
+        family=FAMILY_I2_LIDAR,
+        cutting_height_adjustment="electronic",
+        cutting_height_range_mm=(20, 70),
+        cutting_height_readable=True,
+        cutting_height_writable=True,
+        edge_sense=True,
+    ),
+    FAMILY_I2_UNKNOWN: ModelCapabilityProfile(family=FAMILY_I2_UNKNOWN),
+    FAMILY_X3: ModelCapabilityProfile(
+        family=FAMILY_X3,
+        cutting_height_adjustment="electronic",
+        cutting_height_range_mm=(20, 70),
+        cutting_height_readable=True,
+        cutting_height_writable=True,
+    ),
+    FAMILY_X4: ModelCapabilityProfile(
+        family=FAMILY_X4,
+        cutting_height_adjustment="electronic",
+        cutting_height_range_mm=(20, 95),
+        cutting_height_readable=True,
+        cutting_height_writable=True,
+        traction_control=True,
+        grass_pattern_enhancement=True,
+    ),
+    # Terranox and X4 share the enhancement concept, but we do not have a
+    # Terranox private-cloud diagnostic/write capture yet.  Keep physical
+    # capabilities documented while remote height writes remain disabled.
+    FAMILY_TERRANOX: ModelCapabilityProfile(
+        family=FAMILY_TERRANOX,
+        cutting_height_adjustment="electronic",
+        cutting_height_range_mm=(19, 102),
+        traction_control=True,
+        grass_pattern_enhancement=True,
+    ),
+    FAMILY_UNKNOWN: ModelCapabilityProfile(family=FAMILY_UNKNOWN),
+}
+
+
+def _normalized_model(model: str | None) -> str:
+    return "".join(ch for ch in str(model or "").upper() if ch.isalnum())
+
+
+def model_family(model: str | None, vehicle_type: int | None = None) -> str:
+    """Resolve the known family without broad H-prefix misclassification."""
+    if is_h1_generation(model, vehicle_type):
+        return FAMILY_H1
+    normalized = _normalized_model(model)
+    if normalized.startswith("H2"):
+        return FAMILY_H2
+    if normalized.startswith("I1"):
+        return FAMILY_I1
+    if normalized.startswith("I2"):
+        if "AWD" in normalized:
+            return FAMILY_I2_AWD
+        if "LIDAR" in normalized:
+            return FAMILY_I2_LIDAR
+        return FAMILY_I2_UNKNOWN
+    if normalized.startswith("X3"):
+        return FAMILY_X3
+    if normalized.startswith("X4"):
+        return FAMILY_X4
+    if normalized.startswith("CM") or "TERRANOX" in normalized:
+        return FAMILY_TERRANOX
+    return FAMILY_UNKNOWN
+
+
+def capability_profile(
+    model: str | None, vehicle_type: int | None = None
+) -> ModelCapabilityProfile:
+    """Return the conservative family profile for one mower."""
+    return _PROFILES[model_family(model, vehicle_type)]
+
+
+__all__ = [
+    "FAMILY_H1",
+    "FAMILY_H2",
+    "FAMILY_I1",
+    "FAMILY_I2_AWD",
+    "FAMILY_I2_LIDAR",
+    "FAMILY_I2_UNKNOWN",
+    "FAMILY_TERRANOX",
+    "FAMILY_UNKNOWN",
+    "FAMILY_X3",
+    "FAMILY_X4",
+    "ModelCapabilityProfile",
+    "capability_profile",
+    "model_family",
+]

--- a/custom_components/navimower/runtime.py
+++ b/custom_components/navimower/runtime.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from .capability_extensions import install_capability_extensions
 from .capability_profile import install_capability_profile
+from .capability_semantics import install_capability_semantics
+from .georeference_semantics import install_georeference_semantics
 from .navigation_fallback import install_navigation_fallback
 from .notification_feed import install_notification_feed
 from .private_cloud_region import install_private_cloud_region
@@ -23,6 +25,8 @@ def install_runtime_extensions() -> None:
     install_private_cloud_region()
     install_capability_extensions()
     install_capability_profile()
+    install_capability_semantics()
+    install_georeference_semantics()
     install_navigation_fallback()
     install_notification_feed()
     install_schedule_pause_semantics()

--- a/tests/test_v044_beta5.py
+++ b/tests/test_v044_beta5.py
@@ -1,0 +1,256 @@
+"""Regression tests for 0.4.4-beta5 capability and georeference hardening."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from custom_components.navimower import capability_semantics
+from custom_components.navimower.georeference import offset_wgs84
+from custom_components.navimower.georeference_semantics import (
+    install_georeference_semantics,
+)
+from custom_components.navimower.model_capabilities import (
+    FAMILY_H1,
+    FAMILY_H2,
+    FAMILY_I1,
+    FAMILY_I2_AWD,
+    FAMILY_I2_LIDAR,
+    FAMILY_TERRANOX,
+    FAMILY_X3,
+    FAMILY_X4,
+    capability_profile,
+    model_family,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def test_model_family_matrix_covers_observed_generations() -> None:
+    assert model_family("H1500", 20000002) == FAMILY_H1
+    assert model_family("H215") == FAMILY_H2
+    assert model_family("i108") == FAMILY_I1
+    assert model_family("i208 AWD") == FAMILY_I2_AWD
+    assert model_family("i215 LiDAR") == FAMILY_I2_LIDAR
+    assert model_family("X390") == FAMILY_X3
+    assert model_family("X420") == FAMILY_X4
+    assert model_family("CM240M1") == FAMILY_TERRANOX
+
+    i1 = capability_profile("i108")
+    assert i1.cutting_height_adjustment == "manual"
+    assert i1.cutting_height_range_mm == (20, 60)
+    assert i1.cutting_height_readable is False
+    assert i1.cutting_height_writable is False
+
+    h2 = capability_profile("H215")
+    assert h2.cutting_height_writable is True
+    assert h2.terrain_adapt is True
+    assert h2.edge_sense is True
+    assert h2.grass_pattern_enhancement is False
+
+    i2_awd = capability_profile("i208 AWD")
+    assert i2_awd.traction_control is True
+    assert i2_awd.grass_pattern_enhancement is False
+
+    x4 = capability_profile("X420")
+    assert x4.traction_control is True
+    assert x4.grass_pattern_enhancement is True
+
+    terranox = capability_profile("CM240M1")
+    assert terranox.grass_pattern_enhancement is True
+    assert terranox.cutting_height_writable is False
+
+
+def test_i1_height_range_is_metadata_not_claimed_current_height() -> None:
+    snapshot = {
+        "model": "i108",
+        "vehicle_type": 160000001,
+        "cutting_height_supported": True,
+        "settings": {
+            "cut_height": 20,
+            "cut_height_raw": 20,
+            "cutting_height_supported": True,
+        },
+        "raw": {
+            "device_info": {"mowingHeightList": [20, 25, 30, 35, 40, 45, 50, 55, 60]},
+            "set_list": {
+                "height": "20",
+                "mode": "02",
+                "grassPatternEnhancement": 0,
+                "tcsSwitch": 0,
+                "terrainAdaptSwitch": 0,
+                "edgeSense": 0,
+            },
+        },
+        "zone_details": [
+            {
+                "id": 1,
+                "cutting_height_supported": True,
+                "configured_height_mm": None,
+                "cutting_height_mm": 20,
+                "inherits_global_height": None,
+            }
+        ],
+        "map": {"zones": [{"boundary": {"height_set": 316}}]},
+        "sessions": [{"cutting_height_mm": 20}],
+        "capabilities": {
+            "schema_version": 1,
+            "observed": {
+                "cutting_height": {"supported": True},
+                "terrain_settings": {"supported": True},
+            },
+        },
+    }
+
+    capability_semantics._strip_untrusted_i1_height(snapshot)  # noqa: SLF001
+    hardened = capability_semantics._harden_capability_profile(  # noqa: SLF001
+        snapshot, snapshot["capabilities"]
+    )
+
+    assert snapshot["cutting_height_supported"] is False
+    assert snapshot["settings"]["cut_height"] is None
+    assert snapshot["settings"]["cut_height_raw"] == 20
+    assert snapshot["zone_details"][0]["cutting_height_mm"] is None
+    assert "height_set" not in snapshot["map"]["zones"][0]["boundary"]
+    assert snapshot["sessions"][0]["cutting_height_mm"] is None
+
+    height = hardened["settings"]["cutting_height"]
+    assert height["physical_range_mm"] == [20, 60]
+    assert height["range_source"] == "device_info.mowingHeightList"
+    assert height["reported_current_value"] == 20
+    assert height["readable_current_value"] is False
+    assert height["writable"] is False
+    assert height["manual_current_value_pending_validation"] is True
+    assert hardened["settings"]["grass_pattern_enhancement"]["reported"] is True
+    assert hardened["settings"]["grass_pattern_enhancement"]["writable"] is False
+    assert hardened["observed"]["terrain_settings"]["supported"] is None
+
+
+def test_battery_bounds_are_only_claimed_when_device_info_supplies_them() -> None:
+    base = {
+        "model": "i108",
+        "vehicle_type": 160000001,
+        "raw": {
+            "set_list": {"returnBatteryLevel": 15, "chargingLimit": 100},
+            "device_info": {"nonstandardVehicleConfig": {"batteryConfig": {}}},
+        },
+    }
+    unbounded = capability_semantics._battery_limits_capability(base)  # noqa: SLF001
+    assert unbounded["vendor_bounds_available"] is False
+    assert unbounded["return_range_pct"] is None
+    assert unbounded["charging_range_pct"] is None
+
+    bounded = {
+        **base,
+        "raw": {
+            "set_list": base["raw"]["set_list"],
+            "device_info": {
+                "nonstandardVehicleConfig": {
+                    "batteryConfig": {
+                        "returnBatteryLevelMin": 5,
+                        "returnBatteryLevelMax": 20,
+                        "chargingLimitMin": 70,
+                        "chargingLimitMax": 100,
+                    }
+                }
+            },
+        },
+    }
+    exact = capability_semantics._battery_limits_capability(bounded)  # noqa: SLF001
+    assert exact["vendor_bounds_available"] is True
+    assert exact["return_range_pct"] == [5, 20]
+    assert exact["charging_range_pct"] == [70, 100]
+
+
+def _learned_map() -> dict:
+    fit = {
+        "schema_version": 2,
+        "source": "cloud_location_fit",
+        "status": "validated",
+        "reference": {
+            "local_x": 0.0,
+            "local_y": 0.0,
+            "latitude": 58.0,
+            "longitude": 24.0,
+        },
+        "rotation_rad": 0.0,
+        "calibration": {
+            "sample_count": 6,
+            "inlier_count": 6,
+            "rejected_count": 0,
+            "baseline_m": 12.0,
+            "rms_error_m": 0.2,
+            "max_error_m": 0.4,
+            "observed_scale": 1.0,
+            "min_samples": 5,
+            "min_baseline_m": 10.0,
+        },
+    }
+    return {
+        "revision": "map-a",
+        "_georeference_calibration": {
+            "map_revision": "map-a",
+            "samples": [
+                {"x": 0.0, "y": 0.0, "latitude": 58.0, "longitude": 24.0, "report_time": 1}
+            ],
+            "fit": fit,
+            "mismatch_count": 0,
+        },
+        "georeference": dict(fit),
+    }
+
+
+def test_validated_georeference_is_frozen_until_map_revision_changes() -> None:
+    install_georeference_semantics()
+    from custom_components.navimower import georeference as georef
+
+    geometry = _learned_map()
+    far = offset_wgs84(58.0, 24.0, 10.0, 0.0)
+    assert far is not None
+
+    for report_time in range(10, 15):
+        result = georef.update_georeference(
+            geometry,
+            {
+                "posture_x": 0.0,
+                "posture_y": 0.0,
+                "latitude": far[0],
+                "longitude": far[1],
+                "report_time": report_time,
+            },
+        )
+        assert result is not None
+        assert result["status"] == "validated"
+        assert geometry["_georeference_calibration"]["fit"] is not None
+
+    assert geometry["_georeference_calibration"]["mismatch_count"] >= 5
+
+    geometry["revision"] = "map-b"
+    changed = georef.update_georeference(
+        geometry,
+        {
+            "posture_x": 0.0,
+            "posture_y": 0.0,
+            "latitude": far[0],
+            "longitude": far[1],
+            "report_time": 20,
+        },
+    )
+    assert changed is not None
+    assert changed["status"] == "learning"
+    assert geometry["_georeference_calibration"]["map_revision"] == "map-b"
+    assert geometry["_georeference_calibration"]["fit"] is None
+
+
+def test_beta5_runtime_and_release_metadata() -> None:
+    runtime = (COMPONENT / "runtime.py").read_text(encoding="utf-8")
+    assert "install_capability_semantics()" in runtime
+    assert "install_georeference_semantics()" in runtime
+
+    manifest = (COMPONENT / "manifest.json").read_text(encoding="utf-8")
+    assert '"version": "0.4.4-beta5"' in manifest
+
+    notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta5.md").read_text(
+        encoding="utf-8"
+    )
+    assert "capability" in notes.lower()
+    assert "map revision" in notes.lower()

--- a/tests/test_v044_beta5.py
+++ b/tests/test_v044_beta5.py
@@ -5,9 +5,7 @@ from pathlib import Path
 
 from custom_components.navimower import capability_semantics
 from custom_components.navimower.georeference import offset_wgs84
-from custom_components.navimower.georeference_semantics import (
-    install_georeference_semantics,
-)
+from custom_components.navimower.georeference_semantics import stable_update_georeference
 from custom_components.navimower.model_capabilities import (
     FAMILY_H1,
     FAMILY_H2,
@@ -90,6 +88,7 @@ def test_i1_height_range_is_metadata_not_claimed_current_height() -> None:
                 "inherits_global_height": None,
             }
         ],
+        "zone_states": [{"id": 1, "cutting_height_mm": 20}],
         "map": {"zones": [{"boundary": {"height_set": 316}}]},
         "sessions": [{"cutting_height_mm": 20}],
         "capabilities": {
@@ -110,6 +109,7 @@ def test_i1_height_range_is_metadata_not_claimed_current_height() -> None:
     assert snapshot["settings"]["cut_height"] is None
     assert snapshot["settings"]["cut_height_raw"] == 20
     assert snapshot["zone_details"][0]["cutting_height_mm"] is None
+    assert snapshot["zone_states"][0]["cutting_height_mm"] is None
     assert "height_set" not in snapshot["map"]["zones"][0]["boundary"]
     assert snapshot["sessions"][0]["cutting_height_mm"] is None
 
@@ -123,6 +123,7 @@ def test_i1_height_range_is_metadata_not_claimed_current_height() -> None:
     assert hardened["settings"]["grass_pattern_enhancement"]["reported"] is True
     assert hardened["settings"]["grass_pattern_enhancement"]["writable"] is False
     assert hardened["observed"]["terrain_settings"]["supported"] is None
+    assert hardened["observed"]["cutting_height"]["supported"] is False
 
 
 def test_battery_bounds_are_only_claimed_when_device_info_supplies_them() -> None:
@@ -200,15 +201,12 @@ def _learned_map() -> dict:
 
 
 def test_validated_georeference_is_frozen_until_map_revision_changes() -> None:
-    install_georeference_semantics()
-    from custom_components.navimower import georeference as georef
-
     geometry = _learned_map()
     far = offset_wgs84(58.0, 24.0, 10.0, 0.0)
     assert far is not None
 
     for report_time in range(10, 15):
-        result = georef.update_georeference(
+        result = stable_update_georeference(
             geometry,
             {
                 "posture_x": 0.0,
@@ -225,7 +223,7 @@ def test_validated_georeference_is_frozen_until_map_revision_changes() -> None:
     assert geometry["_georeference_calibration"]["mismatch_count"] >= 5
 
     geometry["revision"] = "map-b"
-    changed = georef.update_georeference(
+    changed = stable_update_georeference(
         geometry,
         {
             "posture_x": 0.0,


### PR DESCRIPTION
## Summary

Hardens two issues found during the first real multi-mower field tests.

### Georeference
- Keep a validated learned local-map -> WGS84 fit frozen while the decoded map revision is unchanged.
- Continue reporting cloud-GPS validation mismatch/error, but do not erase a good transform after three stationary GPS outliers.
- A real map revision change remains the automatic relearn trigger.

### Model capabilities
- Add conservative H1/H2/i1/i2 AWD/i2 LiDAR/X3/X4/Terranox family profiles.
- Treat shared `set-list` keys as reported schema rather than capability proof.
- i1 keeps its 20–60 mm physical range metadata but no longer exposes `height=20` as a trusted current/manual-knob height or remote height control pending the planned knob before/after test.
- Device `mowingHeightList` remains the preferred electronic-height range/step source.
- Battery number entities use exact `batteryConfig` bounds when available and broad safe fallback ranges otherwise.
- Rename the existing `mode` select presentation to **Mowing speed** and keep Grass Pattern Enhancement separate.
- Gate Grass Pattern Enhancement to X4/Terranox, TCS to i2 AWD/X4/Terranox, Terrain adapt to H2, Edge sense to H2/i2 LiDAR.
- Hide unverified i2-AWD investigation controls pending field evidence.
- Add capability diagnostics schema v2 with per-setting reported/documented/readable/writable evidence.

Adds beta5 regression coverage for model-family classification, i1 manual-height semantics, battery metadata ranges, and georeference freeze/relearn behavior.