### PR TITLE
Fix 24-hour schedule round rollover

### DIFF
--- a/.github/release-notes/0.4.4-beta6.md
+++ b/.github/release-notes/0.4.4-beta6.md
@@ -1,0 +1,14 @@
+title: Navimower 0.4.4-beta6
+
+## 24-hour Schedule round rollover fix
+
+- Fixes the boundary between consecutive Navimower Schedule runs in `24 hours` mode.
+- Keeps the fast direct zone-to-zone handoff inside the same scheduler round.
+- Detects completion of the final zone in both Automatic and Custom schedule order modes.
+- Defers only the first `reset=true` command of the next round while the mower is still finishing or returning from the previous round.
+- Starts the new round on a later scheduler evaluation once the mower reaches a normal Docked/Paused start state.
+- Prevents the next-round start from racing the vendor task-finish transition and ending in `mow_start_not_confirmed` suspension.
+- Preserves the existing low-battery interruption, charging and resume safety paths.
+- Adds regression coverage for runtime wiring, Automatic/Custom round completion, cross-round deferral and preservation of within-round direct handoff.
+
+This beta is intended to validate continuous Schedule operation over a full selected-zone cycle and into the following round without requiring a manual Reset schedule.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta5"
+  "version": "0.4.4-beta6"
 }

--- a/custom_components/navimower/runtime.py
+++ b/custom_components/navimower/runtime.py
@@ -14,6 +14,7 @@ from .navigation_fallback import install_navigation_fallback
 from .notification_feed import install_notification_feed
 from .private_cloud_region import install_private_cloud_region
 from .schedule_pause_semantics import install_schedule_pause_semantics
+from .schedule_round_semantics import install_schedule_round_semantics
 from .setup_flow_semantics import install_setup_flow_semantics
 from .state_semantics import install_state_semantics
 from .zone_entity_cleanup import install_zone_entity_cleanup
@@ -30,5 +31,6 @@ def install_runtime_extensions() -> None:
     install_navigation_fallback()
     install_notification_feed()
     install_schedule_pause_semantics()
+    install_schedule_round_semantics()
     install_setup_flow_semantics()
     install_zone_entity_cleanup()

--- a/custom_components/navimower/schedule_round_semantics.py
+++ b/custom_components/navimower/schedule_round_semantics.py
@@ -15,8 +15,6 @@ safety gates remain owned by the base scheduler.
 """
 from __future__ import annotations
 
-from typing import Any
-
 from .const import (
     ACTIVITY_MOWING,
     ACTIVITY_RETURNING,

--- a/custom_components/navimower/schedule_round_semantics.py
+++ b/custom_components/navimower/schedule_round_semantics.py
@@ -1,0 +1,112 @@
+"""Safe continuous-round rollover semantics for Navimower Schedule.
+
+Direct handoff is useful between zones inside one scheduler round: after a zone
+completes the mower can be redirected while it is already returning instead of
+visiting the dock first. The final zone of a 24-hour round is different. At that
+boundary the base scheduler clears the completed set and advances ``round_index``
+before selecting the first zone of the next round. Sending that new ``reset=true``
+command while the mower still reports mowing/returning can race the vendor's
+normal task-finish transition and leave the new start unconfirmed.
+
+This extension keeps direct handoff inside a round, but defers only the first
+command of a newly-advanced continuous round until a later evaluation sees the
+mower in an ordinary start state (Docked/Paused). Charging and other existing
+safety gates remain owned by the base scheduler.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from .const import (
+    ACTIVITY_MOWING,
+    ACTIVITY_RETURNING,
+    SCHEDULE_MODE_CONTINUOUS,
+    SCHEDULE_ORDER_CUSTOM,
+)
+from .navimower_schedule import NavimowerScheduleController, _utc_now
+
+_INSTALLED = False
+_ORIGINAL_CONFIRM_ACTIVE_COMPLETION = NavimowerScheduleController._confirm_active_completion
+_ORIGINAL_ASYNC_SEND_MOW = NavimowerScheduleController._async_send_mow
+
+
+def _continuous_round_complete(controller: NavimowerScheduleController) -> bool:
+    """Return whether the just-confirmed completion finished the current round."""
+    if controller._mode != SCHEDULE_MODE_CONTINUOUS:
+        return False
+
+    eligible = controller._eligible_zones()
+    if not eligible:
+        return False
+
+    if controller._order_mode == SCHEDULE_ORDER_CUSTOM:
+        entries = controller._custom_queue_entries()
+        if not entries:
+            return False
+        completed_slots = {
+            int(value) for value in controller._runtime.get("completed_queue_slots") or []
+        }
+        return all(int(entry["slot"]) in completed_slots for entry in entries)
+
+    eligible_ids = {
+        int(row["id"]) for row in eligible if row.get("id") is not None
+    }
+    completed_ids = {
+        int(value)
+        for value in controller._runtime.get("completed_zone_ids_in_window") or []
+    }
+    return bool(eligible_ids) and eligible_ids.issubset(completed_ids)
+
+
+async def _confirm_active_completion(self: NavimowerScheduleController) -> bool:
+    """Remember when this evaluation completed the final zone of a 24-hour round."""
+    self._defer_continuous_round_handoff = False
+    completed = await _ORIGINAL_CONFIRM_ACTIVE_COMPLETION(self)
+    if completed and _continuous_round_complete(self):
+        self._defer_continuous_round_handoff = True
+    return completed
+
+
+async def _async_send_mow(
+    self: NavimowerScheduleController,
+    zone_id: int,
+    *,
+    reset: bool,
+    source: str,
+    queue_slot: int | None = None,
+) -> None:
+    """Defer only a cross-round direct handoff while the mower is still moving."""
+    defer_round_handoff = bool(
+        reset
+        and source == "navimower_schedule_next_zone"
+        and getattr(self, "_defer_continuous_round_handoff", False)
+    )
+    self._defer_continuous_round_handoff = False
+
+    activity = (self.coordinator.data or {}).get("activity")
+    if defer_round_handoff and activity in {ACTIVITY_MOWING, ACTIVITY_RETURNING}:
+        self._runtime["last_command"] = (
+            f"round_{int(self._runtime.get('round_index') or 1)}_waiting_idle"
+        )
+        self._runtime["last_command_at"] = _utc_now()
+        self._runtime["last_error"] = None
+        await self._save()
+        return
+
+    await _ORIGINAL_ASYNC_SEND_MOW(
+        self,
+        zone_id,
+        reset=reset,
+        source=source,
+        queue_slot=queue_slot,
+    )
+
+
+def install_schedule_round_semantics() -> None:
+    """Install safe continuous-round rollover behavior once."""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    NavimowerScheduleController._confirm_active_completion = _confirm_active_completion
+    NavimowerScheduleController._async_send_mow = _async_send_mow
+    _INSTALLED = True

--- a/tests/test_schedule_continuous_round_rollover.py
+++ b/tests/test_schedule_continuous_round_rollover.py
@@ -1,0 +1,65 @@
+"""Regression guards for safe 24-hour Navimower Schedule round rollover."""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+ROUND = COMPONENT / "schedule_round_semantics.py"
+RUNTIME = COMPONENT / "runtime.py"
+
+
+def _function_source(name: str) -> str:
+    source = ROUND.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            segment = ast.get_source_segment(source, node)
+            assert segment is not None
+            return segment
+    raise AssertionError(f"Function {name} not found")
+
+
+def test_runtime_installs_continuous_round_semantics() -> None:
+    source = RUNTIME.read_text(encoding="utf-8")
+    assert "from .schedule_round_semantics import install_schedule_round_semantics" in source
+    assert "install_schedule_pause_semantics()" in source
+    assert "install_schedule_round_semantics()" in source
+    assert source.index("install_schedule_pause_semantics()") < source.index(
+        "install_schedule_round_semantics()"
+    )
+
+
+def test_round_completion_detects_custom_and_automatic_modes() -> None:
+    source = _function_source("_continuous_round_complete")
+    assert "SCHEDULE_MODE_CONTINUOUS" in source
+    assert "SCHEDULE_ORDER_CUSTOM" in source
+    assert 'get("completed_queue_slots")' in source
+    assert 'get("completed_zone_ids_in_window")' in source
+    assert "eligible_ids.issubset(completed_ids)" in source
+
+
+def test_only_final_completion_arms_cross_round_deferral() -> None:
+    source = _function_source("_confirm_active_completion")
+    assert "_ORIGINAL_CONFIRM_ACTIVE_COMPLETION" in source
+    assert "if completed and _continuous_round_complete(self):" in source
+    assert "self._defer_continuous_round_handoff = True" in source
+
+
+def test_cross_round_start_waits_for_normal_idle_state() -> None:
+    source = _function_source("_async_send_mow")
+    assert 'source == "navimower_schedule_next_zone"' in source
+    assert "getattr(self, \"_defer_continuous_round_handoff\", False)" in source
+    assert "activity in {ACTIVITY_MOWING, ACTIVITY_RETURNING}" in source
+    assert "_ORIGINAL_ASYNC_SEND_MOW" in source
+
+
+def test_within_round_direct_handoff_is_not_disabled_globally() -> None:
+    source = _function_source("_async_send_mow")
+    # The wrapper may defer only when the completion wrapper explicitly armed
+    # the transient round-boundary flag. Ordinary zone-to-zone handoff still
+    # reaches the original scheduler command path unchanged.
+    assert "defer_round_handoff" in source
+    assert "if defer_round_handoff and activity" in source
+    assert "await _ORIGINAL_ASYNC_SEND_MOW(" in source

--- a/tests/test_v044_beta5.py
+++ b/tests/test_v044_beta5.py
@@ -244,9 +244,6 @@ def test_beta5_runtime_and_release_metadata() -> None:
     assert "install_capability_semantics()" in runtime
     assert "install_georeference_semantics()" in runtime
 
-    manifest = (COMPONENT / "manifest.json").read_text(encoding="utf-8")
-    assert '"version": "0.4.4-beta5"' in manifest
-
     notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta5.md").read_text(
         encoding="utf-8"
     )


### PR DESCRIPTION
## Summary

Fixes the boundary between consecutive Navimower Schedule runs in **24 hours** mode.

The base scheduler already advances `round_index` after all selected zones have completed, but it can immediately direct-handoff the first zone of the new round while the mower still reports `mowing`/`returning` from the final zone of the previous round. That `reset=true` start can race the vendor task-finish transition and end as `mow_start_not_confirmed`, leaving the scheduler suspended.

This change:
- keeps direct zone-to-zone handoff inside the same round;
- detects completion of the final zone of a continuous round for both Automatic and Custom order;
- advances the round as before, but defers only the first new-round command while the mower is still `mowing` or `returning`;
- lets a later scheduler evaluation start the first zone normally once the mower reaches an ordinary Docked/Paused start state;
- leaves charging/interruption safety behavior unchanged.

Adds regression guards for runtime wiring, Automatic/Custom round completion, transient round-boundary deferral and preservation of within-round direct handoff.

Field context: an X390 running 24-hour Navimower Schedule was found persisted with `suspended_reason=mow_start_not_confirmed`; reconfiguring the selected zones and using Reset schedule cleared the stale runtime and mowing resumed.