### PR TITLE
Refine georeference in staged sample passes

### DIFF
--- a/.github/release-notes/0.4.4-beta7.md
+++ b/.github/release-notes/0.4.4-beta7.md
@@ -1,0 +1,14 @@
+title: Navimower 0.4.4-beta7
+
+## Staged georeference refinement
+
+- Keeps the first usable learned map transform available from the existing 5-sample / 10 m minimum so OpenStreetMap and Multi mower do not need to wait for a full mowing cycle.
+- Continues collecting genuinely new local-X/Y + WGS84 movement samples after that first fit instead of freezing the orientation permanently.
+- Refines the transform again at 8, 9 and 10 accepted samples.
+- Enters a high-confidence stage from 12 accepted samples onward and keeps refining with later accepted samples up to the existing 24-sample cap.
+- Preserves the existing >=1.5 m local sample-separation rule, so stationary cloud-GPS drift cannot manufacture calibration samples.
+- Keeps the revision-stable safety policy: transient GPS mismatches do not discard a validated map transform; a map revision change remains the authoritative relearn trigger.
+- Exposes `refinement_stage`, refinement sample count, and the last accepted/rejected refinement result in georeference diagnostics.
+- Adds regression coverage for the 5 -> 8-10 -> 12+ refinement stages and for stationary GPS drift rejection.
+
+This beta is intended to improve OpenStreetMap alignment and Multi mower relative alignment automatically as each mower covers more of its map, without adding manual rotation or position controls.

--- a/custom_components/navimower/georeference_semantics.py
+++ b/custom_components/navimower/georeference_semantics.py
@@ -1,9 +1,20 @@
-"""Protect a validated map transform from stationary cloud-GPS drift.
+"""Keep map georeference stable while refining it from wider movement samples.
 
-The learned transform is tied to the decoded map revision.  Once that transform
-has passed the multi-point fit, repeated GPS validation mismatches are useful
-diagnostics but are not sufficient evidence that the map frame changed.  The
-map revision is the authoritative relearn trigger.
+The first usable cloud-location fit is intentionally available early so map
+consumers do not have to wait for a whole mowing cycle.  It is not, however,
+considered the final orientation.  For the same map revision we keep collecting
+well-separated local-X/Y + WGS84 pairs and improve the transform in three
+stages:
+
+* provisional: the existing first fit at >=5 samples;
+* refined: re-fit at 8, 9 and 10 samples;
+* high confidence: re-fit from >=12 samples onward, up to the learner's sample
+  cap.
+
+Sample separation is still enforced by the base learner, so stationary GPS
+wander cannot manufacture calibration points.  A validated transform is never
+thrown away merely because later stationary cloud GPS validation drifts; map
+revision remains the authoritative reset trigger.
 """
 from __future__ import annotations
 
@@ -13,6 +24,8 @@ from typing import Any
 from . import georeference as _georeference
 
 _LEARNED_VALIDATION_LIMIT_M = 3.0
+_REFINED_SAMPLE_COUNTS = frozenset({8, 9, 10})
+_HIGH_CONFIDENCE_MIN_SAMPLES = 12
 _ORIGINAL_UPDATE_GEOREFERENCE = _georeference.update_georeference
 
 
@@ -25,10 +38,63 @@ def _validated_fit(calibration: Any, revision: str) -> dict[str, Any] | None:
     return fit
 
 
+def _refinement_stage(sample_count: int) -> str:
+    if sample_count >= _HIGH_CONFIDENCE_MIN_SAMPLES:
+        return "high_confidence"
+    if sample_count >= min(_REFINED_SAMPLE_COUNTS):
+        return "refined"
+    if sample_count >= 5:
+        return "provisional"
+    return "learning"
+
+
+def _should_refit(sample_count: int) -> bool:
+    return sample_count in _REFINED_SAMPLE_COUNTS or sample_count >= _HIGH_CONFIDENCE_MIN_SAMPLES
+
+
+def _append_refinement_sample(state: dict[str, Any], location: Any) -> bool:
+    sample = _georeference._current_location_sample(location)  # noqa: SLF001
+    if sample is None:
+        return False
+    samples = [
+        dict(item) for item in state.get("samples") or [] if isinstance(item, dict)
+    ]
+    state["samples"] = samples
+    return _georeference._append_sample(samples, sample)  # noqa: SLF001
+
+
+def _refine_fit_if_due(
+    state: dict[str, Any], current_fit: dict[str, Any]
+) -> dict[str, Any]:
+    samples = state.get("samples") or []
+    sample_count = len(samples)
+    state["refinement_stage"] = _refinement_stage(sample_count)
+    state["refinement_sample_count"] = sample_count
+
+    if not _should_refit(sample_count):
+        return current_fit
+
+    candidate = _georeference._fit_samples(samples)  # noqa: SLF001
+    if not isinstance(candidate, dict) or candidate.get("status") != "validated":
+        state["last_refinement_result"] = "rejected"
+        return current_fit
+
+    refined = {
+        key: deepcopy(value)
+        for key, value in candidate.items()
+        if key != "validation"
+    }
+    refined["refinement_stage"] = _refinement_stage(sample_count)
+    state["fit"] = refined
+    state["last_refinement_result"] = "accepted"
+    state["last_refinement_sample_count"] = sample_count
+    return refined
+
+
 def stable_update_georeference(
     map_geometry: Any, location: Any
 ) -> dict[str, Any] | None:
-    """Update georeference while freezing a good fit for the same map revision."""
+    """Update georeference with staged refinement and revision-stable safety."""
     if not isinstance(map_geometry, dict):
         return _ORIGINAL_UPDATE_GEOREFERENCE(map_geometry, location)
 
@@ -40,16 +106,42 @@ def stable_update_georeference(
 
     result = _ORIGINAL_UPDATE_GEOREFERENCE(map_geometry, location)
     if frozen_state is None or frozen_fit_copy is None:
+        # The base learner owns the initial >=5-sample fit. Annotate its stage
+        # immediately so diagnostics explain that this is an early usable fit.
+        calibration = map_geometry.get("_georeference_calibration")
+        if isinstance(calibration, dict):
+            sample_count = len(calibration.get("samples") or [])
+            calibration["refinement_stage"] = _refinement_stage(sample_count)
+            calibration["refinement_sample_count"] = sample_count
+            fit = calibration.get("fit")
+            if isinstance(fit, dict) and _georeference.georeference_is_valid(fit):
+                fit["refinement_stage"] = _refinement_stage(sample_count)
+                active = map_geometry.get("georeference")
+                if isinstance(active, dict):
+                    active["refinement_stage"] = _refinement_stage(sample_count)
+                    active["calibration"] = _georeference._calibration_summary(  # noqa: SLF001
+                        calibration
+                    )
         return result
 
-    # The old learner reset after three consecutive >3 m cloud-GPS mismatches.
-    # A stationary mower can produce exactly that while the already fitted local
-    # map remains correct. Preserve the fit/samples and only update diagnostics.
+    # Continue collecting only genuinely new movement samples.  The base
+    # learner's >=1.5 m local separation rejects stationary GPS wander.
+    sample_added = _append_refinement_sample(frozen_state, location)
+    active_fit = frozen_fit_copy
+    if sample_added:
+        active_fit = _refine_fit_if_due(frozen_state, active_fit)
+    else:
+        sample_count = len(frozen_state.get("samples") or [])
+        frozen_state["refinement_stage"] = _refinement_stage(sample_count)
+        frozen_state["refinement_sample_count"] = sample_count
+
+    # Preserve the fitted map transform through transient cloud-GPS drift.  A
+    # changed map revision still resets the whole learner through the base path.
     validated = _georeference.validate_georeference(
-        frozen_fit_copy,
+        active_fit,
         location,
         limit_m=_LEARNED_VALIDATION_LIMIT_M,
-    ) or frozen_fit_copy
+    ) or active_fit
     validation = dict((validated.get("validation") or {}))
     previous_mismatches = int(frozen_state.get("mismatch_count") or 0)
     if validation.get("valid") is False:
@@ -59,17 +151,30 @@ def stable_update_georeference(
     else:
         frozen_state["mismatch_count"] = previous_mismatches
     frozen_state["last_validation"] = validation
-    frozen_state["fit"] = frozen_fit_copy
+    frozen_state["fit"] = deepcopy(active_fit)
     map_geometry["_georeference_calibration"] = frozen_state
 
+    sample_count = len(frozen_state.get("samples") or [])
+    stage = _refinement_stage(sample_count)
     active = dict(validated)
     active["schema_version"] = 2
     active["source"] = "cloud_location_fit"
     active["status"] = "validated"
     active["map_revision"] = revision
+    active["refinement_stage"] = stage
     active["calibration"] = _georeference._calibration_summary(  # noqa: SLF001
         frozen_state
     )
+    active["calibration"]["refinement_stage"] = stage
+    active["calibration"]["refinement_sample_count"] = sample_count
+    if frozen_state.get("last_refinement_result") is not None:
+        active["calibration"]["last_refinement_result"] = frozen_state[
+            "last_refinement_result"
+        ]
+    if frozen_state.get("last_refinement_sample_count") is not None:
+        active["calibration"]["last_refinement_sample_count"] = frozen_state[
+            "last_refinement_sample_count"
+        ]
 
     vendor = map_geometry.get("_vendor_georeference")
     _, vendor_hint = _georeference._vendor_hint(  # noqa: SLF001
@@ -85,7 +190,7 @@ def stable_update_georeference(
 
 
 def install_georeference_semantics() -> None:
-    """Route the coordinator through the revision-stable update policy once."""
+    """Route the coordinator through the staged revision-stable policy once."""
     if getattr(_georeference, "_stable_revision_fit_installed", False):
         return
 

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta6"
+  "version": "0.4.4-beta7"
 }

--- a/tests/test_v044_beta7.py
+++ b/tests/test_v044_beta7.py
@@ -1,0 +1,126 @@
+"""Regression tests for 0.4.4-beta7 staged georeference refinement."""
+from __future__ import annotations
+
+from custom_components.navimower.georeference import offset_wgs84
+from custom_components.navimower.georeference_semantics import stable_update_georeference
+
+
+def _sample(x: float, report_time: int) -> dict:
+    point = offset_wgs84(58.0, 24.0, x, 0.0)
+    assert point is not None
+    return {
+        "x": x,
+        "y": 0.0,
+        "latitude": point[0],
+        "longitude": point[1],
+        "report_time": report_time,
+    }
+
+
+def _location(x: float, report_time: int) -> dict:
+    sample = _sample(x, report_time)
+    return {
+        "posture_x": sample["x"],
+        "posture_y": sample["y"],
+        "latitude": sample["latitude"],
+        "longitude": sample["longitude"],
+        "report_time": report_time,
+    }
+
+
+def _geometry_with_five_sample_fit() -> dict:
+    samples = [_sample(float(index * 3), index + 1) for index in range(5)]
+    fit = {
+        "schema_version": 2,
+        "source": "cloud_location_fit",
+        "status": "validated",
+        "reference": {
+            "local_x": 6.0,
+            "local_y": 0.0,
+            "latitude": offset_wgs84(58.0, 24.0, 6.0, 0.0)[0],
+            "longitude": offset_wgs84(58.0, 24.0, 6.0, 0.0)[1],
+        },
+        "rotation_rad": 0.0,
+        "calibration": {
+            "sample_count": 5,
+            "inlier_count": 5,
+            "rejected_count": 0,
+            "baseline_m": 12.0,
+            "rms_error_m": 0.0,
+            "max_error_m": 0.0,
+            "observed_scale": 1.0,
+            "min_samples": 5,
+            "min_baseline_m": 10.0,
+        },
+    }
+    return {
+        "revision": "map-staged",
+        "_georeference_calibration": {
+            "map_revision": "map-staged",
+            "samples": samples,
+            "fit": fit,
+            "mismatch_count": 0,
+        },
+        "georeference": dict(fit),
+    }
+
+
+def test_refinement_runs_at_8_to_10_and_again_from_12_samples() -> None:
+    geometry = _geometry_with_five_sample_fit()
+
+    result = stable_update_georeference(geometry, _location(15.0, 6))
+    assert result is not None
+    assert result["refinement_stage"] == "provisional"
+    assert result["calibration"]["refinement_sample_count"] == 6
+    assert result["calibration"].get("last_refinement_sample_count") is None
+
+    result = stable_update_georeference(geometry, _location(18.0, 7))
+    assert result["refinement_stage"] == "provisional"
+    assert result["calibration"]["refinement_sample_count"] == 7
+
+    result = stable_update_georeference(geometry, _location(21.0, 8))
+    assert result["refinement_stage"] == "refined"
+    assert result["calibration"]["last_refinement_result"] == "accepted"
+    assert result["calibration"]["last_refinement_sample_count"] == 8
+
+    result = stable_update_georeference(geometry, _location(24.0, 9))
+    assert result["calibration"]["last_refinement_sample_count"] == 9
+
+    result = stable_update_georeference(geometry, _location(27.0, 10))
+    assert result["calibration"]["last_refinement_sample_count"] == 10
+
+    result = stable_update_georeference(geometry, _location(30.0, 11))
+    assert result["refinement_stage"] == "refined"
+    assert result["calibration"]["refinement_sample_count"] == 11
+    assert result["calibration"]["last_refinement_sample_count"] == 10
+
+    result = stable_update_georeference(geometry, _location(33.0, 12))
+    assert result["refinement_stage"] == "high_confidence"
+    assert result["calibration"]["last_refinement_sample_count"] == 12
+
+    result = stable_update_georeference(geometry, _location(36.0, 13))
+    assert result["refinement_stage"] == "high_confidence"
+    assert result["calibration"]["last_refinement_sample_count"] == 13
+
+
+def test_stationary_gps_drift_does_not_create_refinement_samples() -> None:
+    geometry = _geometry_with_five_sample_fit()
+    drifted = offset_wgs84(58.0, 24.0, 10.0, 0.0)
+    assert drifted is not None
+
+    result = stable_update_georeference(
+        geometry,
+        {
+            "posture_x": 12.0,
+            "posture_y": 0.0,
+            "latitude": drifted[0],
+            "longitude": drifted[1],
+            "report_time": 99,
+        },
+    )
+
+    assert result is not None
+    assert result["status"] == "validated"
+    assert result["refinement_stage"] == "provisional"
+    assert result["calibration"]["refinement_sample_count"] == 5
+    assert len(geometry["_georeference_calibration"]["samples"]) == 5


### PR DESCRIPTION
Implement automatic staged georeference refinement for the same map revision. Keep the first usable fit from 5 samples, refine again at 8/9/10 samples, then enter high-confidence refinement from 12+ accepted samples up to the existing cap. Preserve stationary GPS-drift protection and map-revision reset semantics. Includes diagnostics metadata, regression tests, release notes, and bumps Navimower to 0.4.4-beta7.