### PR TITLE
Stabilize high-confidence georeference refinement

### DIFF
--- a/.github/release-notes/0.4.4-beta8.md
+++ b/.github/release-notes/0.4.4-beta8.md
@@ -1,0 +1,15 @@
+title: Navimower 0.4.4-beta8
+
+## Stable staged georeference refinement
+
+- Fixes a regression in the beta7 staged georeference learner where the 24-sample calibration became a rolling latest-24 window.
+- Prevents an already high-confidence map from drifting as older calibration points are replaced by a short recent mowing segment.
+- Keeps the original accepted calibration samples anchored to the map revision instead of dropping them FIFO-style.
+- Refines at the intended milestones: 8, 9 and 10 samples, then 12, 16, 20 and 24 samples.
+- Freezes the learned transform once 24 accepted samples have been collected for the current map revision.
+- Uses wider movement spacing for later refinement samples so high-confidence fits are built from broader spatial coverage.
+- Keeps stationary GPS-drift protection and map-revision reset behavior intact.
+- Adds diagnostics for the anchored refinement policy, sample spacing and locked high-confidence state.
+- Updates regression coverage so high-confidence fitting no longer moves the map on every later sample.
+
+This beta is intended to keep OpenStreetMap and Multi mower alignment stable after the initial staged calibration has converged.

--- a/custom_components/navimower/georeference_semantics.py
+++ b/custom_components/navimower/georeference_semantics.py
@@ -3,18 +3,21 @@
 The first usable cloud-location fit is intentionally available early so map
 consumers do not have to wait for a whole mowing cycle.  It is not, however,
 considered the final orientation.  For the same map revision we keep collecting
-well-separated local-X/Y + WGS84 pairs and improve the transform in three
+spatially separated local-X/Y + WGS84 pairs and improve the transform in three
 stages:
 
 * provisional: the existing first fit at >=5 samples;
-* refined: re-fit at 8, 9 and 10 samples;
-* high confidence: re-fit from >=12 samples onward, up to the learner's sample
-  cap.
+* refined: re-fit at 8, 9 and 10 accepted samples;
+* high confidence: re-fit at 12, 16, 20 and 24 accepted samples.
 
-Sample separation is still enforced by the base learner, so stationary GPS
-wander cannot manufacture calibration points.  A validated transform is never
-thrown away merely because later stationary cloud GPS validation drifts; map
-revision remains the authoritative reset trigger.
+Refinement samples are anchored for the map revision.  Once accepted they are
+never dropped in FIFO order, and once the 24-sample cap is reached the learned
+transform is frozen.  Later high-confidence samples also need wider local
+spacing so a short recent mowing segment cannot replace a broader calibration.
+
+A validated transform is never thrown away merely because later stationary
+cloud GPS validation drifts; map revision remains the authoritative reset
+trigger.
 """
 from __future__ import annotations
 
@@ -26,6 +29,12 @@ from . import georeference as _georeference
 _LEARNED_VALIDATION_LIMIT_M = 3.0
 _REFINED_SAMPLE_COUNTS = frozenset({8, 9, 10})
 _HIGH_CONFIDENCE_MIN_SAMPLES = 12
+_HIGH_CONFIDENCE_REFIT_COUNTS = frozenset({12, 16, 20, 24})
+_MAX_REFINEMENT_SAMPLES = 24
+_PROVISIONAL_SEPARATION_M = 1.5
+_REFINED_SEPARATION_M = 2.0
+_HIGH_CONFIDENCE_SEPARATION_M = 3.0
+_REFINEMENT_POLICY = "anchored_milestones_v2"
 _ORIGINAL_UPDATE_GEOREFERENCE = _georeference.update_georeference
 
 
@@ -49,34 +58,78 @@ def _refinement_stage(sample_count: int) -> str:
 
 
 def _should_refit(sample_count: int) -> bool:
-    return sample_count in _REFINED_SAMPLE_COUNTS or sample_count >= _HIGH_CONFIDENCE_MIN_SAMPLES
+    return (
+        sample_count in _REFINED_SAMPLE_COUNTS
+        or sample_count in _HIGH_CONFIDENCE_REFIT_COUNTS
+    )
+
+
+def _required_sample_separation(sample_count: int) -> float:
+    if sample_count >= 10:
+        return _HIGH_CONFIDENCE_SEPARATION_M
+    if sample_count >= 5:
+        return _REFINED_SEPARATION_M
+    return _PROVISIONAL_SEPARATION_M
 
 
 def _append_refinement_sample(state: dict[str, Any], location: Any) -> bool:
+    """Append one anchored movement sample without FIFO replacement."""
     sample = _georeference._current_location_sample(location)  # noqa: SLF001
     if sample is None:
         return False
+
     samples = [
         dict(item) for item in state.get("samples") or [] if isinstance(item, dict)
     ]
     state["samples"] = samples
-    return _georeference._append_sample(samples, sample)  # noqa: SLF001
+    state["refinement_policy"] = _REFINEMENT_POLICY
+
+    if len(samples) >= _MAX_REFINEMENT_SAMPLES:
+        state["refinement_locked"] = True
+        return False
+
+    required_separation = _required_sample_separation(len(samples))
+    state["refinement_sample_separation_m"] = required_separation
+    report_time = sample.get("report_time")
+    for existing in samples:
+        if report_time is not None and existing.get("report_time") == report_time:
+            return False
+        if (
+            _georeference._sample_distance_m(existing, sample)  # noqa: SLF001
+            < required_separation
+        ):
+            return False
+
+    samples.append(sample)
+    state["refinement_locked"] = len(samples) >= _MAX_REFINEMENT_SAMPLES
+    return True
+
+
+def _annotate_state(state: dict[str, Any]) -> tuple[int, str]:
+    sample_count = len(state.get("samples") or [])
+    stage = _refinement_stage(sample_count)
+    state["refinement_policy"] = _REFINEMENT_POLICY
+    state["refinement_stage"] = stage
+    state["refinement_sample_count"] = sample_count
+    state["refinement_locked"] = sample_count >= _MAX_REFINEMENT_SAMPLES
+    state["refinement_sample_separation_m"] = _required_sample_separation(
+        sample_count
+    )
+    return sample_count, stage
 
 
 def _refine_fit_if_due(
     state: dict[str, Any], current_fit: dict[str, Any]
 ) -> dict[str, Any]:
-    samples = state.get("samples") or []
-    sample_count = len(samples)
-    state["refinement_stage"] = _refinement_stage(sample_count)
-    state["refinement_sample_count"] = sample_count
-
+    sample_count, stage = _annotate_state(state)
     if not _should_refit(sample_count):
         return current_fit
 
+    samples = state.get("samples") or []
     candidate = _georeference._fit_samples(samples)  # noqa: SLF001
     if not isinstance(candidate, dict) or candidate.get("status") != "validated":
         state["last_refinement_result"] = "rejected"
+        state["last_refinement_sample_count"] = sample_count
         return current_fit
 
     refined = {
@@ -84,17 +137,51 @@ def _refine_fit_if_due(
         for key, value in candidate.items()
         if key != "validation"
     }
-    refined["refinement_stage"] = _refinement_stage(sample_count)
+    refined["refinement_stage"] = stage
+    refined["refinement_policy"] = _REFINEMENT_POLICY
     state["fit"] = refined
     state["last_refinement_result"] = "accepted"
     state["last_refinement_sample_count"] = sample_count
     return refined
 
 
+def _decorate_active(
+    active: dict[str, Any], state: dict[str, Any], revision: str
+) -> dict[str, Any]:
+    sample_count, stage = _annotate_state(state)
+    active["schema_version"] = 2
+    active["source"] = "cloud_location_fit"
+    active["status"] = "validated"
+    active["map_revision"] = revision
+    active["refinement_stage"] = stage
+    active["refinement_policy"] = _REFINEMENT_POLICY
+    active["calibration"] = _georeference._calibration_summary(state)  # noqa: SLF001
+    active["calibration"].update(
+        {
+            "refinement_stage": stage,
+            "refinement_policy": _REFINEMENT_POLICY,
+            "refinement_sample_count": sample_count,
+            "refinement_locked": bool(state.get("refinement_locked")),
+            "refinement_sample_separation_m": state.get(
+                "refinement_sample_separation_m"
+            ),
+        }
+    )
+    if state.get("last_refinement_result") is not None:
+        active["calibration"]["last_refinement_result"] = state[
+            "last_refinement_result"
+        ]
+    if state.get("last_refinement_sample_count") is not None:
+        active["calibration"]["last_refinement_sample_count"] = state[
+            "last_refinement_sample_count"
+        ]
+    return active
+
+
 def stable_update_georeference(
     map_geometry: Any, location: Any
 ) -> dict[str, Any] | None:
-    """Update georeference with staged refinement and revision-stable safety."""
+    """Update georeference with anchored staged refinement and revision safety."""
     if not isinstance(map_geometry, dict):
         return _ORIGINAL_UPDATE_GEOREFERENCE(map_geometry, location)
 
@@ -110,30 +197,28 @@ def stable_update_georeference(
         # immediately so diagnostics explain that this is an early usable fit.
         calibration = map_geometry.get("_georeference_calibration")
         if isinstance(calibration, dict):
-            sample_count = len(calibration.get("samples") or [])
-            calibration["refinement_stage"] = _refinement_stage(sample_count)
-            calibration["refinement_sample_count"] = sample_count
+            _annotate_state(calibration)
             fit = calibration.get("fit")
             if isinstance(fit, dict) and _georeference.georeference_is_valid(fit):
-                fit["refinement_stage"] = _refinement_stage(sample_count)
+                fit["refinement_stage"] = calibration["refinement_stage"]
+                fit["refinement_policy"] = _REFINEMENT_POLICY
                 active = map_geometry.get("georeference")
                 if isinstance(active, dict):
-                    active["refinement_stage"] = _refinement_stage(sample_count)
-                    active["calibration"] = _georeference._calibration_summary(  # noqa: SLF001
-                        calibration
-                    )
+                    active["refinement_stage"] = calibration["refinement_stage"]
+                    active["refinement_policy"] = _REFINEMENT_POLICY
+                    active["calibration"] = _decorate_active(
+                        dict(active), calibration, revision
+                    )["calibration"]
         return result
 
-    # Continue collecting only genuinely new movement samples.  The base
-    # learner's >=1.5 m local separation rejects stationary GPS wander.
+    # Continue collecting only genuinely new movement samples.  Unlike beta7,
+    # the accepted set never becomes a rolling latest-24 window.
     sample_added = _append_refinement_sample(frozen_state, location)
     active_fit = frozen_fit_copy
     if sample_added:
         active_fit = _refine_fit_if_due(frozen_state, active_fit)
     else:
-        sample_count = len(frozen_state.get("samples") or [])
-        frozen_state["refinement_stage"] = _refinement_stage(sample_count)
-        frozen_state["refinement_sample_count"] = sample_count
+        _annotate_state(frozen_state)
 
     # Preserve the fitted map transform through transient cloud-GPS drift.  A
     # changed map revision still resets the whole learner through the base path.
@@ -154,27 +239,7 @@ def stable_update_georeference(
     frozen_state["fit"] = deepcopy(active_fit)
     map_geometry["_georeference_calibration"] = frozen_state
 
-    sample_count = len(frozen_state.get("samples") or [])
-    stage = _refinement_stage(sample_count)
-    active = dict(validated)
-    active["schema_version"] = 2
-    active["source"] = "cloud_location_fit"
-    active["status"] = "validated"
-    active["map_revision"] = revision
-    active["refinement_stage"] = stage
-    active["calibration"] = _georeference._calibration_summary(  # noqa: SLF001
-        frozen_state
-    )
-    active["calibration"]["refinement_stage"] = stage
-    active["calibration"]["refinement_sample_count"] = sample_count
-    if frozen_state.get("last_refinement_result") is not None:
-        active["calibration"]["last_refinement_result"] = frozen_state[
-            "last_refinement_result"
-        ]
-    if frozen_state.get("last_refinement_sample_count") is not None:
-        active["calibration"]["last_refinement_sample_count"] = frozen_state[
-            "last_refinement_sample_count"
-        ]
+    active = _decorate_active(dict(validated), frozen_state, revision)
 
     vendor = map_geometry.get("_vendor_georeference")
     _, vendor_hint = _georeference._vendor_hint(  # noqa: SLF001
@@ -190,7 +255,7 @@ def stable_update_georeference(
 
 
 def install_georeference_semantics() -> None:
-    """Route the coordinator through the staged revision-stable policy once."""
+    """Route the coordinator through the anchored revision-stable policy once."""
     if getattr(_georeference, "_stable_revision_fit_installed", False):
         return
 

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta7"
+  "version": "0.4.4-beta8"
 }

--- a/tests/test_v044_beta7.py
+++ b/tests/test_v044_beta7.py
@@ -65,7 +65,7 @@ def _geometry_with_five_sample_fit() -> dict:
     }
 
 
-def test_refinement_runs_at_8_to_10_and_again_from_12_samples() -> None:
+def test_refinement_runs_at_8_to_10_and_enters_high_confidence_at_12() -> None:
     geometry = _geometry_with_five_sample_fit()
 
     result = stable_update_georeference(geometry, _location(15.0, 6))
@@ -98,9 +98,12 @@ def test_refinement_runs_at_8_to_10_and_again_from_12_samples() -> None:
     assert result["refinement_stage"] == "high_confidence"
     assert result["calibration"]["last_refinement_sample_count"] == 12
 
+    # Later high-confidence samples are collected, but do not move the map on
+    # every sample.  The next refit milestone is 16.
     result = stable_update_georeference(geometry, _location(36.0, 13))
     assert result["refinement_stage"] == "high_confidence"
-    assert result["calibration"]["last_refinement_sample_count"] == 13
+    assert result["calibration"]["refinement_sample_count"] == 13
+    assert result["calibration"]["last_refinement_sample_count"] == 12
 
 
 def test_stationary_gps_drift_does_not_create_refinement_samples() -> None:


### PR DESCRIPTION
Fix the beta7 georeference regression observed against OpenStreetMap: once the calibration reached 24 samples, the base helper's FIFO sample cap turned refinement into a rolling latest-24 window and beta7 re-fit on every later sample. That allowed a short recent mowing segment to move an already good map transform. This change anchors accepted samples to the map revision, refits only at 8/9/10 and 12/16/20/24 samples, freezes at 24, increases separation for later samples, preserves stationary-drift and map-revision safety, updates regression coverage, and prepares 0.4.4-beta8.