### PR TITLE
Adapt georeference to wider spatial coverage

### DIFF
--- a/.github/release-notes/0.4.4-beta9.md
+++ b/.github/release-notes/0.4.4-beta9.md
@@ -1,0 +1,15 @@
+title: Navimower 0.4.4-beta9
+
+## Adaptive spatial georeference refinement
+
+- Replaces the beta8 fixed first-24 calibration set with an adaptive spatially optimized 24-point set.
+- Keeps the early 5 / 8-10 / 12-24 staged learning behavior, then continues improving only when a new location sample materially expands spatial coverage.
+- At the 24-point cap, a farther or otherwise more useful point may replace one redundant retained point instead of being ignored forever.
+- Scores coverage using both maximum baseline and 2-D convex-hull spread, so one long straight line is not treated as ideal calibration coverage.
+- Re-fits only after a materially better point set is found; ordinary recent mowing samples do not turn calibration back into a rolling latest-24 window.
+- Rejects replacements that worsen fit RMS/max-error beyond conservative limits.
+- Existing beta8 24-point calibrations migrate automatically to the adaptive policy without requiring a map edit or manual reset.
+- Adds diagnostics for spatial baseline, convex-hull area, spatial score, adaptive replacement count and the last adaptive decision.
+- Adds regression coverage for beta8 migration, farther-point replacement, no-gain rejection and fit-health protection.
+
+This beta is intended to let mowers with initially narrow calibration coverage improve naturally as they later reach more distant parts of the lawn, while preserving the stability gained in beta8.

--- a/custom_components/navimower/georeference_semantics.py
+++ b/custom_components/navimower/georeference_semantics.py
@@ -1,19 +1,21 @@
 """Keep map georeference stable while refining it from wider movement samples.
 
 The first usable cloud-location fit is intentionally available early so map
-consumers do not have to wait for a whole mowing cycle.  It is not, however,
-considered the final orientation.  For the same map revision we keep collecting
-spatially separated local-X/Y + WGS84 pairs and improve the transform in three
-stages:
+consumers do not have to wait for a whole mowing cycle. For the same map
+revision we keep collecting spatially separated local-X/Y + WGS84 pairs and
+improve the transform in stages:
 
 * provisional: the existing first fit at >=5 samples;
 * refined: re-fit at 8, 9 and 10 accepted samples;
-* high confidence: re-fit at 12, 16, 20 and 24 accepted samples.
+* high confidence: re-fit at 12, 16, 20 and 24 accepted samples;
+* adaptive spatial refinement: after 24 samples, a genuinely better spatial
+  candidate may replace one redundant sample and trigger a new fit.
 
-Refinement samples are anchored for the map revision.  Once accepted they are
-never dropped in FIFO order, and once the 24-sample cap is reached the learned
-transform is frozen.  Later high-confidence samples also need wider local
-spacing so a short recent mowing segment cannot replace a broader calibration.
+The adaptive stage does not become a rolling latest-24 window. A new point is
+accepted only when replacing one existing point measurably improves the spatial
+coverage of the retained set and the resulting fit remains healthy. This lets a
+mower gradually improve calibration as it reaches farther parts of the lawn
+without letting a short recent mowing segment move an already good transform.
 
 A validated transform is never thrown away merely because later stationary
 cloud GPS validation drifts; map revision remains the authoritative reset
@@ -22,6 +24,7 @@ trigger.
 from __future__ import annotations
 
 from copy import deepcopy
+import math
 from typing import Any
 
 from . import georeference as _georeference
@@ -34,7 +37,12 @@ _MAX_REFINEMENT_SAMPLES = 24
 _PROVISIONAL_SEPARATION_M = 1.5
 _REFINED_SEPARATION_M = 2.0
 _HIGH_CONFIDENCE_SEPARATION_M = 3.0
-_REFINEMENT_POLICY = "anchored_milestones_v2"
+_MIN_SPATIAL_SCORE_GAIN_M = 0.75
+_MIN_SPATIAL_SCORE_GAIN_RATIO = 0.015
+_MAX_RMS_DEGRADATION_M = 0.25
+_MAX_RMS_DEGRADATION_RATIO = 1.35
+_MAX_MAX_ERROR_DEGRADATION_M = 0.50
+_REFINEMENT_POLICY = "adaptive_spatial_v3"
 _ORIGINAL_UPDATE_GEOREFERENCE = _georeference.update_georeference
 
 
@@ -72,8 +80,54 @@ def _required_sample_separation(sample_count: int) -> float:
     return _PROVISIONAL_SEPARATION_M
 
 
+def _convex_hull_area(samples: list[dict[str, Any]]) -> float:
+    points = sorted({(float(item["x"]), float(item["y"])) for item in samples})
+    if len(points) < 3:
+        return 0.0
+
+    def cross(o: tuple[float, float], a: tuple[float, float], b: tuple[float, float]) -> float:
+        return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+
+    lower: list[tuple[float, float]] = []
+    for point in points:
+        while len(lower) >= 2 and cross(lower[-2], lower[-1], point) <= 0:
+            lower.pop()
+        lower.append(point)
+    upper: list[tuple[float, float]] = []
+    for point in reversed(points):
+        while len(upper) >= 2 and cross(upper[-2], upper[-1], point) <= 0:
+            upper.pop()
+        upper.append(point)
+    hull = lower[:-1] + upper[:-1]
+    area2 = 0.0
+    for index, point in enumerate(hull):
+        nxt = hull[(index + 1) % len(hull)]
+        area2 += point[0] * nxt[1] - nxt[0] * point[1]
+    return abs(area2) / 2.0
+
+
+def _spatial_metrics(samples: list[dict[str, Any]]) -> dict[str, float]:
+    baseline = _georeference._baseline_m(samples) if samples else 0.0  # noqa: SLF001
+    hull_area = _convex_hull_area(samples)
+    # Metre-like score: baseline rewards long lever arms while sqrt(area)
+    # rewards 2-D coverage instead of allowing a single long line to dominate.
+    score = baseline + 2.0 * math.sqrt(max(0.0, hull_area))
+    return {
+        "baseline_m": float(baseline),
+        "hull_area_m2": float(hull_area),
+        "score_m": float(score),
+    }
+
+
+def _sample_is_duplicate(samples: list[dict[str, Any]], sample: dict[str, Any]) -> bool:
+    report_time = sample.get("report_time")
+    return report_time is not None and any(
+        existing.get("report_time") == report_time for existing in samples
+    )
+
+
 def _append_refinement_sample(state: dict[str, Any], location: Any) -> bool:
-    """Append one anchored movement sample without FIFO replacement."""
+    """Append a normal pre-cap refinement sample."""
     sample = _georeference._current_location_sample(location)  # noqa: SLF001
     if sample is None:
         return False
@@ -83,26 +137,110 @@ def _append_refinement_sample(state: dict[str, Any], location: Any) -> bool:
     ]
     state["samples"] = samples
     state["refinement_policy"] = _REFINEMENT_POLICY
-
-    if len(samples) >= _MAX_REFINEMENT_SAMPLES:
-        state["refinement_locked"] = True
+    if len(samples) >= _MAX_REFINEMENT_SAMPLES or _sample_is_duplicate(samples, sample):
         return False
 
     required_separation = _required_sample_separation(len(samples))
     state["refinement_sample_separation_m"] = required_separation
-    report_time = sample.get("report_time")
-    for existing in samples:
-        if report_time is not None and existing.get("report_time") == report_time:
-            return False
-        if (
-            _georeference._sample_distance_m(existing, sample)  # noqa: SLF001
-            < required_separation
-        ):
-            return False
+    if any(
+        _georeference._sample_distance_m(existing, sample) < required_separation  # noqa: SLF001
+        for existing in samples
+    ):
+        return False
 
     samples.append(sample)
-    state["refinement_locked"] = len(samples) >= _MAX_REFINEMENT_SAMPLES
     return True
+
+
+def _fit_quality_ok(current_fit: dict[str, Any], candidate_fit: dict[str, Any]) -> bool:
+    current = current_fit.get("calibration") or {}
+    candidate = candidate_fit.get("calibration") or {}
+    current_rms = float(current.get("rms_error_m") or 0.0)
+    candidate_rms = float(candidate.get("rms_error_m") or 0.0)
+    current_max = float(current.get("max_error_m") or 0.0)
+    candidate_max = float(candidate.get("max_error_m") or 0.0)
+    if current_rms > 0.0:
+        rms_limit = max(
+            current_rms + _MAX_RMS_DEGRADATION_M,
+            current_rms * _MAX_RMS_DEGRADATION_RATIO,
+        )
+        if candidate_rms > rms_limit:
+            return False
+    if current_max > 0.0 and candidate_max > current_max + _MAX_MAX_ERROR_DEGRADATION_M:
+        return False
+    return True
+
+
+def _try_adaptive_replacement(
+    state: dict[str, Any], location: Any, current_fit: dict[str, Any]
+) -> dict[str, Any]:
+    """Replace one redundant retained sample when coverage improves materially."""
+    sample = _georeference._current_location_sample(location)  # noqa: SLF001
+    samples = [
+        dict(item) for item in state.get("samples") or [] if isinstance(item, dict)
+    ]
+    state["samples"] = samples
+    if sample is None or len(samples) < _MAX_REFINEMENT_SAMPLES:
+        return current_fit
+    if _sample_is_duplicate(samples, sample):
+        state["last_adaptive_result"] = "duplicate"
+        return current_fit
+
+    current_metrics = _spatial_metrics(samples)
+    required_separation = _HIGH_CONFIDENCE_SEPARATION_M
+    best_samples: list[dict[str, Any]] | None = None
+    best_metrics = current_metrics
+    best_removed_index: int | None = None
+
+    for index in range(len(samples)):
+        remaining = samples[:index] + samples[index + 1 :]
+        if any(
+            _georeference._sample_distance_m(existing, sample) < required_separation  # noqa: SLF001
+            for existing in remaining
+        ):
+            continue
+        proposed = remaining + [sample]
+        metrics = _spatial_metrics(proposed)
+        if metrics["score_m"] > best_metrics["score_m"]:
+            best_samples = proposed
+            best_metrics = metrics
+            best_removed_index = index
+
+    gain = best_metrics["score_m"] - current_metrics["score_m"]
+    required_gain = max(
+        _MIN_SPATIAL_SCORE_GAIN_M,
+        current_metrics["score_m"] * _MIN_SPATIAL_SCORE_GAIN_RATIO,
+    )
+    state["last_spatial_score_gain_m"] = round(gain, 3)
+    state["required_spatial_score_gain_m"] = round(required_gain, 3)
+    if best_samples is None or gain < required_gain:
+        state["last_adaptive_result"] = "no_material_coverage_gain"
+        return current_fit
+
+    candidate = _georeference._fit_samples(best_samples)  # noqa: SLF001
+    if (
+        not isinstance(candidate, dict)
+        or candidate.get("status") != "validated"
+        or not _fit_quality_ok(current_fit, candidate)
+    ):
+        state["last_adaptive_result"] = "fit_rejected"
+        return current_fit
+
+    refined = {
+        key: deepcopy(value)
+        for key, value in candidate.items()
+        if key != "validation"
+    }
+    refined["refinement_stage"] = "high_confidence"
+    refined["refinement_policy"] = _REFINEMENT_POLICY
+    state["samples"] = best_samples
+    state["fit"] = refined
+    state["last_adaptive_result"] = "accepted"
+    state["adaptive_replacement_count"] = int(state.get("adaptive_replacement_count") or 0) + 1
+    state["last_adaptive_removed_index"] = best_removed_index
+    state["last_refinement_result"] = "accepted"
+    state["last_refinement_sample_count"] = len(best_samples)
+    return refined
 
 
 def _annotate_state(state: dict[str, Any]) -> tuple[int, str]:
@@ -111,10 +249,12 @@ def _annotate_state(state: dict[str, Any]) -> tuple[int, str]:
     state["refinement_policy"] = _REFINEMENT_POLICY
     state["refinement_stage"] = stage
     state["refinement_sample_count"] = sample_count
-    state["refinement_locked"] = sample_count >= _MAX_REFINEMENT_SAMPLES
-    state["refinement_sample_separation_m"] = _required_sample_separation(
-        sample_count
-    )
+    state["refinement_locked"] = False
+    state["refinement_sample_separation_m"] = _required_sample_separation(sample_count)
+    metrics = _spatial_metrics(state.get("samples") or [])
+    state["spatial_baseline_m"] = round(metrics["baseline_m"], 3)
+    state["spatial_hull_area_m2"] = round(metrics["hull_area_m2"], 3)
+    state["spatial_score_m"] = round(metrics["score_m"], 3)
     return sample_count, stage
 
 
@@ -161,27 +301,30 @@ def _decorate_active(
             "refinement_stage": stage,
             "refinement_policy": _REFINEMENT_POLICY,
             "refinement_sample_count": sample_count,
-            "refinement_locked": bool(state.get("refinement_locked")),
-            "refinement_sample_separation_m": state.get(
-                "refinement_sample_separation_m"
-            ),
+            "refinement_locked": False,
+            "refinement_sample_separation_m": state.get("refinement_sample_separation_m"),
+            "spatial_baseline_m": state.get("spatial_baseline_m"),
+            "spatial_hull_area_m2": state.get("spatial_hull_area_m2"),
+            "spatial_score_m": state.get("spatial_score_m"),
+            "adaptive_replacement_count": int(state.get("adaptive_replacement_count") or 0),
         }
     )
-    if state.get("last_refinement_result") is not None:
-        active["calibration"]["last_refinement_result"] = state[
-            "last_refinement_result"
-        ]
-    if state.get("last_refinement_sample_count") is not None:
-        active["calibration"]["last_refinement_sample_count"] = state[
-            "last_refinement_sample_count"
-        ]
+    for key in (
+        "last_refinement_result",
+        "last_refinement_sample_count",
+        "last_adaptive_result",
+        "last_spatial_score_gain_m",
+        "required_spatial_score_gain_m",
+    ):
+        if state.get(key) is not None:
+            active["calibration"][key] = state[key]
     return active
 
 
 def stable_update_georeference(
     map_geometry: Any, location: Any
 ) -> dict[str, Any] | None:
-    """Update georeference with anchored staged refinement and revision safety."""
+    """Update georeference with staged and adaptive spatial refinement."""
     if not isinstance(map_geometry, dict):
         return _ORIGINAL_UPDATE_GEOREFERENCE(map_geometry, location)
 
@@ -193,8 +336,6 @@ def stable_update_georeference(
 
     result = _ORIGINAL_UPDATE_GEOREFERENCE(map_geometry, location)
     if frozen_state is None or frozen_fit_copy is None:
-        # The base learner owns the initial >=5-sample fit. Annotate its stage
-        # immediately so diagnostics explain that this is an early usable fit.
         calibration = map_geometry.get("_georeference_calibration")
         if isinstance(calibration, dict):
             _annotate_state(calibration)
@@ -211,17 +352,19 @@ def stable_update_georeference(
                     )["calibration"]
         return result
 
-    # Continue collecting only genuinely new movement samples.  Unlike beta7,
-    # the accepted set never becomes a rolling latest-24 window.
-    sample_added = _append_refinement_sample(frozen_state, location)
     active_fit = frozen_fit_copy
-    if sample_added:
-        active_fit = _refine_fit_if_due(frozen_state, active_fit)
+    if len(frozen_state.get("samples") or []) < _MAX_REFINEMENT_SAMPLES:
+        sample_added = _append_refinement_sample(frozen_state, location)
+        if sample_added:
+            active_fit = _refine_fit_if_due(frozen_state, active_fit)
+        else:
+            _annotate_state(frozen_state)
     else:
+        # A beta8 24-sample calibration migrates directly into this adaptive
+        # policy; it does not need a map edit or manual reset to improve.
+        active_fit = _try_adaptive_replacement(frozen_state, location, active_fit)
         _annotate_state(frozen_state)
 
-    # Preserve the fitted map transform through transient cloud-GPS drift.  A
-    # changed map revision still resets the whole learner through the base path.
     validated = _georeference.validate_georeference(
         active_fit,
         location,
@@ -255,13 +398,10 @@ def stable_update_georeference(
 
 
 def install_georeference_semantics() -> None:
-    """Route the coordinator through the anchored revision-stable policy once."""
+    """Route the coordinator through the adaptive revision-stable policy once."""
     if getattr(_georeference, "_stable_revision_fit_installed", False):
         return
 
-    # Coordinator semantics imports update_georeference directly, so update both
-    # the source module and that bound runtime reference. Import the HA-dependent
-    # coordinator lazily so the pure policy remains usable in lightweight tests.
     from . import coordinator_semantics as _coordinator_semantics
 
     _georeference.update_georeference = stable_update_georeference

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta8"
+  "version": "0.4.4-beta9"
 }

--- a/tests/test_v044_beta9.py
+++ b/tests/test_v044_beta9.py
@@ -1,0 +1,102 @@
+"""Regression tests for 0.4.4-beta9 adaptive spatial georeference refinement."""
+from __future__ import annotations
+
+from custom_components.navimower import georeference as geo
+from custom_components.navimower.georeference_semantics import stable_update_georeference
+
+
+def _sample(x: float, y: float, report_time: int) -> dict:
+    point = geo.offset_wgs84(58.0, 24.0, x, y)
+    assert point is not None
+    return {
+        "x": x,
+        "y": y,
+        "latitude": point[0],
+        "longitude": point[1],
+        "report_time": report_time,
+    }
+
+
+def _location(x: float, y: float, report_time: int) -> dict:
+    sample = _sample(x, y, report_time)
+    return {
+        "posture_x": x,
+        "posture_y": y,
+        "latitude": sample["latitude"],
+        "longitude": sample["longitude"],
+        "report_time": report_time,
+    }
+
+
+def _full_geometry() -> dict:
+    # 24 well-separated points, intentionally confined to a 20 x 20 m patch.
+    samples = []
+    report_time = 1
+    for y in (0.0, 4.0, 8.0, 12.0):
+        for x in (0.0, 4.0, 8.0, 12.0, 16.0, 20.0):
+            samples.append(_sample(x, y, report_time))
+            report_time += 1
+    fit = geo._fit_samples(samples)  # noqa: SLF001
+    assert fit is not None and fit["status"] == "validated"
+    return {
+        "revision": "map-adaptive",
+        "_georeference_calibration": {
+            "map_revision": "map-adaptive",
+            "samples": samples,
+            "fit": fit,
+            "mismatch_count": 0,
+            "refinement_policy": "anchored_milestones_v2",
+            "refinement_locked": True,
+            "last_refinement_result": "accepted",
+            "last_refinement_sample_count": 24,
+        },
+        "georeference": dict(fit),
+    }
+
+
+def test_beta8_full_set_migrates_and_accepts_farther_spatial_point() -> None:
+    geometry = _full_geometry()
+    before_samples = list(geometry["_georeference_calibration"]["samples"])
+    before_baseline = geo._baseline_m(before_samples)  # noqa: SLF001
+
+    result = stable_update_georeference(geometry, _location(42.0, 18.0, 100))
+
+    assert result is not None
+    calibration = result["calibration"]
+    assert calibration["refinement_policy"] == "adaptive_spatial_v3"
+    assert calibration["refinement_sample_count"] == 24
+    assert calibration["refinement_locked"] is False
+    assert calibration["last_adaptive_result"] == "accepted"
+    assert calibration["adaptive_replacement_count"] == 1
+    assert calibration["spatial_baseline_m"] > before_baseline
+    assert len(geometry["_georeference_calibration"]["samples"]) == 24
+    assert any(item["report_time"] == 100 for item in geometry["_georeference_calibration"]["samples"])
+
+
+def test_full_set_rejects_point_without_material_coverage_gain() -> None:
+    geometry = _full_geometry()
+    before = [dict(item) for item in geometry["_georeference_calibration"]["samples"]]
+
+    result = stable_update_georeference(geometry, _location(10.0, 10.0, 101))
+
+    assert result is not None
+    calibration = result["calibration"]
+    assert calibration["refinement_policy"] == "adaptive_spatial_v3"
+    assert calibration["adaptive_replacement_count"] == 0
+    assert calibration["last_adaptive_result"] in {
+        "no_material_coverage_gain",
+        "duplicate",
+    }
+    assert geometry["_georeference_calibration"]["samples"] == before
+
+
+def test_adaptive_replacement_keeps_fit_healthy() -> None:
+    geometry = _full_geometry()
+
+    result = stable_update_georeference(geometry, _location(45.0, -10.0, 102))
+
+    assert result is not None
+    assert result["status"] == "validated"
+    assert result["calibration"]["last_adaptive_result"] == "accepted"
+    assert result["calibration"]["rms_error_m"] < 0.05
+    assert result["calibration"]["max_error_m"] < 0.10


### PR DESCRIPTION
Prepare Navimower 0.4.4-beta9 with adaptive spatial georeference refinement. Existing beta8 24-point calibrations migrate automatically. After the 24-point cap, a new XY+GPS sample can replace one redundant retained point only when the retained set gains meaningful spatial coverage (baseline + convex-hull spread) and the resulting fit remains healthy. This avoids both beta7-style rolling drift and beta8-style permanent lock-in to a narrow first-24 sample area. Adds diagnostics and regression tests for migration, useful replacement, no-gain rejection and fit quality.