### PR TITLE
Fix scheduler task ownership and repeat time-window rounds

### DIFF
--- a/.github/release-notes/0.4.4-beta10.md
+++ b/.github/release-notes/0.4.4-beta10.md
@@ -1,0 +1,8 @@
+# Navimower 0.4.4-beta10
+
+- Harden Navimower Schedule retained-task ownership so a stale scheduler `active_zone_id` can no longer adopt or Resume an unrelated native/manual multi-zone mower task.
+- Persist explicit one-zone scheduler ownership after a scheduler start is confirmed, reject conflicting live target/task evidence, and fail closed when older runtime cannot prove ownership.
+- Refuse vendor Resume when retained-task ownership is not proven instead of risking mowing zones outside the configured Navimower Schedule allowlist.
+- Make **Time window** mode repeat rounds while the window remains open. After all selected zones (or custom queue slots) complete, a new round is prepared and starts after the mower reaches a normal idle start state.
+- Keep the configured Time window end as the hard daily boundary; cross-round starts still wait out the mower's finishing/returning transition to avoid reset/start races.
+- Add beta10 regression coverage for ownership enforcement, multi-zone conflict detection, safe Resume refusal, and repeated Time window rounds.

--- a/.github/release-notes/0.4.4-beta10.md
+++ b/.github/release-notes/0.4.4-beta10.md
@@ -1,4 +1,6 @@
-# Navimower 0.4.4-beta10
+title: Navimower 0.4.4-beta10
+
+## Scheduler ownership and repeated Time window rounds
 
 - Harden Navimower Schedule retained-task ownership so a stale scheduler `active_zone_id` can no longer adopt or Resume an unrelated native/manual multi-zone mower task.
 - Persist explicit one-zone scheduler ownership after a scheduler start is confirmed, reject conflicting live target/task evidence, and fail closed when older runtime cannot prove ownership.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta9"
+  "version": "0.4.4-beta10"
 }

--- a/custom_components/navimower/runtime.py
+++ b/custom_components/navimower/runtime.py
@@ -13,6 +13,7 @@ from .georeference_semantics import install_georeference_semantics
 from .navigation_fallback import install_navigation_fallback
 from .notification_feed import install_notification_feed
 from .private_cloud_region import install_private_cloud_region
+from .schedule_ownership_semantics import install_schedule_ownership_semantics
 from .schedule_pause_semantics import install_schedule_pause_semantics
 from .schedule_round_semantics import install_schedule_round_semantics
 from .setup_flow_semantics import install_setup_flow_semantics
@@ -31,6 +32,7 @@ def install_runtime_extensions() -> None:
     install_navigation_fallback()
     install_notification_feed()
     install_schedule_pause_semantics()
+    install_schedule_ownership_semantics()
     install_schedule_round_semantics()
     install_setup_flow_semantics()
     install_zone_entity_cleanup()

--- a/custom_components/navimower/schedule_ownership_semantics.py
+++ b/custom_components/navimower/schedule_ownership_semantics.py
@@ -1,0 +1,262 @@
+"""Strict ownership guards for Navimower Schedule retained tasks.
+
+Navimower Schedule owns one mower zone at a time. A generic vendor Resume command,
+however, resumes the mower's whole retained task and does not accept a zone id.
+That makes stale scheduler runtime dangerous: an old ``active_zone_id`` must never
+be enough to adopt or resume a native/manual multi-zone task.
+
+This extension records explicit ownership after a scheduler start is confirmed,
+rejects conflicting live task evidence, and fails closed when upgrading older
+runtime that cannot prove scheduler ownership.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from . import schedule_pause_semantics as pause_semantics
+from .navimower_schedule import NavimowerScheduleController, _utc_now
+
+_INSTALLED = False
+_ORIGINAL_EMPTY_RUNTIME = NavimowerScheduleController._empty_runtime
+_ORIGINAL_CONFIRM_PENDING = NavimowerScheduleController._confirm_pending
+_ORIGINAL_CONFIRM_ACTIVE_COMPLETION = NavimowerScheduleController._confirm_active_completion
+_ORIGINAL_CONTINUE_INTERRUPTED_TASK = NavimowerScheduleController._continue_interrupted_task
+_ORIGINAL_EVALUATE_LOCKED = NavimowerScheduleController._evaluate_locked
+_ORIGINAL_ADOPT_RETAINED_TASK = pause_semantics._adopt_retained_task
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _dedupe_ids(values: Any) -> list[int]:
+    result: list[int] = []
+    for raw in values or []:
+        value = _as_int(raw)
+        if value is not None and value > 0 and value not in result:
+            result.append(value)
+    return result
+
+
+def _empty_runtime() -> dict[str, Any]:
+    runtime = _ORIGINAL_EMPTY_RUNTIME()
+    runtime.update(
+        {
+            "owned_zone_id": None,
+            "owned_dispatch_started_at": None,
+            "ownership_source": None,
+            "last_ownership_result": None,
+        }
+    )
+    return runtime
+
+
+def _notification_task(controller: NavimowerScheduleController) -> dict[str, Any] | None:
+    center = getattr(controller.coordinator, "notification_center", None)
+    task = getattr(center, "active_task", None)
+    return task if isinstance(task, dict) else None
+
+
+def _scheduler_task_evidence(task: dict[str, Any] | None, zone_id: int) -> bool:
+    """Return positive persisted evidence that a one-zone task came from scheduler."""
+    if task is None:
+        return False
+    trigger = str(task.get("trigger") or "")
+    task_ids = _dedupe_ids(task.get("zone_ids"))
+    return trigger.startswith("navimower_schedule") and task_ids == [zone_id]
+
+
+def _live_task_conflicts(controller: NavimowerScheduleController, zone_id: int) -> bool:
+    """Reject clear evidence that the mower is currently cutting another task."""
+    data = controller.coordinator.data or {}
+    if not controller._vendor_mowing(data):
+        return False
+
+    # While mowing, the coordinator's resolved target reflects the vendor task
+    # once a short-lived HA command intent has expired. A scheduler-owned task is
+    # strictly one-zone-at-a-time; a different/multi-zone live target conflicts.
+    target_ids = _dedupe_ids(data.get("target_zone_ids"))
+    target_source = str(data.get("target_zone_source") or "")
+    if target_ids and target_source not in {"last_known", "none"} and target_ids != [zone_id]:
+        return True
+
+    task = _notification_task(controller)
+    if task is None:
+        return False
+    trigger = str(task.get("trigger") or "")
+    task_ids = _dedupe_ids(task.get("zone_ids"))
+    # Scheduler handoffs may leave Notification Center on the previous scheduler
+    # zone because mowing never transitioned through idle. That is still scheduler
+    # provenance. Native/manual/other-HA task context is a real conflict.
+    if task_ids and not trigger.startswith("navimower_schedule"):
+        return True
+    return False
+
+
+def _ownership_proven(controller: NavimowerScheduleController, zone_id: int) -> bool:
+    if zone_id <= 0 or zone_id not in controller._selected_zone_ids:
+        return False
+    if _live_task_conflicts(controller, zone_id):
+        return False
+
+    owned = _as_int(controller._runtime.get("owned_zone_id"))
+    if owned == zone_id:
+        return True
+
+    task = _notification_task(controller)
+    if _scheduler_task_evidence(task, zone_id):
+        # Safe beta9 -> beta10 migration: only a persisted one-zone task with an
+        # explicit scheduler trigger may seed the new ownership fields.
+        controller._runtime["owned_zone_id"] = zone_id
+        controller._runtime["owned_dispatch_started_at"] = (
+            controller._runtime.get("dispatch_started_at")
+            or task.get("started_at")
+            or _utc_now()
+        )
+        controller._runtime["ownership_source"] = "migrated_scheduler_task_context"
+        controller._runtime["last_ownership_result"] = "ownership_migrated"
+        return True
+    return False
+
+
+def _clear_unverified_context(controller: NavimowerScheduleController, *, reason: str) -> None:
+    """Drop scheduler ownership only; never send a mower command here."""
+    controller._runtime["active_zone_id"] = None
+    controller._runtime["active_queue_slot"] = None
+    controller._runtime["active_cycle_id"] = None
+    controller._runtime["active_zone_baseline_completed_at"] = None
+    controller._runtime["dispatch_started_at"] = None
+    controller._runtime["resume_pending"] = False
+    controller._runtime["interrupted_reason"] = None
+    controller._runtime["interrupted_zone_id"] = None
+    controller._runtime["interrupted_cycle_id"] = None
+    controller._runtime["progress_before_interrupt"] = None
+    controller._runtime["charging_limit_reached_at"] = None
+    controller._runtime["pending_command"] = None
+    controller._runtime["retry_not_before"] = None
+    controller._runtime["owned_zone_id"] = None
+    controller._runtime["owned_dispatch_started_at"] = None
+    controller._runtime["ownership_source"] = None
+    controller._runtime["last_ownership_result"] = reason
+    controller.coordinator.clear_pending_activity()
+    controller.coordinator.clear_command_target()
+
+
+def _adopt_retained_task(controller: NavimowerScheduleController) -> int | None:
+    """Adopt only a task whose one-zone scheduler ownership is positively proven."""
+    active_zone_id = _as_int(controller._runtime.get("active_zone_id"))
+    if active_zone_id is not None:
+        if _ownership_proven(controller, active_zone_id):
+            controller._runtime["last_ownership_result"] = "retained_task_verified"
+            return _ORIGINAL_ADOPT_RETAINED_TASK(controller)
+        _clear_unverified_context(controller, reason="retained_task_rejected_unverified")
+        return None
+
+    task = _notification_task(controller)
+    task_ids = _dedupe_ids(task.get("zone_ids")) if task is not None else []
+    if len(task_ids) == 1 and _scheduler_task_evidence(task, task_ids[0]):
+        adopted = _ORIGINAL_ADOPT_RETAINED_TASK(controller)
+        if adopted is not None:
+            controller._runtime["owned_zone_id"] = int(adopted)
+            controller._runtime["owned_dispatch_started_at"] = (
+                controller._runtime.get("dispatch_started_at") or _utc_now()
+            )
+            controller._runtime["ownership_source"] = "scheduler_task_context"
+            controller._runtime["last_ownership_result"] = "retained_task_verified"
+        return adopted
+    return None
+
+
+async def _confirm_pending(
+    self: NavimowerScheduleController,
+    data: dict[str, Any],
+    activity: Any,
+) -> None:
+    pending = deepcopy(self._runtime.get("pending_command"))
+    await _ORIGINAL_CONFIRM_PENDING(self, data, activity)
+    if not isinstance(pending, dict) or pending.get("kind") != "mow":
+        return
+    zone_id = _as_int(pending.get("zone_id"))
+    if zone_id is None or _as_int(self._runtime.get("active_zone_id")) != zone_id:
+        return
+    if isinstance(self._runtime.get("pending_command"), dict):
+        return
+    source = str(pending.get("source") or "")
+    if not source.startswith("navimower_schedule"):
+        return
+    self._runtime["owned_zone_id"] = zone_id
+    self._runtime["owned_dispatch_started_at"] = (
+        pending.get("sent_at") or self._runtime.get("dispatch_started_at") or _utc_now()
+    )
+    self._runtime["ownership_source"] = source
+    self._runtime["last_ownership_result"] = "scheduler_start_confirmed"
+    await self._save()
+
+
+async def _confirm_active_completion(self: NavimowerScheduleController) -> bool:
+    completed = await _ORIGINAL_CONFIRM_ACTIVE_COMPLETION(self)
+    if completed:
+        self._runtime["owned_zone_id"] = None
+        self._runtime["owned_dispatch_started_at"] = None
+        self._runtime["ownership_source"] = None
+        self._runtime["last_ownership_result"] = "owned_zone_completed"
+        await self._save()
+    return completed
+
+
+async def _continue_interrupted_task(
+    self: NavimowerScheduleController,
+    *,
+    source: str,
+    continue_source: str,
+) -> None:
+    zone_id = _as_int(
+        self._runtime.get("interrupted_zone_id") or self._runtime.get("active_zone_id")
+    )
+    if zone_id is None or not _ownership_proven(self, zone_id):
+        _clear_unverified_context(self, reason="resume_refused_unverified_task")
+        self._runtime["last_command"] = "resume_refused_unverified_task"
+        self._runtime["last_command_at"] = _utc_now()
+        self._runtime["last_error"] = (
+            "Retained mower task ownership could not be proven; vendor Resume was refused"
+        )
+        await self._save()
+        return
+    self._runtime["last_ownership_result"] = "resume_ownership_verified"
+    await _ORIGINAL_CONTINUE_INTERRUPTED_TASK(
+        self,
+        source=source,
+        continue_source=continue_source,
+    )
+
+
+async def _evaluate_locked(self: NavimowerScheduleController) -> None:
+    """Fail closed on stale pre-beta10 ownership before normal scheduler decisions."""
+    zone_id = _as_int(self._runtime.get("active_zone_id"))
+    if zone_id is not None and not isinstance(self._runtime.get("pending_command"), dict):
+        if not _ownership_proven(self, zone_id):
+            _clear_unverified_context(self, reason="active_task_rejected_unverified")
+            self._runtime["last_command"] = "stale_scheduler_ownership_cleared"
+            self._runtime["last_command_at"] = _utc_now()
+            self._runtime["last_error"] = None
+            await self._save()
+    await _ORIGINAL_EVALUATE_LOCKED(self)
+
+
+def install_schedule_ownership_semantics() -> None:
+    """Install strict retained-task ownership once, after pause semantics."""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    NavimowerScheduleController._empty_runtime = staticmethod(_empty_runtime)
+    NavimowerScheduleController._confirm_pending = _confirm_pending
+    NavimowerScheduleController._confirm_active_completion = _confirm_active_completion
+    NavimowerScheduleController._continue_interrupted_task = _continue_interrupted_task
+    NavimowerScheduleController._evaluate_locked = _evaluate_locked
+    # pause_semantics._async_set_enabled resolves this module global at call time.
+    pause_semantics._adopt_retained_task = _adopt_retained_task
+    _INSTALLED = True

--- a/custom_components/navimower/schedule_round_semantics.py
+++ b/custom_components/navimower/schedule_round_semantics.py
@@ -12,6 +12,8 @@ end remains the hard boundary.
 """
 from __future__ import annotations
 
+from typing import Any, Awaitable, Callable
+
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -24,9 +26,9 @@ from .const import (
 from .navimower_schedule import NavimowerScheduleController, _utc_now
 
 _INSTALLED = False
-_ORIGINAL_CONFIRM_ACTIVE_COMPLETION = NavimowerScheduleController._confirm_active_completion
-_ORIGINAL_ASYNC_SEND_MOW = NavimowerScheduleController._async_send_mow
-_ORIGINAL_EVALUATE_LOCKED = NavimowerScheduleController._evaluate_locked
+_ORIGINAL_CONFIRM_ACTIVE_COMPLETION: Callable[..., Awaitable[bool]] | None = None
+_ORIGINAL_ASYNC_SEND_MOW: Callable[..., Awaitable[None]] | None = None
+_ORIGINAL_EVALUATE_LOCKED: Callable[..., Awaitable[None]] | None = None
 
 
 def _continuous_round_complete(controller: NavimowerScheduleController) -> bool:
@@ -60,6 +62,7 @@ def _continuous_round_complete(controller: NavimowerScheduleController) -> bool:
 async def _confirm_active_completion(self: NavimowerScheduleController) -> bool:
     """Remember when this evaluation completed the final zone of a round."""
     self._defer_continuous_round_handoff = False
+    assert _ORIGINAL_CONFIRM_ACTIVE_COMPLETION is not None
     completed = await _ORIGINAL_CONFIRM_ACTIVE_COMPLETION(self)
     if completed and _continuous_round_complete(self):
         self._defer_continuous_round_handoff = True
@@ -92,6 +95,7 @@ async def _async_send_mow(
         await self._save()
         return
 
+    assert _ORIGINAL_ASYNC_SEND_MOW is not None
     await _ORIGINAL_ASYNC_SEND_MOW(
         self,
         zone_id,
@@ -103,6 +107,7 @@ async def _async_send_mow(
 
 async def _evaluate_locked(self: NavimowerScheduleController) -> None:
     """Advance a completed Time window round while the same window is still open."""
+    assert _ORIGINAL_EVALUATE_LOCKED is not None
     await _ORIGINAL_EVALUATE_LOCKED(self)
 
     if self._mode != SCHEDULE_MODE_WINDOW or not self._enabled:
@@ -137,10 +142,19 @@ async def _evaluate_locked(self: NavimowerScheduleController) -> None:
 
 
 def install_schedule_round_semantics() -> None:
-    """Install safe repeated-round behavior once."""
+    """Install safe repeated-round behavior once after ownership semantics."""
     global _INSTALLED
+    global _ORIGINAL_CONFIRM_ACTIVE_COMPLETION
+    global _ORIGINAL_ASYNC_SEND_MOW
+    global _ORIGINAL_EVALUATE_LOCKED
     if _INSTALLED:
         return
+    # Capture at installation time, not module-import time. Runtime installs the
+    # ownership extension first, so these wrappers must chain through it rather
+    # than bypassing its completion/evaluation guards.
+    _ORIGINAL_CONFIRM_ACTIVE_COMPLETION = NavimowerScheduleController._confirm_active_completion
+    _ORIGINAL_ASYNC_SEND_MOW = NavimowerScheduleController._async_send_mow
+    _ORIGINAL_EVALUATE_LOCKED = NavimowerScheduleController._evaluate_locked
     NavimowerScheduleController._confirm_active_completion = _confirm_active_completion
     NavimowerScheduleController._async_send_mow = _async_send_mow
     NavimowerScheduleController._evaluate_locked = _evaluate_locked

--- a/custom_components/navimower/schedule_round_semantics.py
+++ b/custom_components/navimower/schedule_round_semantics.py
@@ -1,24 +1,24 @@
-"""Safe continuous-round rollover semantics for Navimower Schedule.
+"""Safe round rollover semantics for Navimower Schedule.
 
-Direct handoff is useful between zones inside one scheduler round: after a zone
-completes the mower can be redirected while it is already returning instead of
-visiting the dock first. The final zone of a 24-hour round is different. At that
-boundary the base scheduler clears the completed set and advances ``round_index``
-before selecting the first zone of the next round. Sending that new ``reset=true``
-command while the mower still reports mowing/returning can race the vendor's
-normal task-finish transition and leave the new start unconfirmed.
+Direct handoff remains useful between zones inside one scheduler round. Starting
+the first zone of a new round is different: a fresh ``reset=true`` command sent
+while the mower still reports mowing/returning can race the vendor's task-finish
+transition. Therefore every round boundary waits for a normal idle start state.
 
-This extension keeps direct handoff inside a round, but defers only the first
-command of a newly-advanced continuous round until a later evaluation sees the
-mower in an ordinary start state (Docked/Paused). Charging and other existing
-safety gates remain owned by the base scheduler.
+24-hour mode already repeated rounds. Time-window mode now does the same while
+the window remains open: once every selected zone/queue slot completes, a new
+round is prepared and starts after the mower reaches Docked/Paused. The window
+end remains the hard boundary.
 """
 from __future__ import annotations
+
+from homeassistant.util import dt as dt_util
 
 from .const import (
     ACTIVITY_MOWING,
     ACTIVITY_RETURNING,
     SCHEDULE_MODE_CONTINUOUS,
+    SCHEDULE_MODE_WINDOW,
     SCHEDULE_ORDER_CUSTOM,
 )
 from .navimower_schedule import NavimowerScheduleController, _utc_now
@@ -26,11 +26,12 @@ from .navimower_schedule import NavimowerScheduleController, _utc_now
 _INSTALLED = False
 _ORIGINAL_CONFIRM_ACTIVE_COMPLETION = NavimowerScheduleController._confirm_active_completion
 _ORIGINAL_ASYNC_SEND_MOW = NavimowerScheduleController._async_send_mow
+_ORIGINAL_EVALUATE_LOCKED = NavimowerScheduleController._evaluate_locked
 
 
 def _continuous_round_complete(controller: NavimowerScheduleController) -> bool:
-    """Return whether the just-confirmed completion finished the current round."""
-    if controller._mode != SCHEDULE_MODE_CONTINUOUS:
+    """Return whether the current automatic/custom round is fully complete."""
+    if controller._mode not in {SCHEDULE_MODE_CONTINUOUS, SCHEDULE_MODE_WINDOW}:
         return False
 
     eligible = controller._eligible_zones()
@@ -57,7 +58,7 @@ def _continuous_round_complete(controller: NavimowerScheduleController) -> bool:
 
 
 async def _confirm_active_completion(self: NavimowerScheduleController) -> bool:
-    """Remember when this evaluation completed the final zone of a 24-hour round."""
+    """Remember when this evaluation completed the final zone of a round."""
     self._defer_continuous_round_handoff = False
     completed = await _ORIGINAL_CONFIRM_ACTIVE_COMPLETION(self)
     if completed and _continuous_round_complete(self):
@@ -100,11 +101,47 @@ async def _async_send_mow(
     )
 
 
+async def _evaluate_locked(self: NavimowerScheduleController) -> None:
+    """Advance a completed Time window round while the same window is still open."""
+    await _ORIGINAL_EVALUATE_LOCKED(self)
+
+    if self._mode != SCHEDULE_MODE_WINDOW or not self._enabled:
+        return
+    in_window, _ = self._window_state(dt_util.now())
+    if not in_window or self._runtime.get("suspended_reason"):
+        return
+    if self._runtime.get("active_zone_id") is not None:
+        return
+    if isinstance(self._runtime.get("pending_command"), dict):
+        return
+    if self._runtime.get("resume_pending"):
+        return
+    if not _continuous_round_complete(self):
+        return
+
+    self._runtime["completed_zone_ids_in_window"] = []
+    self._runtime["completed_queue_slots"] = []
+    self._runtime["active_queue_slot"] = None
+    self._runtime["just_completed_zone_id"] = None
+    self._runtime["round_index"] = int(self._runtime.get("round_index") or 1) + 1
+    self._runtime["round_started_at"] = _utc_now()
+    activity = (self.coordinator.data or {}).get("activity")
+    self._runtime["last_command"] = (
+        f"round_{self._runtime['round_index']}_waiting_idle"
+        if activity in {ACTIVITY_MOWING, ACTIVITY_RETURNING}
+        else f"round_{self._runtime['round_index']}_ready"
+    )
+    self._runtime["last_command_at"] = _utc_now()
+    self._runtime["last_error"] = None
+    await self._save()
+
+
 def install_schedule_round_semantics() -> None:
-    """Install safe continuous-round rollover behavior once."""
+    """Install safe repeated-round behavior once."""
     global _INSTALLED
     if _INSTALLED:
         return
     NavimowerScheduleController._confirm_active_completion = _confirm_active_completion
     NavimowerScheduleController._async_send_mow = _async_send_mow
+    NavimowerScheduleController._evaluate_locked = _evaluate_locked
     _INSTALLED = True

--- a/custom_components/navimower/schedule_round_semantics.py
+++ b/custom_components/navimower/schedule_round_semantics.py
@@ -12,7 +12,7 @@ end remains the hard boundary.
 """
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable
+from typing import Awaitable, Callable
 
 from homeassistant.util import dt as dt_util
 

--- a/tests/test_v044_beta10.py
+++ b/tests/test_v044_beta10.py
@@ -1,0 +1,86 @@
+"""Regression guards for Navimower 0.4.4-beta10 scheduler safety."""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+OWNERSHIP = COMPONENT / "schedule_ownership_semantics.py"
+ROUND = COMPONENT / "schedule_round_semantics.py"
+RUNTIME = COMPONENT / "runtime.py"
+MANIFEST = COMPONENT / "manifest.json"
+
+
+def _function_source(path: Path, name: str) -> str:
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            segment = ast.get_source_segment(source, node)
+            assert segment is not None
+            return segment
+    raise AssertionError(f"Function {name} not found in {path.name}")
+
+
+def test_beta10_version_and_runtime_install_order() -> None:
+    assert '"version": "0.4.4-beta10"' in MANIFEST.read_text(encoding="utf-8")
+    source = RUNTIME.read_text(encoding="utf-8")
+    assert "from .schedule_ownership_semantics import install_schedule_ownership_semantics" in source
+    assert "install_schedule_pause_semantics()" in source
+    assert "install_schedule_ownership_semantics()" in source
+    assert "install_schedule_round_semantics()" in source
+    assert source.index("install_schedule_pause_semantics()") < source.index(
+        "install_schedule_ownership_semantics()"
+    ) < source.index("install_schedule_round_semantics()")
+
+
+def test_retained_task_requires_positive_scheduler_ownership() -> None:
+    source = _function_source(OWNERSHIP, "_adopt_retained_task")
+    assert "_ownership_proven(controller, active_zone_id)" in source
+    assert "retained_task_rejected_unverified" in source
+    assert "_scheduler_task_evidence" in source
+
+    evidence = _function_source(OWNERSHIP, "_scheduler_task_evidence")
+    assert 'trigger.startswith("navimower_schedule")' in evidence
+    assert "task_ids == [zone_id]" in evidence
+
+
+def test_live_multi_zone_or_external_task_conflicts_with_one_zone_ownership() -> None:
+    source = _function_source(OWNERSHIP, "_live_task_conflicts")
+    assert 'data.get("target_zone_ids")' in source
+    assert "target_ids != [zone_id]" in source
+    assert 'not trigger.startswith("navimower_schedule")' in source
+
+
+def test_resume_refuses_unverified_vendor_retained_task() -> None:
+    source = _function_source(OWNERSHIP, "_continue_interrupted_task")
+    assert "not _ownership_proven(self, zone_id)" in source
+    assert "resume_refused_unverified_task" in source
+    assert "vendor Resume was refused" in source
+    assert "_ORIGINAL_CONTINUE_INTERRUPTED_TASK" in source
+
+
+def test_confirmed_scheduler_start_records_explicit_ownership() -> None:
+    source = _function_source(OWNERSHIP, "_confirm_pending")
+    assert 'pending.get("kind") != "mow"' in source
+    assert 'source.startswith("navimower_schedule")' in source
+    assert 'self._runtime["owned_zone_id"] = zone_id' in source
+    assert 'self._runtime["ownership_source"] = source' in source
+
+
+def test_window_mode_repeats_completed_rounds_but_keeps_window_boundary() -> None:
+    source = _function_source(ROUND, "_evaluate_locked")
+    assert "self._mode != SCHEDULE_MODE_WINDOW" in source
+    assert "in_window, _ = self._window_state(dt_util.now())" in source
+    assert "if not in_window" in source
+    assert "not _continuous_round_complete(self)" in source
+    assert 'self._runtime["completed_zone_ids_in_window"] = []' in source
+    assert 'self._runtime["completed_queue_slots"] = []' in source
+    assert 'self._runtime["round_index"]' in source
+
+
+def test_new_round_waits_for_idle_when_previous_task_is_still_finishing() -> None:
+    source = _function_source(ROUND, "_async_send_mow")
+    assert "activity in {ACTIVITY_MOWING, ACTIVITY_RETURNING}" in source
+    assert "round_" in source and "waiting_idle" in source


### PR DESCRIPTION
## Summary
- require positive one-zone scheduler ownership before adopting or resuming a retained mower task
- fail closed on stale pre-beta10 scheduler runtime instead of resuming unrelated native/manual multi-zone tasks
- persist scheduler ownership after a confirmed scheduler start and expose ownership state through existing schedule diagnostics
- make Time window mode start a new round after all selected zones/custom queue slots complete, while keeping the configured window end as the hard boundary
- retain safe cross-round idle deferral to avoid reset/start races while the mower is still mowing or returning

## Issue
Addresses the unsafe retained-task behavior reported in #235, where a vendor Resume could continue zones outside the Navimower Schedule allowlist.

## Release
Bumps manifest to `0.4.4-beta10` and adds beta10 release notes/regression guards.