### PR TITLE
Add georeference relearn and raw diagnostic capture

### DIFF
--- a/.github/release-notes/0.4.4-beta11.md
+++ b/.github/release-notes/0.4.4-beta11.md
@@ -1,0 +1,11 @@
+title: Navimower 0.4.4-beta11
+
+## Georeference diagnostics and development capture tools
+
+- Add a georeference `local-frame` diagnostic block that compares the decoded map charging-station X/Y, private-cloud `posture_x/posture_y`, and official MQTT live X/Y together with their timestamps/ages. While docked it also reports the private/MQTT offset from the map station, making model-specific local-coordinate origin differences visible.
+- Add `navimower.relearn_georeference` to clear only the selected mower's learned local-map -> WGS84 calibration and immediately begin learning again from fresh location samples. Map geometry, mowing history, Navimower Schedule state, and other integration data are retained.
+- Add `navimower.export_raw_data` for controlled local development. It writes an unredacted capture under `/config/navimower_diagnostics/raw/`, including fresh read-only private-cloud responses, cached raw responses, full plain/compressed map detail, station map, decoded map/calibration state, coordinator state, and the latest exact MQTT payload for each observed current-device topic.
+- Preserve MQTT payload bytes exactly in the raw export with a Base64 copy in addition to the readable UTF-8 form.
+- Keep Home Assistant **Download diagnostics** unchanged as the user-shareable sanitized/redacted path. The raw export is intentionally sensitive and should not be published or attached to public issues.
+
+This beta is intended to diagnose the remaining i1/i108 absolute OSM alignment offset without weakening the privacy contract of normal Home Assistant diagnostics.

--- a/custom_components/navimower/georeference_diagnostics_semantics.py
+++ b/custom_components/navimower/georeference_diagnostics_semantics.py
@@ -16,7 +16,7 @@ def _parse(self: NavimowCoordinator, raw: dict[str, Any]) -> dict[str, Any]:
     georeference = snapshot.get("georeference")
     if isinstance(georeference, dict):
         decorated = deepcopy(georeference)
-        decorated["local_frame_check"] = local_frame_diagnostics(self)
+        decorated["local_frame_check"] = local_frame_diagnostics(self, snapshot)
         snapshot["georeference"] = decorated
         map_data = snapshot.get("map")
         if isinstance(map_data, dict):

--- a/custom_components/navimower/georeference_diagnostics_semantics.py
+++ b/custom_components/navimower/georeference_diagnostics_semantics.py
@@ -1,0 +1,37 @@
+"""Attach coordinate-frame comparison diagnostics to georeference metadata."""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from .coordinator_semantics import NavimowCoordinator
+from .georeference_tools import local_frame_diagnostics
+
+_INSTALLED = False
+_ORIGINAL_PARSE = NavimowCoordinator._parse
+
+
+def _parse(self: NavimowCoordinator, raw: dict[str, Any]) -> dict[str, Any]:
+    snapshot = _ORIGINAL_PARSE(self, raw)
+    georeference = snapshot.get("georeference")
+    if isinstance(georeference, dict):
+        decorated = deepcopy(georeference)
+        decorated["local_frame_check"] = local_frame_diagnostics(self)
+        snapshot["georeference"] = decorated
+        map_data = snapshot.get("map")
+        if isinstance(map_data, dict):
+            map_data = dict(map_data)
+            map_data["georeference"] = decorated
+            snapshot["map"] = map_data
+    return snapshot
+
+
+def install_georeference_diagnostics_semantics() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    NavimowCoordinator._parse = _parse
+    _INSTALLED = True
+
+
+__all__ = ["install_georeference_diagnostics_semantics"]

--- a/custom_components/navimower/georeference_tools.py
+++ b/custom_components/navimower/georeference_tools.py
@@ -22,14 +22,17 @@ def _xy(mapping: Any, x_key: str, y_key: str) -> tuple[float, float] | None:
     return (x, y) if x is not None and y is not None else None
 
 
-def local_frame_diagnostics(coordinator: Any) -> dict[str, Any]:
+def local_frame_diagnostics(
+    coordinator: Any,
+    data_override: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Compare map-station, private-cloud and MQTT local coordinate frames.
 
     Station deltas are physically meaningful only while the mower is docked.
     Cloud-vs-MQTT deltas are included with their source timestamps/ages so stale
     samples are visible instead of being silently treated as simultaneous.
     """
-    data = coordinator.data or {}
+    data = data_override if isinstance(data_override, dict) else (coordinator.data or {})
     raw = data.get("raw") if isinstance(data.get("raw"), dict) else {}
     cloud = raw.get("location") if isinstance(raw.get("location"), dict) else {}
     mqtt = getattr(coordinator, "_mqtt_location", None)

--- a/custom_components/navimower/georeference_tools.py
+++ b/custom_components/navimower/georeference_tools.py
@@ -1,0 +1,128 @@
+"""Georeference field diagnostics and explicit relearn support."""
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+from typing import Any
+
+
+def _float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _xy(mapping: Any, x_key: str, y_key: str) -> tuple[float, float] | None:
+    if not isinstance(mapping, dict):
+        return None
+    x = _float(mapping.get(x_key))
+    y = _float(mapping.get(y_key))
+    return (x, y) if x is not None and y is not None else None
+
+
+def local_frame_diagnostics(coordinator: Any) -> dict[str, Any]:
+    """Compare map-station, private-cloud and MQTT local coordinate frames.
+
+    Station deltas are physically meaningful only while the mower is docked.
+    Cloud-vs-MQTT deltas are included with their source timestamps/ages so stale
+    samples are visible instead of being silently treated as simultaneous.
+    """
+    data = coordinator.data or {}
+    raw = data.get("raw") if isinstance(data.get("raw"), dict) else {}
+    cloud = raw.get("location") if isinstance(raw.get("location"), dict) else {}
+    mqtt = getattr(coordinator, "_mqtt_location", None)
+    mqtt = mqtt if isinstance(mqtt, dict) else {}
+    geometry = getattr(coordinator, "_map_geometry", None)
+    geometry = geometry if isinstance(geometry, dict) else {}
+    station = geometry.get("station") if isinstance(geometry.get("station"), dict) else {}
+
+    station_xy = _xy(station, "x", "y")
+    cloud_xy = _xy(cloud, "posture_x", "posture_y")
+    mqtt_xy = _xy(mqtt, "x", "y")
+    docked = bool(data.get("docked"))
+
+    result: dict[str, Any] = {
+        "map_revision": geometry.get("revision"),
+        "docked": docked,
+        "map_station": {
+            "x": station_xy[0] if station_xy else None,
+            "y": station_xy[1] if station_xy else None,
+        },
+        "private_cloud": {
+            "x": cloud_xy[0] if cloud_xy else None,
+            "y": cloud_xy[1] if cloud_xy else None,
+            "report_time": cloud.get("report_time"),
+        },
+        "mqtt": {
+            "x": mqtt_xy[0] if mqtt_xy else None,
+            "y": mqtt_xy[1] if mqtt_xy else None,
+            "pose_time": mqtt.get("pose_time"),
+            "pose_age_s": data.get("mqtt_pose_age"),
+        },
+    }
+
+    if cloud_xy and mqtt_xy:
+        dx = cloud_xy[0] - mqtt_xy[0]
+        dy = cloud_xy[1] - mqtt_xy[1]
+        result["private_minus_mqtt"] = {
+            "dx_m": round(dx, 4),
+            "dy_m": round(dy, 4),
+            "distance_m": round(math.hypot(dx, dy), 4),
+        }
+
+    if docked and station_xy:
+        if cloud_xy:
+            dx = cloud_xy[0] - station_xy[0]
+            dy = cloud_xy[1] - station_xy[1]
+            result["docked_private_minus_map_station"] = {
+                "dx_m": round(dx, 4),
+                "dy_m": round(dy, 4),
+                "distance_m": round(math.hypot(dx, dy), 4),
+            }
+        if mqtt_xy:
+            dx = mqtt_xy[0] - station_xy[0]
+            dy = mqtt_xy[1] - station_xy[1]
+            result["docked_mqtt_minus_map_station"] = {
+                "dx_m": round(dx, 4),
+                "dy_m": round(dy, 4),
+                "distance_m": round(math.hypot(dx, dy), 4),
+            }
+    return result
+
+
+async def async_relearn_georeference(coordinator: Any) -> dict[str, Any]:
+    """Clear only learned georeference calibration for the current map revision."""
+    geometry = getattr(coordinator, "_map_geometry", None)
+    if not isinstance(geometry, dict):
+        raise ValueError("Map geometry is not available yet")
+
+    previous = deepcopy(geometry.get("georeference"))
+    previous_calibration = deepcopy(geometry.get("_georeference_calibration"))
+    vendor = geometry.get("_vendor_georeference")
+
+    geometry.pop("_georeference_calibration", None)
+    if isinstance(vendor, dict):
+        geometry["georeference"] = deepcopy(vendor)
+    else:
+        geometry.pop("georeference", None)
+    coordinator._map_dirty = True  # noqa: SLF001 - integration-owned maintenance action.
+
+    try:
+        await coordinator._state_store.async_save(coordinator._state_store_data())  # noqa: SLF001
+    except Exception:  # persistence will also happen on the next normal refresh
+        pass
+
+    # A normal refresh collects the first new paired private-cloud XY/GPS sample.
+    await coordinator.async_request_refresh()
+    active = (coordinator.data or {}).get("georeference")
+    return {
+        "map_revision": geometry.get("revision"),
+        "previous_source": (previous or {}).get("source") if isinstance(previous, dict) else None,
+        "previous_sample_count": len((previous_calibration or {}).get("samples") or [])
+        if isinstance(previous_calibration, dict)
+        else 0,
+        "active_status": (active or {}).get("status") if isinstance(active, dict) else None,
+        "active_source": (active or {}).get("source") if isinstance(active, dict) else None,
+    }

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta10"
+  "version": "0.4.4-beta11"
 }

--- a/custom_components/navimower/raw_export.py
+++ b/custom_components/navimower/raw_export.py
@@ -1,0 +1,123 @@
+"""Explicit unredacted Navimower raw-data export for local development.
+
+Unlike Home Assistant Download diagnostics, this action deliberately preserves
+vendor payload values and full map data. It is intended for the integration
+owner's local field research only and writes files below /config.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+from homeassistant.core import HomeAssistant
+
+from .georeference_tools import local_frame_diagnostics
+from .map_identifiers import resolve_map_identifiers
+
+
+def _write_json(path: Path, document: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(document, ensure_ascii=False, indent=2, default=repr),
+        encoding="utf-8",
+    )
+
+
+def _call_capture(name: str, getter: Callable[[], Any]) -> dict[str, Any]:
+    """Capture one read-only endpoint without making one failure lose the export."""
+    try:
+        return {"ok": True, "data": getter()}
+    except Exception as err:  # noqa: BLE001 - diagnostics should retain partial data.
+        return {"ok": False, "error": repr(err)}
+
+
+def _fresh_private_payloads(coordinator: Any) -> dict[str, Any]:
+    """Read all known non-mutating private-cloud endpoints with original values."""
+    client = coordinator.client
+    sn = coordinator.sn
+    vehicle_type = coordinator.vehicle_type
+    result: dict[str, Any] = {}
+    reads: tuple[tuple[str, Callable[[], Any]], ...] = (
+        ("auth_list", client.auth_list),
+        ("index2", lambda: client.index2(sn)),
+        ("device_info", lambda: client.device_info(sn)),
+        ("set_list", lambda: client.set_list(sn)),
+        ("vehicle_config", lambda: client.vehicle_config(sn)),
+        ("today_plan", lambda: client.today_plan(sn, vehicle_type)),
+        ("location", lambda: client.location(sn, vehicle_type)),
+        ("errors", lambda: client.errors(sn, vehicle_type)),
+        ("maintenance", lambda: client.maintenance(sn)),
+        ("path_info_time", lambda: client.path_info_time(sn)),
+        ("map_list", lambda: client.map_list(sn)),
+    )
+    for name, getter in reads:
+        result[name] = _call_capture(name, getter)
+
+    location = result.get("location", {}).get("data")
+    map_list = result.get("map_list", {}).get("data")
+    map_id, map_base_id, edit_time = resolve_map_identifiers(location, map_list)
+    result["resolved_map_identifiers"] = {
+        "map_id": map_id,
+        "map_base_id": map_base_id,
+        "edit_time": edit_time,
+    }
+    if map_id is not None and map_base_id is not None:
+        result["map_detail_plain"] = _call_capture(
+            "map_detail_plain",
+            lambda: client.map_detail_plain(sn, str(map_id), str(map_base_id)),
+        )
+        result["map_detail_compress"] = _call_capture(
+            "map_detail_compress",
+            lambda: client.map_detail(sn, str(map_id), str(map_base_id)),
+        )
+        result["station_map"] = _call_capture(
+            "station_map",
+            lambda: client.station_map(sn, str(map_id), str(map_base_id)),
+        )
+    return result
+
+
+async def async_export_raw_data(hass: HomeAssistant, coordinator: Any) -> str:
+    """Write a full-value raw capture and return its local HA path."""
+    private_payloads = await hass.async_add_executor_job(
+        _fresh_private_payloads, coordinator
+    )
+    mqtt_bridge = getattr(coordinator, "mqtt_bridge", None)
+    mqtt_raw = (
+        mqtt_bridge.raw_message_diagnostics()
+        if mqtt_bridge is not None and hasattr(mqtt_bridge, "raw_message_diagnostics")
+        else None
+    )
+    document = {
+        "format": "navimower-raw-data-v1",
+        "created_utc": datetime.now(UTC).isoformat(),
+        "warning": (
+            "UNREDACTED DEVELOPMENT EXPORT. Contains exact vendor/map/location "
+            "values and identifiers. Do not publish or attach publicly."
+        ),
+        "source": "navimower.export_raw_data",
+        "entry_id": coordinator.entry.entry_id,
+        "vehicle_sn": coordinator.sn,
+        "vehicle_type": coordinator.vehicle_type,
+        "private_cloud_fresh": private_payloads,
+        "private_cloud_cached": deepcopy(getattr(coordinator, "_raw_cache", {})),
+        "map_geometry_decoded": deepcopy(getattr(coordinator, "_map_geometry", None)),
+        "map_cache_key": deepcopy(getattr(coordinator, "_map_cache_key", None)),
+        "mqtt_raw_last_messages": deepcopy(mqtt_raw),
+        "mqtt_parsed_cache": deepcopy(getattr(coordinator, "_mqtt_location", None)),
+        "coordinator_snapshot": deepcopy(coordinator.data or {}),
+        "local_frame_check": local_frame_diagnostics(coordinator),
+        "endpoint_status": deepcopy(getattr(coordinator, "_endpoint_status", {})),
+    }
+
+    now = datetime.now(UTC)
+    folder = Path(hass.config.path("navimower_diagnostics", "raw"))
+    stamp = now.strftime("%Y%m%d_%H%M%S")
+    path = folder / f"navimower_raw_{stamp}.json"
+    latest = folder / "navimower_raw_latest.json"
+    await hass.async_add_executor_job(_write_json, path, document)
+    await hass.async_add_executor_job(_write_json, latest, document)
+    return str(path)

--- a/custom_components/navimower/raw_mqtt_semantics.py
+++ b/custom_components/navimower/raw_mqtt_semantics.py
@@ -1,0 +1,56 @@
+"""Retain bounded exact MQTT payloads for explicit local raw-data exports."""
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime
+from typing import Any
+
+from .mqtt import NavimowerMqttBridge
+
+_INSTALLED = False
+_ORIGINAL_RECORD = NavimowerMqttBridge._record_message_inventory
+
+
+def _record_message_inventory(
+    self: NavimowerMqttBridge,
+    topic: str,
+    payload: bytes,
+    incoming_device_id: str,
+) -> None:
+    _ORIGINAL_RECORD(self, topic, payload, incoming_device_id)
+    if incoming_device_id != getattr(self, "_device_id", ""):
+        return
+
+    cache = getattr(self, "_raw_message_cache", None)
+    if not isinstance(cache, dict):
+        cache = {}
+        self._raw_message_cache = cache
+
+    topic_text = str(topic)
+    raw = bytes(payload or b"")
+    cache[topic_text] = {
+        "seen_utc": datetime.now(UTC).isoformat(),
+        "incoming_device_id": str(incoming_device_id),
+        "payload_bytes": len(raw),
+        "payload_utf8": raw.decode("utf-8", errors="replace"),
+    }
+    # Exact latest message per topic is enough for the explicit snapshot action;
+    # bound topic count so leaving this enabled has negligible memory impact.
+    while len(cache) > 64:
+        del cache[next(iter(cache))]
+
+
+def raw_message_diagnostics(self: NavimowerMqttBridge) -> dict[str, Any]:
+    return deepcopy(getattr(self, "_raw_message_cache", {}) or {})
+
+
+def install_raw_mqtt_semantics() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    NavimowerMqttBridge._record_message_inventory = _record_message_inventory
+    NavimowerMqttBridge.raw_message_diagnostics = raw_message_diagnostics
+    _INSTALLED = True
+
+
+__all__ = ["install_raw_mqtt_semantics"]

--- a/custom_components/navimower/raw_mqtt_semantics.py
+++ b/custom_components/navimower/raw_mqtt_semantics.py
@@ -1,6 +1,7 @@
 """Retain bounded exact MQTT payloads for explicit local raw-data exports."""
 from __future__ import annotations
 
+import base64
 from copy import deepcopy
 from datetime import UTC, datetime
 from typing import Any
@@ -32,7 +33,10 @@ def _record_message_inventory(
         "seen_utc": datetime.now(UTC).isoformat(),
         "incoming_device_id": str(incoming_device_id),
         "payload_bytes": len(raw),
+        # Keep a readable form for ordinary JSON traffic and a byte-exact copy
+        # so even an unexpected non-UTF8 payload is never lost by the exporter.
         "payload_utf8": raw.decode("utf-8", errors="replace"),
+        "payload_base64": base64.b64encode(raw).decode("ascii"),
     }
     # Exact latest message per topic is enough for the explicit snapshot action;
     # bound topic count so leaving this enabled has negligible memory impact.

--- a/custom_components/navimower/runtime.py
+++ b/custom_components/navimower/runtime.py
@@ -13,6 +13,7 @@ from .georeference_semantics import install_georeference_semantics
 from .navigation_fallback import install_navigation_fallback
 from .notification_feed import install_notification_feed
 from .private_cloud_region import install_private_cloud_region
+from .raw_mqtt_semantics import install_raw_mqtt_semantics
 from .schedule_ownership_semantics import install_schedule_ownership_semantics
 from .schedule_pause_semantics import install_schedule_pause_semantics
 from .schedule_round_semantics import install_schedule_round_semantics
@@ -31,6 +32,7 @@ def install_runtime_extensions() -> None:
     install_georeference_semantics()
     install_navigation_fallback()
     install_notification_feed()
+    install_raw_mqtt_semantics()
     install_schedule_pause_semantics()
     install_schedule_ownership_semantics()
     install_schedule_round_semantics()

--- a/custom_components/navimower/runtime.py
+++ b/custom_components/navimower/runtime.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from .capability_extensions import install_capability_extensions
 from .capability_profile import install_capability_profile
 from .capability_semantics import install_capability_semantics
+from .georeference_diagnostics_semantics import install_georeference_diagnostics_semantics
 from .georeference_semantics import install_georeference_semantics
 from .navigation_fallback import install_navigation_fallback
 from .notification_feed import install_notification_feed
@@ -30,6 +31,7 @@ def install_runtime_extensions() -> None:
     install_capability_profile()
     install_capability_semantics()
     install_georeference_semantics()
+    install_georeference_diagnostics_semantics()
     install_navigation_fallback()
     install_notification_feed()
     install_raw_mqtt_semantics()

--- a/custom_components/navimower/services.py
+++ b/custom_components/navimower/services.py
@@ -1,27 +1,8 @@
-"""Services for Navimower.
-
-- ``navimower.set_schedule`` writes one weekday's plan (enabled + one or more
-  time periods, each optionally restricted to zones) via the proven
-  save-set-data format.
-- ``navimower.mow`` starts mowing now: chosen zones and a ``reset`` flag
-  (True = restart from scratch, False = continue). On models that support
-  custom sequencing, listing zones explicitly also fixes their mowing order.
-  First-generation H-series mowers still accept the selected zones but choose
-  their order themselves.
-- ``navimower.resume`` resumes the vendor-retained interrupted task without
-  selecting zones, resetting progress or starting a new Navimower mowing cycle.
-- ``navimower.mark_notification_read`` opens one Device notification through the
-  same encrypted detail route as the official app and then refreshes the Device
-  feed to confirm the resulting vendor read state.
-- ``navimower.mark_all_notifications_read`` executes the official app's Mark all
-  as read request for the selected mower/account and refreshes the Device feed.
-
-Diagnostics are exposed through Home Assistant's native Download diagnostics
-flow rather than custom development services.
-"""
+"""Services for Navimower."""
 from __future__ import annotations
 
 import voluptuous as vol
+from homeassistant.components import persistent_notification
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv
@@ -34,11 +15,13 @@ from .const import (
     encode_partition_ids,
     mow_setup,
 )
+from .georeference_tools import async_relearn_georeference
 from .model_support import supports_ordered_zone_mowing
 from .notification_actions import (
     async_mark_all_notifications_read,
     async_mark_notification_read,
 )
+from .raw_export import async_export_raw_data
 from .resume import async_resume_task
 
 install_runtime_extensions()
@@ -49,6 +32,8 @@ SERVICE_RESUME = "resume"
 SERVICE_SET_SCHEDULE_QUEUE = "set_schedule_queue"
 SERVICE_MARK_NOTIFICATION_READ = "mark_notification_read"
 SERVICE_MARK_ALL_NOTIFICATIONS_READ = "mark_all_notifications_read"
+SERVICE_RELEARN_GEOREFERENCE = "relearn_georeference"
+SERVICE_EXPORT_RAW_DATA = "export_raw_data"
 
 _WEEKDAY_TO_NUM = {
     "sunday": 1,
@@ -85,13 +70,17 @@ MOW_SCHEMA = vol.Schema(
     }
 )
 
-SET_SCHEDULE_QUEUE_SCHEMA = vol.Schema({vol.Optional("device_id"): cv.string, vol.Required("zones"): vol.All(cv.ensure_list, [vol.Coerce(int)])})
-
-RESUME_SCHEMA = vol.Schema(
+SET_SCHEDULE_QUEUE_SCHEMA = vol.Schema(
     {
         vol.Optional("device_id"): cv.string,
+        vol.Required("zones"): vol.All(cv.ensure_list, [vol.Coerce(int)]),
     }
 )
+
+DEVICE_ONLY_SCHEMA = vol.Schema({vol.Optional("device_id"): cv.string})
+RESUME_SCHEMA = DEVICE_ONLY_SCHEMA
+RELEARN_GEOREFERENCE_SCHEMA = DEVICE_ONLY_SCHEMA
+EXPORT_RAW_DATA_SCHEMA = DEVICE_ONLY_SCHEMA
 
 MARK_NOTIFICATION_READ_SCHEMA = vol.Schema(
     {
@@ -100,11 +89,7 @@ MARK_NOTIFICATION_READ_SCHEMA = vol.Schema(
     }
 )
 
-MARK_ALL_NOTIFICATIONS_READ_SCHEMA = vol.Schema(
-    {
-        vol.Optional("device_id"): cv.string,
-    }
-)
+MARK_ALL_NOTIFICATIONS_READ_SCHEMA = DEVICE_ONLY_SCHEMA
 
 
 def _hhmm_to_min(value: str) -> int:
@@ -264,11 +249,15 @@ def async_setup_services(hass: HomeAssistant) -> None:
         if controller is None:
             raise ServiceValidationError("Navimower Schedule controller is not available")
         try:
-            await controller.async_set_custom_queue([int(v) for v in call.data.get("zones") or []])
+            await controller.async_set_custom_queue(
+                [int(v) for v in call.data.get("zones") or []]
+            )
         except ValueError as err:
             raise ServiceValidationError(str(err)) from err
         except Exception as err:
-            raise HomeAssistantError(f"Navimower set_schedule_queue failed: {err}") from err
+            raise HomeAssistantError(
+                f"Navimower set_schedule_queue failed: {err}"
+            ) from err
 
     async def _resume(call: ServiceCall) -> None:
         coordinator = _resolve_coordinator(call)
@@ -296,35 +285,59 @@ def async_setup_services(hass: HomeAssistant) -> None:
                 f"Navimow mark_all_notifications_read failed: {err}"
             ) from err
 
-    if not hass.services.has_service(DOMAIN, SERVICE_SET_SCHEDULE):
-        hass.services.async_register(
-            DOMAIN,
-            SERVICE_SET_SCHEDULE,
-            _set_schedule,
-            schema=SET_SCHEDULE_SCHEMA,
+    async def _relearn_georeference(call: ServiceCall) -> None:
+        coordinator = _resolve_coordinator(call)
+        try:
+            result = await async_relearn_georeference(coordinator)
+        except ValueError as err:
+            raise ServiceValidationError(str(err)) from err
+        except Exception as err:
+            raise HomeAssistantError(
+                f"Navimower georeference relearn failed: {err}"
+            ) from err
+        persistent_notification.async_create(
+            hass,
+            (
+                "Navimower georeference calibration was cleared for this mower. "
+                "A fresh calibration is now learning from new location samples.\n\n"
+                f"Map revision: `{result.get('map_revision')}`\n"
+                f"Previous samples: `{result.get('previous_sample_count')}`\n"
+                f"Current status: `{result.get('active_status')}`"
+            ),
+            title="Navimower georeference relearn started",
+            notification_id=f"navimower_georeference_relearn_{coordinator.entry.entry_id}",
         )
-    if not hass.services.has_service(DOMAIN, SERVICE_MOW):
-        hass.services.async_register(DOMAIN, SERVICE_MOW, _mow, schema=MOW_SCHEMA)
-    if not hass.services.has_service(DOMAIN, SERVICE_SET_SCHEDULE_QUEUE):
-        hass.services.async_register(DOMAIN, SERVICE_SET_SCHEDULE_QUEUE, _set_schedule_queue, schema=SET_SCHEDULE_QUEUE_SCHEMA)
-    if not hass.services.has_service(DOMAIN, SERVICE_RESUME):
-        hass.services.async_register(
-            DOMAIN,
-            SERVICE_RESUME,
-            _resume,
-            schema=RESUME_SCHEMA,
+
+    async def _export_raw_data(call: ServiceCall) -> None:
+        coordinator = _resolve_coordinator(call)
+        try:
+            path = await async_export_raw_data(hass, coordinator)
+        except Exception as err:
+            raise HomeAssistantError(
+                f"Navimower raw data export failed: {err}"
+            ) from err
+        persistent_notification.async_create(
+            hass,
+            (
+                "Unredacted Navimower raw-data export completed.\n\n"
+                f"File: `{path}`\n\n"
+                "This file intentionally contains exact vendor/map/location values "
+                "and identifiers. Do not publish or attach it publicly."
+            ),
+            title="Navimower raw data export",
+            notification_id="navimower_raw_data_export",
         )
-    if not hass.services.has_service(DOMAIN, SERVICE_MARK_NOTIFICATION_READ):
-        hass.services.async_register(
-            DOMAIN,
-            SERVICE_MARK_NOTIFICATION_READ,
-            _mark_notification_read,
-            schema=MARK_NOTIFICATION_READ_SCHEMA,
-        )
-    if not hass.services.has_service(DOMAIN, SERVICE_MARK_ALL_NOTIFICATIONS_READ):
-        hass.services.async_register(
-            DOMAIN,
-            SERVICE_MARK_ALL_NOTIFICATIONS_READ,
-            _mark_all_notifications_read,
-            schema=MARK_ALL_NOTIFICATIONS_READ_SCHEMA,
-        )
+
+    registrations = (
+        (SERVICE_SET_SCHEDULE, _set_schedule, SET_SCHEDULE_SCHEMA),
+        (SERVICE_MOW, _mow, MOW_SCHEMA),
+        (SERVICE_SET_SCHEDULE_QUEUE, _set_schedule_queue, SET_SCHEDULE_QUEUE_SCHEMA),
+        (SERVICE_RESUME, _resume, RESUME_SCHEMA),
+        (SERVICE_MARK_NOTIFICATION_READ, _mark_notification_read, MARK_NOTIFICATION_READ_SCHEMA),
+        (SERVICE_MARK_ALL_NOTIFICATIONS_READ, _mark_all_notifications_read, MARK_ALL_NOTIFICATIONS_READ_SCHEMA),
+        (SERVICE_RELEARN_GEOREFERENCE, _relearn_georeference, RELEARN_GEOREFERENCE_SCHEMA),
+        (SERVICE_EXPORT_RAW_DATA, _export_raw_data, EXPORT_RAW_DATA_SCHEMA),
+    )
+    for service, handler, schema in registrations:
+        if not hass.services.has_service(DOMAIN, service):
+            hass.services.async_register(DOMAIN, service, handler, schema=schema)

--- a/custom_components/navimower/services.yaml
+++ b/custom_components/navimower/services.yaml
@@ -83,9 +83,8 @@ resume:
     Ask the mower to resume its vendor-retained interrupted task. This sends the
     dedicated Resume command and does not select zones, send a new Mow command,
     reset mowing progress or start a new Navimower mowing cycle. Paused resume is
-    already known to work. Resume from docked/charging state is included in
-    0.4.2-beta3 for field validation and may depend on mower model, firmware and
-    whether the mower still retains an interrupted task.
+    already known to work. Resume from docked/charging state may depend on mower
+    model, firmware and whether the mower still retains an interrupted task.
   fields:
     device_id:
       name: Mower
@@ -158,6 +157,39 @@ reset_schedule:
     If Navimower Schedule is enabled, its next eligible zone is treated as a new
     mowing cycle and may therefore start from scratch. Reset is refused while the
     mower is mowing or returning; pause or dock it first.
+  fields:
+    device_id:
+      name: Mower
+      description: Target mower (only required if more than one is configured).
+      required: false
+      selector:
+        device:
+          integration: navimower
+
+relearn_georeference:
+  name: Relearn map georeference
+  description: >-
+    Clear only this mower's learned local-map to WGS84 calibration and immediately
+    start learning it again from fresh location samples. Map geometry, mowing
+    history, Schedule state and other integration data are not reset.
+  fields:
+    device_id:
+      name: Mower
+      description: Target mower (only required if more than one is configured).
+      required: false
+      selector:
+        device:
+          integration: navimower
+
+export_raw_data:
+  name: Export raw development data
+  description: >-
+    Write an explicit unredacted development capture under
+    /config/navimower_diagnostics/raw/. The file preserves fresh private-cloud
+    responses, full map-detail data, decoded map/calibration state and the latest
+    exact MQTT payload per observed topic. This is separate from Home Assistant
+    Download diagnostics, which remains sanitized for user sharing. Raw exports
+    contain sensitive coordinates and identifiers and must not be published.
   fields:
     device_id:
       name: Mower

--- a/tests/test_v044_beta10.py
+++ b/tests/test_v044_beta10.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import ast
+import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -24,7 +25,10 @@ def _function_source(path: Path, name: str) -> str:
 
 
 def test_beta10_version_and_runtime_install_order() -> None:
-    assert '"version": "0.4.4-beta10"' in MANIFEST.read_text(encoding="utf-8")
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    version = str(manifest.get("version") or "")
+    assert version.startswith("0.4.4-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 10
     source = RUNTIME.read_text(encoding="utf-8")
     assert "from .schedule_ownership_semantics import install_schedule_ownership_semantics" in source
     assert "install_schedule_pause_semantics()" in source

--- a/tests/test_v044_beta11.py
+++ b/tests/test_v044_beta11.py
@@ -1,0 +1,129 @@
+"""Regression guards for Navimower 0.4.4-beta11 diagnostics tools."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _source(name: str) -> str:
+    text = (COMPONENT / name).read_text(encoding="utf-8")
+    ast.parse(text)
+    return text
+
+
+def test_beta11_version_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.4-beta11"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta11.md").read_text(
+        encoding="utf-8"
+    )
+    for phrase in (
+        "local-frame",
+        "relearn_georeference",
+        "export_raw_data",
+        "Download diagnostics",
+    ):
+        assert phrase in notes
+
+
+def test_frame_diagnostics_compare_map_cloud_and_mqtt() -> None:
+    source = _source("georeference_tools.py")
+    for marker in (
+        'geometry.get("station")',
+        'cloud, "posture_x", "posture_y"',
+        'mqtt, "x", "y"',
+        '"private_minus_mqtt"',
+        '"docked_private_minus_map_station"',
+        '"docked_mqtt_minus_map_station"',
+        '"report_time"',
+        '"pose_time"',
+    ):
+        assert marker in source
+
+
+def test_georeference_relearn_is_scoped_to_calibration() -> None:
+    source = _source("georeference_tools.py")
+    assert 'geometry.pop("_georeference_calibration", None)' in source
+    assert 'geometry.pop("georeference", None)' in source
+    assert 'geometry.get("_vendor_georeference")' in source
+    assert "async_request_refresh" in source
+    for forbidden in ("history.async_remove", "reset_schedule", "mow_zones", "client.dock"):
+        assert forbidden not in source
+
+
+def test_raw_export_preserves_full_vendor_and_map_values() -> None:
+    source = _source("raw_export.py")
+    for marker in (
+        '"navimower-raw-data-v1"',
+        '"private_cloud_fresh"',
+        '"private_cloud_cached"',
+        '"map_geometry_decoded"',
+        '"mqtt_raw_last_messages"',
+        '"coordinator_snapshot"',
+        '"local_frame_check"',
+        '"map_detail_plain"',
+        '"map_detail_compress"',
+        '"station_map"',
+        '"vehicle_config"',
+        '"navimower_raw_latest.json"',
+    ):
+        assert marker in source
+    assert "sanitize(" not in source
+
+
+def test_raw_export_is_read_only() -> None:
+    source = _source("raw_export.py")
+    for forbidden in (
+        "mow_zones(",
+        "save_setting(",
+        "send_setting_device(",
+        "set_day_schedule(",
+        "client.pause(",
+        "client.dock(",
+        "client.resume(",
+    ):
+        assert forbidden not in source
+
+
+def test_exact_latest_mqtt_payload_is_retained_bounded() -> None:
+    source = _source("raw_mqtt_semantics.py")
+    assert 'raw.decode("utf-8", errors="replace")' in source
+    assert '"payload_bytes"' in source
+    assert "while len(cache) > 64" in source
+    assert "sanitize_discovery_payload" not in source
+
+
+def test_services_expose_relearn_and_raw_export() -> None:
+    source = _source("services.py")
+    yaml = (COMPONENT / "services.yaml").read_text(encoding="utf-8")
+    for marker in (
+        'SERVICE_RELEARN_GEOREFERENCE = "relearn_georeference"',
+        'SERVICE_EXPORT_RAW_DATA = "export_raw_data"',
+        "async_relearn_georeference",
+        "async_export_raw_data",
+    ):
+        assert marker in source
+    assert "relearn_georeference:" in yaml
+    assert "export_raw_data:" in yaml
+    assert "unredacted" in yaml.lower()
+
+
+def test_download_diagnostics_remain_sanitized() -> None:
+    diagnostics = _source("diagnostics.py")
+    assert '"diagnostics_source": "home_assistant_download"' in diagnostics
+    assert '"raw": sanitize(raw_for_diagnostics)' in diagnostics
+    assert "export_raw_data" not in diagnostics
+
+
+def test_runtime_installs_frame_and_raw_mqtt_semantics() -> None:
+    runtime = _source("runtime.py")
+    assert "install_georeference_semantics()" in runtime
+    assert "install_georeference_diagnostics_semantics()" in runtime
+    assert runtime.index("install_georeference_semantics()") < runtime.index(
+        "install_georeference_diagnostics_semantics()"
+    )
+    assert "install_raw_mqtt_semantics()" in runtime

--- a/tests/test_v044_beta11.py
+++ b/tests/test_v044_beta11.py
@@ -92,6 +92,8 @@ def test_raw_export_is_read_only() -> None:
 def test_exact_latest_mqtt_payload_is_retained_bounded() -> None:
     source = _source("raw_mqtt_semantics.py")
     assert 'raw.decode("utf-8", errors="replace")' in source
+    assert '"payload_base64"' in source
+    assert "base64.b64encode(raw)" in source
     assert '"payload_bytes"' in source
     assert "while len(cache) > 64" in source
     assert "sanitize_discovery_payload" not in source


### PR DESCRIPTION
## Summary
- add local coordinate-frame diagnostics comparing map station, private-cloud posture X/Y and MQTT X/Y, including docked offset checks
- add `navimower.relearn_georeference` to reset only learned georeference calibration and begin learning again from fresh samples
- restore an explicit `navimower.export_raw_data` development action that writes an unredacted local capture under `/config/navimower_diagnostics/raw/`
- include fresh read-only private-cloud responses, full map detail, station map, decoded map/calibration state, coordinator state and exact latest MQTT payloads
- retain byte-exact MQTT payloads via Base64 as well as readable UTF-8
- keep Home Assistant Download diagnostics sanitized/redacted and cached-only

## Purpose
These tools are intended to diagnose the remaining i1/i108 absolute OSM alignment offset and distinguish private-cloud GPS bias from local-coordinate-frame offsets without weakening normal diagnostics privacy.

## Release
Bumps Navimower to `0.4.4-beta11` and adds regression guards/release notes.