### PR TITLE
Use validated static vendor map anchors for OSM alignment

### DIFF
--- a/.github/release-notes/0.4.4-beta12.md
+++ b/.github/release-notes/0.4.4-beta12.md
@@ -1,0 +1,12 @@
+title: Navimower 0.4.4-beta12
+
+## Static vendor map anchors for i1/X3 OSM alignment
+
+- Use the static WGS84 map metadata already present in Navimow map-detail when `map_north_offset` is absent. The new path fits a rigid map transform from `origin_gps`, `center_gps`, `sw_gps`, `ne_gps`, `map_circle_center`, `map_width`, and `map_height`.
+- Accept the static anchor only when all four vendor tie points agree within 1 metre and the observed map scale remains within 0.97-1.03. Captured i108 and X390 maps validate much more tightly than that, with sub-0.25 m maximum residuals.
+- Make the validated static map transform authoritative for map placement on those map generations. The ordinary cloud-location fit still learns in the background and is retained as a diagnostic/validation signal, but live cloud GPS drift can no longer translate or rotate the whole map.
+- Keep the existing explicit `map_north_offset` vendor path unchanged for H2-style maps such as H215.
+- Force one map-detail refresh for older persisted cloud-only georeference caches so existing i108/X390 installations can discover the static vendor anchor without requiring a map edit or manual georeference reset.
+- Expose the static anchor source, fit residuals, observed scale, rotation, live cloud validation, and learned-vs-static difference through the existing georeference diagnostics.
+
+This beta is intended to improve Multi mower / OSM absolute alignment, especially the several-metre translation error observed on i108, while keeping live GPS fitting useful as a secondary consistency check.

--- a/custom_components/navimower/georeference_static_anchor_semantics.py
+++ b/custom_components/navimower/georeference_static_anchor_semantics.py
@@ -1,19 +1,4 @@
-"""Prefer vendor static map anchors when map-detail proves a north-aligned frame.
-
-Some Navimow map generations (observed on i1 and X3 families) omit
-``map_north_offset`` but still expose a complete static WGS84 frame:
-
-* ``origin_gps`` ties local map coordinate (0, 0) to WGS84;
-* ``map_circle_center`` + ``center_gps`` provide an independent center check;
-* ``sw_gps`` / ``ne_gps`` plus ``map_width`` / ``map_height`` provide a long
-  baseline bounds check.
-
-For those maps the local X/Y axes are already East/North aligned. Accept the
-static origin only when all independent vendor fields agree within tight metre
-limits. Once accepted, that static map anchor is authoritative for translation
-and rotation for the map revision. Cloud-location fitting continues in the
-background as diagnostics/validation, but GPS drift may no longer move the map.
-"""
+"""Prefer vendor static map anchors when map-detail proves a stable WGS84 frame."""
 from __future__ import annotations
 
 from copy import deepcopy
@@ -22,144 +7,155 @@ from typing import Any, Callable
 
 from . import georeference as _georeference
 
-_STATIC_SOURCE = "vendor_map_origin"
+_STATIC_SOURCE = "vendor_map_static_fit"
 _STATIC_MAX_POINT_ERROR_M = 1.0
 _STATIC_MIN_DIAGONAL_M = 10.0
 _STATIC_MIN_SCALE = 0.97
 _STATIC_MAX_SCALE = 1.03
+_PROBE_MARKER = "static_vendor_anchor_v1"
 
 _INSTALLED = False
 _ORIGINAL_FROM_GEOMETRY: Callable[[Any], dict[str, Any] | None] | None = None
 _ORIGINAL_UPDATE: Callable[[Any, Any], dict[str, Any] | None] | None = None
+_ORIGINAL_LOAD: Callable[..., Any] | None = None
 
 
 def _gps_dict(pair: tuple[float, float]) -> dict[str, float]:
-    latitude, longitude = pair
-    return {"latitude": latitude, "longitude": longitude}
+    return {"latitude": pair[0], "longitude": pair[1]}
 
 
-def _point_error_m(
-    candidate: dict[str, Any],
-    local: tuple[float, float],
-    gps: tuple[float, float],
-) -> float | None:
-    projected = _georeference.local_xy_to_wgs84(candidate, local[0], local[1])
-    if projected is None:
+def _fit_static_ties(
+    ties: list[tuple[tuple[float, float], tuple[float, float]]]
+) -> tuple[dict[str, Any], list[float], float] | None:
+    """Fit a fixed-scale rigid transform from vendor map metadata only."""
+    if len(ties) < 3:
         return None
-    return _georeference._distance_m(  # noqa: SLF001 - same integration module.
-        projected[0], projected[1], gps[0], gps[1]
-    )
+    mean_x = sum(local[0] for local, _ in ties) / len(ties)
+    mean_y = sum(local[1] for local, _ in ties) / len(ties)
+    mean_lat = sum(gps[0] for _, gps in ties) / len(ties)
+    mean_lon = sum(gps[1] for _, gps in ties) / len(ties)
+
+    dot_sum = 0.0
+    cross_sum = 0.0
+    local_energy = 0.0
+    offsets: list[tuple[float, float]] = []
+    for (x, y), (lat, lon) in ties:
+        offset = _georeference.wgs84_offset_m(mean_lat, mean_lon, lat, lon)
+        if offset is None:
+            return None
+        east, north = offset
+        offsets.append((east, north))
+        local_x = x - mean_x
+        local_y = y - mean_y
+        dot_sum += local_x * east + local_y * north
+        cross_sum += local_x * north - local_y * east
+        local_energy += local_x * local_x + local_y * local_y
+    if local_energy <= 1e-9:
+        return None
+
+    rotation = -math.atan2(cross_sum, dot_sum)
+    observed_scale = math.hypot(dot_sum, cross_sum) / local_energy
+    transform = {
+        "schema_version": 1,
+        "source": _STATIC_SOURCE,
+        "reference": {
+            "local_x": mean_x,
+            "local_y": mean_y,
+            "latitude": mean_lat,
+            "longitude": mean_lon,
+        },
+        "rotation_rad": rotation,
+    }
+    residuals: list[float] = []
+    for ((x, y), _), (east, north) in zip(ties, offsets, strict=True):
+        dx = x - mean_x
+        dy = y - mean_y
+        calc_east = dx * math.cos(rotation) + dy * math.sin(rotation)
+        calc_north = -dx * math.sin(rotation) + dy * math.cos(rotation)
+        residuals.append(math.hypot(calc_east - east, calc_north - north))
+    return transform, residuals, observed_scale
 
 
-def _static_map_origin_georeference(geom: Any) -> dict[str, Any] | None:
-    """Build a validated local-(0,0) vendor anchor for north-aligned maps."""
+def _static_map_georeference(geom: Any) -> dict[str, Any] | None:
+    """Build a static vendor transform from origin/center/SW/NE map ties."""
     if not isinstance(geom, dict):
         return None
-
-    # A real map_north_offset belongs to the established vendor_map_detail path.
+    # Keep H2-style maps on the established explicit-angle path.
     if _georeference._float(geom.get("map_north_offset")) is not None:  # noqa: SLF001
         return None
 
     origin = _georeference._gps(geom.get("origin_gps"))  # noqa: SLF001
     center_gps = _georeference._gps(geom.get("center_gps"))  # noqa: SLF001
-    south_west_gps = _georeference._gps(geom.get("sw_gps"))  # noqa: SLF001
-    north_east_gps = _georeference._gps(geom.get("ne_gps"))  # noqa: SLF001
-    center_local = _georeference._xy(geom.get("map_circle_center"))  # noqa: SLF001
+    sw_gps = _georeference._gps(geom.get("sw_gps"))  # noqa: SLF001
+    ne_gps = _georeference._gps(geom.get("ne_gps"))  # noqa: SLF001
+    center = _georeference._xy(geom.get("map_circle_center"))  # noqa: SLF001
     width = _georeference._float(geom.get("map_width"))  # noqa: SLF001
     height = _georeference._float(geom.get("map_height"))  # noqa: SLF001
+    if None in (origin, center_gps, sw_gps, ne_gps, center, width, height):
+        return None
+    assert origin and center_gps and sw_gps and ne_gps and center
+    assert width is not None and height is not None
+    if width <= 0.0 or height <= 0.0 or math.hypot(width, height) < _STATIC_MIN_DIAGONAL_M:
+        return None
+
+    cx, cy = center
+    local_sw = (cx - width / 2.0, cy - height / 2.0)
+    local_ne = (cx + width / 2.0, cy + height / 2.0)
+    ties = [
+        ((0.0, 0.0), origin),
+        (center, center_gps),
+        (local_sw, sw_gps),
+        (local_ne, ne_gps),
+    ]
+    fitted = _fit_static_ties(ties)
+    if fitted is None:
+        return None
+    candidate, residuals, observed_scale = fitted
+    max_error = max(residuals)
     if (
-        origin is None
-        or center_gps is None
-        or south_west_gps is None
-        or north_east_gps is None
-        or center_local is None
-        or width is None
-        or height is None
-        or width <= 0.0
-        or height <= 0.0
+        max_error > _STATIC_MAX_POINT_ERROR_M
+        or not (_STATIC_MIN_SCALE <= observed_scale <= _STATIC_MAX_SCALE)
     ):
         return None
 
-    diagonal_m = math.hypot(width, height)
-    if diagonal_m < _STATIC_MIN_DIAGONAL_M:
-        return None
-
-    latitude, longitude = origin
-    candidate: dict[str, Any] = {
-        "schema_version": 1,
-        "source": _STATIC_SOURCE,
-        "reference": {
-            "local_x": 0.0,
-            "local_y": 0.0,
-            "latitude": latitude,
-            "longitude": longitude,
-        },
-        # Missing map_north_offset is accepted only after the independent
-        # center/bounds checks prove that local X/Y is already East/North aligned.
-        "rotation_rad": 0.0,
-        "origin": _gps_dict(origin),
-        "center": _gps_dict(center_gps),
-        "bounds": {
-            "south_west": _gps_dict(south_west_gps),
-            "north_east": _gps_dict(north_east_gps),
-        },
-    }
-
-    center_x, center_y = center_local
-    local_south_west = (center_x - width / 2.0, center_y - height / 2.0)
-    local_north_east = (center_x + width / 2.0, center_y + height / 2.0)
-
-    center_error = _point_error_m(candidate, center_local, center_gps)
-    south_west_error = _point_error_m(
-        candidate, local_south_west, south_west_gps
+    candidate.update(
+        {
+            "status": "validated",
+            "anchor_policy": "static_map_primary",
+            "origin": _gps_dict(origin),
+            "center": _gps_dict(center_gps),
+            "bounds": {
+                "south_west": _gps_dict(sw_gps),
+                "north_east": _gps_dict(ne_gps),
+            },
+            "static_validation": {
+                "status": "validated",
+                "valid": True,
+                "tie_count": len(ties),
+                "origin_error_m": round(residuals[0], 3),
+                "center_error_m": round(residuals[1], 3),
+                "south_west_error_m": round(residuals[2], 3),
+                "north_east_error_m": round(residuals[3], 3),
+                "rms_error_m": round(
+                    math.sqrt(sum(value * value for value in residuals) / len(residuals)),
+                    3,
+                ),
+                "max_error_m": round(max_error, 3),
+                "limit_m": _STATIC_MAX_POINT_ERROR_M,
+                "rotation_deg": round(math.degrees(candidate["rotation_rad"]), 4),
+                "observed_scale": round(observed_scale, 6),
+                "scale_limits": [_STATIC_MIN_SCALE, _STATIC_MAX_SCALE],
+            },
+        }
     )
-    north_east_error = _point_error_m(
-        candidate, local_north_east, north_east_gps
-    )
-    if None in (center_error, south_west_error, north_east_error):
-        return None
-
-    gps_diagonal_m = _georeference._distance_m(  # noqa: SLF001
-        south_west_gps[0],
-        south_west_gps[1],
-        north_east_gps[0],
-        north_east_gps[1],
-    )
-    observed_scale = gps_diagonal_m / diagonal_m
-    max_error = max(center_error, south_west_error, north_east_error)
-    valid = (
-        max_error <= _STATIC_MAX_POINT_ERROR_M
-        and _STATIC_MIN_SCALE <= observed_scale <= _STATIC_MAX_SCALE
-    )
-    if not valid:
-        return None
-
-    candidate["status"] = "validated"
-    candidate["anchor_policy"] = "static_map_primary"
-    candidate["static_validation"] = {
-        "status": "validated",
-        "valid": True,
-        "rotation_assumption_deg": 0.0,
-        "center_error_m": round(center_error, 3),
-        "south_west_error_m": round(south_west_error, 3),
-        "north_east_error_m": round(north_east_error, 3),
-        "max_error_m": round(max_error, 3),
-        "limit_m": _STATIC_MAX_POINT_ERROR_M,
-        "local_diagonal_m": round(diagonal_m, 3),
-        "gps_diagonal_m": round(gps_diagonal_m, 3),
-        "observed_scale": round(observed_scale, 6),
-        "scale_limits": [_STATIC_MIN_SCALE, _STATIC_MAX_SCALE],
-    }
     return candidate
 
 
 def _from_geometry(geom: Any) -> dict[str, Any] | None:
     if _ORIGINAL_FROM_GEOMETRY is None:
         return None
-    existing = _ORIGINAL_FROM_GEOMETRY(geom)
-    if existing is not None:
-        return existing
-    return _static_map_origin_georeference(geom)
+    explicit = _ORIGINAL_FROM_GEOMETRY(geom)
+    return explicit if explicit is not None else _static_map_georeference(geom)
 
 
 def _learned_fit(map_geometry: dict[str, Any], result: Any) -> dict[str, Any] | None:
@@ -168,18 +164,12 @@ def _learned_fit(map_geometry: dict[str, Any], result: Any) -> dict[str, Any] | 
         fit = calibration.get("fit")
         if isinstance(fit, dict) and _georeference.georeference_is_valid(fit):
             return fit
-    if (
-        isinstance(result, dict)
-        and result.get("source") == "cloud_location_fit"
-        and _georeference.georeference_is_valid(result)
-    ):
+    if isinstance(result, dict) and result.get("source") == "cloud_location_fit" and _georeference.georeference_is_valid(result):
         return result
     return None
 
 
-def _static_primary_active(
-    map_geometry: dict[str, Any], location: Any, result: Any
-) -> dict[str, Any] | None:
+def _static_primary_active(map_geometry: dict[str, Any], location: Any, result: Any) -> dict[str, Any] | None:
     vendor = map_geometry.get("_vendor_georeference")
     if (
         not isinstance(vendor, dict)
@@ -188,19 +178,20 @@ def _static_primary_active(
     ):
         return None
 
-    revision = str(map_geometry.get("revision") or "")
     calibration = map_geometry.get("_georeference_calibration")
     calibration = calibration if isinstance(calibration, dict) else {}
     learned = _learned_fit(map_geometry, result)
-
     active = deepcopy(vendor)
-    active["schema_version"] = 2
-    active["source"] = _STATIC_SOURCE
-    active["status"] = "validated"
-    active["map_revision"] = revision
-    active["anchor_policy"] = "static_map_primary"
-    active["calibration"] = _georeference._calibration_summary(calibration)  # noqa: SLF001
-
+    active.update(
+        {
+            "schema_version": 2,
+            "source": _STATIC_SOURCE,
+            "status": "validated",
+            "map_revision": str(map_geometry.get("revision") or ""),
+            "anchor_policy": "static_map_primary",
+            "calibration": _georeference._calibration_summary(calibration),  # noqa: SLF001
+        }
+    )
     if isinstance(result, dict):
         for key in ("refinement_stage", "refinement_policy"):
             if result.get(key) is not None:
@@ -211,24 +202,14 @@ def _static_primary_active(
         location,
         limit_m=_georeference._LEARNED_VALIDATION_LIMIT_M,  # noqa: SLF001
     )
-    active["cloud_validation"] = dict(
-        (cloud_checked or {}).get("validation") or {}
-    )
+    active["cloud_validation"] = dict((cloud_checked or {}).get("validation") or {})
 
     learned_hint: dict[str, Any] = {"available": learned is not None}
     if learned is not None:
-        _, hint = _georeference._vendor_hint(  # noqa: SLF001
-            vendor, location, learned
-        )
+        _, hint = _georeference._vendor_hint(vendor, location, learned)  # noqa: SLF001
         if isinstance(hint, dict):
-            if hint.get("learned_position_difference_m") is not None:
-                learned_hint["position_difference_m"] = hint[
-                    "learned_position_difference_m"
-                ]
-            if hint.get("learned_rotation_difference_deg") is not None:
-                learned_hint["rotation_difference_deg"] = hint[
-                    "learned_rotation_difference_deg"
-                ]
+            learned_hint["position_difference_m"] = hint.get("learned_position_difference_m")
+            learned_hint["rotation_difference_deg"] = hint.get("learned_rotation_difference_deg")
     active["learned_hint"] = learned_hint
     return active
 
@@ -239,29 +220,48 @@ def _update(map_geometry: Any, location: Any) -> dict[str, Any] | None:
     result = _ORIGINAL_UPDATE(map_geometry, location)
     if not isinstance(map_geometry, dict):
         return result
+    map_geometry[_PROBE_MARKER] = True
     static_active = _static_primary_active(map_geometry, location, result)
-    if static_active is None:
-        return result
-    map_geometry["georeference"] = static_active
-    return static_active
+    if static_active is not None:
+        map_geometry["georeference"] = static_active
+        return static_active
+    return result
+
+
+async def _load_persistent_state(self: Any) -> None:
+    """Force one map-detail refresh for pre-beta12 cloud-only cached maps."""
+    if _ORIGINAL_LOAD is None:
+        return
+    await _ORIGINAL_LOAD(self)
+    geometry = getattr(self, "_map_geometry", None)
+    if not isinstance(geometry, dict) or geometry.get(_PROBE_MARKER):
+        return
+    georeference = geometry.get("georeference")
+    if (
+        isinstance(georeference, dict)
+        and georeference.get("source") == "cloud_location_fit"
+        and not isinstance(geometry.get("_vendor_georeference"), dict)
+    ):
+        # The old persisted geometry did not retain origin_gps/center_gps/bounds,
+        # so re-download map-detail exactly once and let the new parser inspect it.
+        self._map_cache_key = None  # noqa: SLF001
 
 
 def install_georeference_static_anchor_semantics() -> None:
-    """Install static-origin detection after the adaptive learned-fit policy."""
-    global _INSTALLED, _ORIGINAL_FROM_GEOMETRY, _ORIGINAL_UPDATE
+    """Install static-anchor detection after the adaptive learned-fit policy."""
+    global _INSTALLED, _ORIGINAL_FROM_GEOMETRY, _ORIGINAL_UPDATE, _ORIGINAL_LOAD
     if _INSTALLED:
         return
-
     from . import coordinator_semantics as _coordinator_semantics
 
     _ORIGINAL_FROM_GEOMETRY = _georeference.georeference_from_geometry
     _ORIGINAL_UPDATE = _georeference.update_georeference
+    _ORIGINAL_LOAD = _coordinator_semantics.NavimowCoordinator.async_load_persistent_state
     _georeference.georeference_from_geometry = _from_geometry
     _georeference.update_georeference = _update
     _coordinator_semantics.update_georeference = _update
+    _coordinator_semantics.NavimowCoordinator.async_load_persistent_state = _load_persistent_state
     _INSTALLED = True
 
 
-__all__ = [
-    "install_georeference_static_anchor_semantics",
-]
+__all__ = ["install_georeference_static_anchor_semantics"]

--- a/custom_components/navimower/georeference_static_anchor_semantics.py
+++ b/custom_components/navimower/georeference_static_anchor_semantics.py
@@ -1,0 +1,267 @@
+"""Prefer vendor static map anchors when map-detail proves a north-aligned frame.
+
+Some Navimow map generations (observed on i1 and X3 families) omit
+``map_north_offset`` but still expose a complete static WGS84 frame:
+
+* ``origin_gps`` ties local map coordinate (0, 0) to WGS84;
+* ``map_circle_center`` + ``center_gps`` provide an independent center check;
+* ``sw_gps`` / ``ne_gps`` plus ``map_width`` / ``map_height`` provide a long
+  baseline bounds check.
+
+For those maps the local X/Y axes are already East/North aligned. Accept the
+static origin only when all independent vendor fields agree within tight metre
+limits. Once accepted, that static map anchor is authoritative for translation
+and rotation for the map revision. Cloud-location fitting continues in the
+background as diagnostics/validation, but GPS drift may no longer move the map.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+from typing import Any, Callable
+
+from . import georeference as _georeference
+
+_STATIC_SOURCE = "vendor_map_origin"
+_STATIC_MAX_POINT_ERROR_M = 1.0
+_STATIC_MIN_DIAGONAL_M = 10.0
+_STATIC_MIN_SCALE = 0.97
+_STATIC_MAX_SCALE = 1.03
+
+_INSTALLED = False
+_ORIGINAL_FROM_GEOMETRY: Callable[[Any], dict[str, Any] | None] | None = None
+_ORIGINAL_UPDATE: Callable[[Any, Any], dict[str, Any] | None] | None = None
+
+
+def _gps_dict(pair: tuple[float, float]) -> dict[str, float]:
+    latitude, longitude = pair
+    return {"latitude": latitude, "longitude": longitude}
+
+
+def _point_error_m(
+    candidate: dict[str, Any],
+    local: tuple[float, float],
+    gps: tuple[float, float],
+) -> float | None:
+    projected = _georeference.local_xy_to_wgs84(candidate, local[0], local[1])
+    if projected is None:
+        return None
+    return _georeference._distance_m(  # noqa: SLF001 - same integration module.
+        projected[0], projected[1], gps[0], gps[1]
+    )
+
+
+def _static_map_origin_georeference(geom: Any) -> dict[str, Any] | None:
+    """Build a validated local-(0,0) vendor anchor for north-aligned maps."""
+    if not isinstance(geom, dict):
+        return None
+
+    # A real map_north_offset belongs to the established vendor_map_detail path.
+    if _georeference._float(geom.get("map_north_offset")) is not None:  # noqa: SLF001
+        return None
+
+    origin = _georeference._gps(geom.get("origin_gps"))  # noqa: SLF001
+    center_gps = _georeference._gps(geom.get("center_gps"))  # noqa: SLF001
+    south_west_gps = _georeference._gps(geom.get("sw_gps"))  # noqa: SLF001
+    north_east_gps = _georeference._gps(geom.get("ne_gps"))  # noqa: SLF001
+    center_local = _georeference._xy(geom.get("map_circle_center"))  # noqa: SLF001
+    width = _georeference._float(geom.get("map_width"))  # noqa: SLF001
+    height = _georeference._float(geom.get("map_height"))  # noqa: SLF001
+    if (
+        origin is None
+        or center_gps is None
+        or south_west_gps is None
+        or north_east_gps is None
+        or center_local is None
+        or width is None
+        or height is None
+        or width <= 0.0
+        or height <= 0.0
+    ):
+        return None
+
+    diagonal_m = math.hypot(width, height)
+    if diagonal_m < _STATIC_MIN_DIAGONAL_M:
+        return None
+
+    latitude, longitude = origin
+    candidate: dict[str, Any] = {
+        "schema_version": 1,
+        "source": _STATIC_SOURCE,
+        "reference": {
+            "local_x": 0.0,
+            "local_y": 0.0,
+            "latitude": latitude,
+            "longitude": longitude,
+        },
+        # Missing map_north_offset is accepted only after the independent
+        # center/bounds checks prove that local X/Y is already East/North aligned.
+        "rotation_rad": 0.0,
+        "origin": _gps_dict(origin),
+        "center": _gps_dict(center_gps),
+        "bounds": {
+            "south_west": _gps_dict(south_west_gps),
+            "north_east": _gps_dict(north_east_gps),
+        },
+    }
+
+    center_x, center_y = center_local
+    local_south_west = (center_x - width / 2.0, center_y - height / 2.0)
+    local_north_east = (center_x + width / 2.0, center_y + height / 2.0)
+
+    center_error = _point_error_m(candidate, center_local, center_gps)
+    south_west_error = _point_error_m(
+        candidate, local_south_west, south_west_gps
+    )
+    north_east_error = _point_error_m(
+        candidate, local_north_east, north_east_gps
+    )
+    if None in (center_error, south_west_error, north_east_error):
+        return None
+
+    gps_diagonal_m = _georeference._distance_m(  # noqa: SLF001
+        south_west_gps[0],
+        south_west_gps[1],
+        north_east_gps[0],
+        north_east_gps[1],
+    )
+    observed_scale = gps_diagonal_m / diagonal_m
+    max_error = max(center_error, south_west_error, north_east_error)
+    valid = (
+        max_error <= _STATIC_MAX_POINT_ERROR_M
+        and _STATIC_MIN_SCALE <= observed_scale <= _STATIC_MAX_SCALE
+    )
+    if not valid:
+        return None
+
+    candidate["status"] = "validated"
+    candidate["anchor_policy"] = "static_map_primary"
+    candidate["static_validation"] = {
+        "status": "validated",
+        "valid": True,
+        "rotation_assumption_deg": 0.0,
+        "center_error_m": round(center_error, 3),
+        "south_west_error_m": round(south_west_error, 3),
+        "north_east_error_m": round(north_east_error, 3),
+        "max_error_m": round(max_error, 3),
+        "limit_m": _STATIC_MAX_POINT_ERROR_M,
+        "local_diagonal_m": round(diagonal_m, 3),
+        "gps_diagonal_m": round(gps_diagonal_m, 3),
+        "observed_scale": round(observed_scale, 6),
+        "scale_limits": [_STATIC_MIN_SCALE, _STATIC_MAX_SCALE],
+    }
+    return candidate
+
+
+def _from_geometry(geom: Any) -> dict[str, Any] | None:
+    if _ORIGINAL_FROM_GEOMETRY is None:
+        return None
+    existing = _ORIGINAL_FROM_GEOMETRY(geom)
+    if existing is not None:
+        return existing
+    return _static_map_origin_georeference(geom)
+
+
+def _learned_fit(map_geometry: dict[str, Any], result: Any) -> dict[str, Any] | None:
+    calibration = map_geometry.get("_georeference_calibration")
+    if isinstance(calibration, dict):
+        fit = calibration.get("fit")
+        if isinstance(fit, dict) and _georeference.georeference_is_valid(fit):
+            return fit
+    if (
+        isinstance(result, dict)
+        and result.get("source") == "cloud_location_fit"
+        and _georeference.georeference_is_valid(result)
+    ):
+        return result
+    return None
+
+
+def _static_primary_active(
+    map_geometry: dict[str, Any], location: Any, result: Any
+) -> dict[str, Any] | None:
+    vendor = map_geometry.get("_vendor_georeference")
+    if (
+        not isinstance(vendor, dict)
+        or vendor.get("source") != _STATIC_SOURCE
+        or (vendor.get("static_validation") or {}).get("valid") is not True
+    ):
+        return None
+
+    revision = str(map_geometry.get("revision") or "")
+    calibration = map_geometry.get("_georeference_calibration")
+    calibration = calibration if isinstance(calibration, dict) else {}
+    learned = _learned_fit(map_geometry, result)
+
+    active = deepcopy(vendor)
+    active["schema_version"] = 2
+    active["source"] = _STATIC_SOURCE
+    active["status"] = "validated"
+    active["map_revision"] = revision
+    active["anchor_policy"] = "static_map_primary"
+    active["calibration"] = _georeference._calibration_summary(calibration)  # noqa: SLF001
+
+    if isinstance(result, dict):
+        for key in ("refinement_stage", "refinement_policy"):
+            if result.get(key) is not None:
+                active[key] = result[key]
+
+    cloud_checked = _georeference.validate_georeference(
+        vendor,
+        location,
+        limit_m=_georeference._LEARNED_VALIDATION_LIMIT_M,  # noqa: SLF001
+    )
+    active["cloud_validation"] = dict(
+        (cloud_checked or {}).get("validation") or {}
+    )
+
+    learned_hint: dict[str, Any] = {"available": learned is not None}
+    if learned is not None:
+        _, hint = _georeference._vendor_hint(  # noqa: SLF001
+            vendor, location, learned
+        )
+        if isinstance(hint, dict):
+            if hint.get("learned_position_difference_m") is not None:
+                learned_hint["position_difference_m"] = hint[
+                    "learned_position_difference_m"
+                ]
+            if hint.get("learned_rotation_difference_deg") is not None:
+                learned_hint["rotation_difference_deg"] = hint[
+                    "learned_rotation_difference_deg"
+                ]
+    active["learned_hint"] = learned_hint
+    return active
+
+
+def _update(map_geometry: Any, location: Any) -> dict[str, Any] | None:
+    if _ORIGINAL_UPDATE is None:
+        return None
+    result = _ORIGINAL_UPDATE(map_geometry, location)
+    if not isinstance(map_geometry, dict):
+        return result
+    static_active = _static_primary_active(map_geometry, location, result)
+    if static_active is None:
+        return result
+    map_geometry["georeference"] = static_active
+    return static_active
+
+
+def install_georeference_static_anchor_semantics() -> None:
+    """Install static-origin detection after the adaptive learned-fit policy."""
+    global _INSTALLED, _ORIGINAL_FROM_GEOMETRY, _ORIGINAL_UPDATE
+    if _INSTALLED:
+        return
+
+    from . import coordinator_semantics as _coordinator_semantics
+
+    _ORIGINAL_FROM_GEOMETRY = _georeference.georeference_from_geometry
+    _ORIGINAL_UPDATE = _georeference.update_georeference
+    _georeference.georeference_from_geometry = _from_geometry
+    _georeference.update_georeference = _update
+    _coordinator_semantics.update_georeference = _update
+    _INSTALLED = True
+
+
+__all__ = [
+    "install_georeference_static_anchor_semantics",
+]

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta11"
+  "version": "0.4.4-beta12"
 }

--- a/custom_components/navimower/runtime.py
+++ b/custom_components/navimower/runtime.py
@@ -11,6 +11,7 @@ from .capability_profile import install_capability_profile
 from .capability_semantics import install_capability_semantics
 from .georeference_diagnostics_semantics import install_georeference_diagnostics_semantics
 from .georeference_semantics import install_georeference_semantics
+from .georeference_static_anchor_semantics import install_georeference_static_anchor_semantics
 from .navigation_fallback import install_navigation_fallback
 from .notification_feed import install_notification_feed
 from .private_cloud_region import install_private_cloud_region
@@ -31,6 +32,7 @@ def install_runtime_extensions() -> None:
     install_capability_profile()
     install_capability_semantics()
     install_georeference_semantics()
+    install_georeference_static_anchor_semantics()
     install_georeference_diagnostics_semantics()
     install_navigation_fallback()
     install_notification_feed()

--- a/tests/test_v044_beta11.py
+++ b/tests/test_v044_beta11.py
@@ -15,9 +15,11 @@ def _source(name: str) -> str:
     return text
 
 
-def test_beta11_version_and_release_notes() -> None:
+def test_beta11_release_notes_and_minimum_version() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.4-beta11"
+    version = manifest["version"]
+    assert version.startswith("0.4.4-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 11
     notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta11.md").read_text(
         encoding="utf-8"
     )

--- a/tests/test_v044_beta12.py
+++ b/tests/test_v044_beta12.py
@@ -1,0 +1,99 @@
+"""Regression tests for Navimower 0.4.4-beta12 static map georeference anchors."""
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+from custom_components.navimower.georeference_static_anchor_semantics import (
+    _static_map_georeference,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+_I108 = {
+    "map_circle_center": [-11.4679, 1.4973],
+    "center_gps": [24.6380367, 58.3840637],
+    "origin_gps": [24.6382313, 58.3840523],
+    "ne_gps": [24.638504, 58.3843384],
+    "sw_gps": [24.6375675, 58.3837929],
+    "map_north_offset": None,
+    "map_width": 54.7474,
+    "map_height": 61.053,
+}
+
+_X390 = {
+    "map_circle_center": [-36.297842, -38.782747],
+    "center_gps": [26.861538, 59.180225],
+    "origin_gps": [26.862171, 59.180573],
+    "ne_gps": [26.862541, 59.180889],
+    "sw_gps": [26.860535, 59.179562],
+    "map_north_offset": None,
+    "map_width": 114.721649,
+    "map_height": 147.822342,
+}
+
+
+def test_beta12_minimum_version_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    version = manifest["version"]
+    assert version.startswith("0.4.4-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 12
+    notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta12.md").read_text(
+        encoding="utf-8"
+    )
+    for phrase in ("origin_gps", "static", "i108", "X390", "cloud"):
+        assert phrase in notes
+
+
+def test_i108_static_vendor_ties_form_a_high_quality_anchor() -> None:
+    result = _static_map_georeference(_I108)
+    assert result is not None
+    assert result["source"] == "vendor_map_static_fit"
+    assert result["status"] == "validated"
+    assert result["anchor_policy"] == "static_map_primary"
+    validation = result["static_validation"]
+    assert validation["tie_count"] == 4
+    assert validation["max_error_m"] < 0.25
+    assert 0.99 < validation["observed_scale"] < 1.01
+    assert abs(validation["rotation_deg"]) < 0.2
+
+
+def test_x390_static_vendor_ties_form_a_high_quality_anchor() -> None:
+    result = _static_map_georeference(_X390)
+    assert result is not None
+    assert result["source"] == "vendor_map_static_fit"
+    validation = result["static_validation"]
+    assert validation["max_error_m"] < 0.25
+    assert 0.99 < validation["observed_scale"] < 1.01
+    assert abs(validation["rotation_deg"]) < 0.2
+
+
+def test_explicit_h2_rotation_stays_on_existing_vendor_path() -> None:
+    geometry = {
+        **_I108,
+        "map_north_offset": 0.5977016091346741,
+    }
+    assert _static_map_georeference(geometry) is None
+
+
+def test_runtime_order_keeps_static_anchor_after_learned_fit_before_diagnostics() -> None:
+    runtime = (COMPONENT / "runtime.py").read_text(encoding="utf-8")
+    learned = runtime.index("install_georeference_semantics()")
+    static = runtime.index("install_georeference_static_anchor_semantics()")
+    diagnostics = runtime.index("install_georeference_diagnostics_semantics()")
+    assert learned < static < diagnostics
+
+
+def test_static_anchor_does_not_depend_on_live_cloud_gps_for_placement() -> None:
+    source = (COMPONENT / "georeference_static_anchor_semantics.py").read_text(
+        encoding="utf-8"
+    )
+    assert 'geom.get("origin_gps")' in source
+    assert 'geom.get("center_gps")' in source
+    assert 'geom.get("sw_gps")' in source
+    assert 'geom.get("ne_gps")' in source
+    assert 'active["cloud_validation"]' in source
+    assert "cloud_location_fit" in source
+    assert "vendor_map_static_fit" in source


### PR DESCRIPTION
## Summary
- detect i1/X3-style map-detail records that omit `map_north_offset` but expose `origin_gps`, `center_gps`, `sw_gps`, `ne_gps`, map center and dimensions
- fit a fixed-scale rigid transform from four static vendor map tie points and accept it only with tight residual/scale validation
- make that static transform primary for map placement while retaining cloud-location fitting as a secondary diagnostic/validation signal
- keep the existing explicit-angle H2 vendor path unchanged
- force one map-detail refresh for older persisted cloud-only caches so existing i108/X390 installations migrate automatically
- add beta12 regression coverage and release notes

## Evidence
The raw beta11 captures supplied for testing showed:
- i108 static four-tie fit: sub-0.25 m maximum residual, near-unit scale, near-zero rotation
- X390 static four-tie fit: sub-0.25 m maximum residual, near-unit scale, near-zero rotation
- private-cloud X/Y and official MQTT X/Y matched at the dock, ruling out a local-frame offset as the source of the several-metre i108 OSM translation

## Release
Bumps Navimower to `0.4.4-beta12`.