### PR TITLE
Apply refined X3 RTK bias correction

### DIFF
--- a/.github/release-notes/0.4.4-beta14.md
+++ b/.github/release-notes/0.4.4-beta14.md
@@ -1,0 +1,15 @@
+title: Navimower 0.4.4-beta14
+
+## X3 RTK bias correction
+
+- Apply the refined X3 `nrtk_lrtk_bias` horizontal correction on top of the beta13 `RTK_anchor` translation when the vendor reports a confirmed calibration, a refined bias, and low bias standard deviation.
+- Interpret the X3 vendor bias in the same swapped map-plane order observed in the LRTK pile metadata: raw bias[0] is north and raw bias[1] is east. The captured X390 sample therefore applies the full correction of **2.081 m west + 3.437 m north = 4.02 m**, approximately toward 11 o'clock.
+- Keep the static vendor four-tie fit authoritative for rotation, so the change moves the map without altering its angle or scale.
+- Fall back to the beta13 plain `RTK_anchor` translation when the calibration flag is not confirmed, the bias is not refined, the standard deviation is too large, or the bias metadata is malformed.
+- Force one map-detail refresh for persisted beta13 X3 caches so an existing installation can adopt the active bias correction without a manual georeference relearn.
+
+## Compatibility
+
+- i1 remains on the beta12 `vendor_map_static_fit` path.
+- H2 remains on the established explicit `map_north_offset` vendor-anchor path.
+- Cloud learned georeference remains an independent validation signal rather than the X3 absolute translation source.

--- a/custom_components/navimower/georeference_x3_bias_semantics.py
+++ b/custom_components/navimower/georeference_x3_bias_semantics.py
@@ -6,7 +6,6 @@ import math
 import re
 from typing import Any, Callable
 
-from . import coordinator_semantics as _coordinator_semantics
 from . import georeference as _georeference
 from . import georeference_static_anchor_semantics as _static
 
@@ -225,6 +224,8 @@ def install_georeference_x3_bias_semantics() -> None:
     global _INSTALLED, _ORIGINAL_APPLY, _ORIGINAL_UPDATE, _ORIGINAL_LOAD
     if _INSTALLED:
         return
+
+    from . import coordinator_semantics as _coordinator_semantics
 
     _ORIGINAL_APPLY = _static._apply_x3_rtk_anchor  # noqa: SLF001
     _ORIGINAL_UPDATE = _georeference.update_georeference

--- a/custom_components/navimower/georeference_x3_bias_semantics.py
+++ b/custom_components/navimower/georeference_x3_bias_semantics.py
@@ -1,0 +1,240 @@
+"""Apply validated X3 NRTK-to-LRTK bias to RTK-anchored map references."""
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+import re
+from typing import Any, Callable
+
+from . import coordinator_semantics as _coordinator_semantics
+from . import georeference as _georeference
+from . import georeference_static_anchor_semantics as _static
+
+_X3_RTK_SOURCE = "x3_rtk_anchor"
+_PROBE_MARKER = "x3_rtk_bias_v1"
+_MAX_BIAS_STD_M = 0.25
+_MAX_HORIZONTAL_BIAS_M = 25.0
+_FLOAT_RE = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
+
+_INSTALLED = False
+_ORIGINAL_APPLY: Callable[[dict[str, Any], dict[str, Any], tuple[float, float]], dict[str, Any]] | None = None
+_ORIGINAL_UPDATE: Callable[[Any, Any], dict[str, Any] | None] | None = None
+_ORIGINAL_LOAD: Callable[..., Any] | None = None
+
+
+def _three_floats(raw: str, key: str) -> list[float] | None:
+    match = re.search(
+        rf"{re.escape(key)}:\s*({_FLOAT_RE})\s+({_FLOAT_RE})\s+({_FLOAT_RE})",
+        raw,
+    )
+    if match is None:
+        return None
+    values = [float(match.group(index)) for index in range(1, 4)]
+    return values if all(math.isfinite(value) for value in values) else None
+
+
+def _x3_bias_metadata(geom: dict[str, Any]) -> dict[str, Any] | None:
+    """Parse X3 NRTK/LRTK calibration metadata and evaluate its quality."""
+    rtk = geom.get("rtk")
+    raw = rtk.get("bias") if isinstance(rtk, dict) else None
+    if not isinstance(raw, str):
+        return None
+
+    flag_match = re.search(
+        r"nrtk_lrtk_calibration_flag:\s*(true|false|1|0)",
+        raw,
+        flags=re.IGNORECASE,
+    )
+    refined_match = re.search(r"nrtk_lrtk_bias_refined:\s*(\d+)", raw)
+    bias = _three_floats(raw, "nrtk_lrtk_bias")
+    std = _three_floats(raw, "nrtk_lrtk_bias_std")
+
+    calibration_flag = (
+        flag_match is not None
+        and flag_match.group(1).lower() in {"true", "1"}
+    )
+    refined = refined_match is not None and refined_match.group(1) == "1"
+    horizontal_m = math.hypot(bias[0], bias[1]) if bias is not None else None
+    std_ok = (
+        std is not None
+        and all(0.0 <= value <= _MAX_BIAS_STD_M for value in std)
+    )
+    magnitude_ok = horizontal_m is not None and horizontal_m <= _MAX_HORIZONTAL_BIAS_M
+    usable = bool(calibration_flag and refined and bias is not None and std_ok and magnitude_ok)
+
+    reasons: list[str] = []
+    if not calibration_flag:
+        reasons.append("calibration_not_confirmed")
+    if not refined:
+        reasons.append("bias_not_refined")
+    if bias is None:
+        reasons.append("bias_missing_or_invalid")
+    if std is None:
+        reasons.append("bias_std_missing_or_invalid")
+    elif not std_ok:
+        reasons.append("bias_std_too_large")
+    if horizontal_m is not None and not magnitude_ok:
+        reasons.append("horizontal_bias_too_large")
+
+    return {
+        "calibration_flag": calibration_flag,
+        "refined": refined,
+        "nrtk_lrtk_bias": bias,
+        "nrtk_lrtk_bias_std": std,
+        "horizontal_m": round(horizontal_m, 3) if horizontal_m is not None else None,
+        "std_limit_m": _MAX_BIAS_STD_M,
+        "horizontal_limit_m": _MAX_HORIZONTAL_BIAS_M,
+        "usable": usable,
+        "reasons": reasons,
+    }
+
+
+def _difference(
+    origin: tuple[float, float], target: tuple[float, float]
+) -> dict[str, float] | None:
+    offset = _georeference.wgs84_offset_m(origin[0], origin[1], target[0], target[1])
+    if offset is None:
+        return None
+    east_m, north_m = offset
+    return {
+        "east_m": round(east_m, 3),
+        "north_m": round(north_m, 3),
+        "distance_m": round(math.hypot(east_m, north_m), 3),
+        "bearing_deg_from_north": round(
+            (math.degrees(math.atan2(east_m, north_m)) + 360.0) % 360.0,
+            2,
+        ),
+    }
+
+
+def _apply_x3_rtk_bias(
+    geom: dict[str, Any], candidate: dict[str, Any], origin: tuple[float, float]
+) -> dict[str, Any]:
+    """Apply the refined vendor NRTK/LRTK horizontal bias to an X3 RTK anchor.
+
+    X390 field data shows the vendor bias plane uses the same Y/X ordering seen
+    in the LRTK pile record. Therefore raw bias[0] is interpreted as north and
+    raw bias[1] as east. The correction is applied in full, in metres, on top of
+    ``RTK_anchor`` while the static vendor tie fit continues to own rotation.
+    """
+    if _ORIGINAL_APPLY is None:
+        return candidate
+    result = _ORIGINAL_APPLY(geom, candidate, origin)
+    if result.get("source") != _X3_RTK_SOURCE:
+        return result
+
+    metadata = _x3_bias_metadata(geom)
+    validation = result.get("rtk_validation")
+    if not isinstance(validation, dict):
+        return result
+
+    updated = deepcopy(result)
+    updated_validation = updated["rtk_validation"]
+    if metadata is None:
+        updated_validation["bias_correction"] = {
+            "applied": False,
+            "reason": "bias_metadata_missing",
+        }
+        return updated
+
+    updated_validation["bias"] = metadata
+    if metadata.get("usable") is not True:
+        updated_validation["bias_correction"] = {
+            "applied": False,
+            "reason": "bias_quality_guard",
+            "reasons": list(metadata.get("reasons") or []),
+        }
+        return updated
+
+    bias = metadata.get("nrtk_lrtk_bias")
+    if not isinstance(bias, list) or len(bias) != 3:
+        return updated
+
+    correction_north_m = float(bias[0])
+    correction_east_m = float(bias[1])
+    corrected = _georeference.offset_wgs84(
+        updated["rtk_anchor"]["latitude"],
+        updated["rtk_anchor"]["longitude"],
+        correction_east_m,
+        correction_north_m,
+    )
+    if corrected is None:
+        updated_validation["bias_correction"] = {
+            "applied": False,
+            "reason": "wgs84_offset_failed",
+        }
+        return updated
+
+    corrected_latitude, corrected_longitude = corrected
+    updated["anchor_policy"] = "x3_rtk_anchor_bias_primary"
+    updated["reference"] = {
+        "local_x": 0.0,
+        "local_y": 0.0,
+        "latitude": corrected_latitude,
+        "longitude": corrected_longitude,
+    }
+    updated_validation["translation_source"] = "RTK_anchor+nrtk_lrtk_bias"
+    updated_validation["bias_correction"] = {
+        "applied": True,
+        "axis_mapping": "east=bias[1], north=bias[0]",
+        "east_m": round(correction_east_m, 3),
+        "north_m": round(correction_north_m, 3),
+        "distance_m": round(math.hypot(correction_east_m, correction_north_m), 3),
+        "bearing_deg_from_north": round(
+            (
+                math.degrees(
+                    math.atan2(correction_east_m, correction_north_m)
+                )
+                + 360.0
+            )
+            % 360.0,
+            2,
+        ),
+    }
+    active_difference = _difference(origin, corrected)
+    if active_difference is not None:
+        updated_validation["active_reference_difference"] = active_difference
+    return updated
+
+
+def _update(map_geometry: Any, location: Any) -> dict[str, Any] | None:
+    if _ORIGINAL_UPDATE is None:
+        return None
+    result = _ORIGINAL_UPDATE(map_geometry, location)
+    if isinstance(map_geometry, dict):
+        map_geometry[_PROBE_MARKER] = True
+    return result
+
+
+async def _load_persistent_state(self: Any) -> None:
+    """Refresh beta13 X3 caches once so the active reference gains the bias."""
+    if _ORIGINAL_LOAD is None:
+        return
+    await _ORIGINAL_LOAD(self)
+    geometry = getattr(self, "_map_geometry", None)
+    if not isinstance(geometry, dict) or geometry.get(_PROBE_MARKER):
+        return
+    georeference = geometry.get("georeference")
+    source = georeference.get("source") if isinstance(georeference, dict) else None
+    if source == _X3_RTK_SOURCE:
+        self._map_cache_key = None  # noqa: SLF001
+
+
+def install_georeference_x3_bias_semantics() -> None:
+    """Install X3 bias correction after RTK anchoring and before diagnostics."""
+    global _INSTALLED, _ORIGINAL_APPLY, _ORIGINAL_UPDATE, _ORIGINAL_LOAD
+    if _INSTALLED:
+        return
+
+    _ORIGINAL_APPLY = _static._apply_x3_rtk_anchor  # noqa: SLF001
+    _ORIGINAL_UPDATE = _georeference.update_georeference
+    _ORIGINAL_LOAD = _coordinator_semantics.NavimowCoordinator.async_load_persistent_state
+
+    _static._apply_x3_rtk_anchor = _apply_x3_rtk_bias  # noqa: SLF001
+    _georeference.update_georeference = _update
+    _coordinator_semantics.update_georeference = _update
+    _coordinator_semantics.NavimowCoordinator.async_load_persistent_state = _load_persistent_state
+    _INSTALLED = True
+
+
+__all__ = ["install_georeference_x3_bias_semantics"]

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta13"
+  "version": "0.4.4-beta14"
 }

--- a/custom_components/navimower/runtime.py
+++ b/custom_components/navimower/runtime.py
@@ -12,6 +12,7 @@ from .capability_semantics import install_capability_semantics
 from .georeference_diagnostics_semantics import install_georeference_diagnostics_semantics
 from .georeference_semantics import install_georeference_semantics
 from .georeference_static_anchor_semantics import install_georeference_static_anchor_semantics
+from .georeference_x3_bias_semantics import install_georeference_x3_bias_semantics
 from .navigation_fallback import install_navigation_fallback
 from .notification_feed import install_notification_feed
 from .private_cloud_region import install_private_cloud_region
@@ -33,6 +34,7 @@ def install_runtime_extensions() -> None:
     install_capability_semantics()
     install_georeference_semantics()
     install_georeference_static_anchor_semantics()
+    install_georeference_x3_bias_semantics()
     install_georeference_diagnostics_semantics()
     install_navigation_fallback()
     install_notification_feed()

--- a/tests/test_v044_beta13.py
+++ b/tests/test_v044_beta13.py
@@ -42,7 +42,9 @@ _I108 = {
 
 def test_beta13_version_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.4-beta13"
+    version = manifest["version"]
+    assert version.startswith("0.4.4-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 13
     notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta13.md").read_text(
         encoding="utf-8"
     )

--- a/tests/test_v044_beta14.py
+++ b/tests/test_v044_beta14.py
@@ -1,0 +1,138 @@
+"""Regression tests for Navimower 0.4.4-beta14 X3 RTK bias correction."""
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+import math
+from pathlib import Path
+
+from custom_components.navimower import georeference as geo
+from custom_components.navimower import georeference_static_anchor_semantics as static_sem
+from custom_components.navimower import georeference_x3_bias_semantics as bias_sem
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+_X390 = {
+    "map_circle_center": [-36.297842, -38.782747],
+    "center_gps": [26.861538, 59.180225],
+    "origin_gps": [26.862171, 59.180573],
+    "ne_gps": [26.862541, 59.180889],
+    "sw_gps": [26.860535, 59.179562],
+    "map_north_offset": None,
+    "map_width": 114.721649,
+    "map_height": 147.822342,
+    "rtk": {
+        "anchor": "RTK_mode: 1\nRTK_anchor: 59.18058352 26.86226353 100.49851990",
+        "bias": "nrtk_lrtk_calibration_flag: true\nnrtk_lrtk_bias: 3.437 -2.081 -8.847\nnrtk_lrtk_bias_std: 0.015 0.007 0.019\nnrtk_lrtk_bias_refined: 1",
+        "pile": "LRTK -0.31932 -1.01919 -3.14535 2.017",
+    },
+}
+
+
+def _apply(geometry: dict, monkeypatch) -> dict:
+    baseline = static_sem._static_map_georeference(geometry)
+    assert baseline is not None
+    monkeypatch.setattr(bias_sem, "_ORIGINAL_APPLY", static_sem._apply_x3_rtk_anchor)
+    result = bias_sem._apply_x3_rtk_bias(
+        geometry,
+        baseline,
+        (59.180573, 26.862171),
+    )
+    assert result is not None
+    return result
+
+
+def test_beta14_version_release_notes_and_runtime_order() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.4-beta14"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta14.md").read_text(
+        encoding="utf-8"
+    )
+    for phrase in (
+        "nrtk_lrtk_bias",
+        "4.02 m",
+        "RTK_anchor",
+        "X3",
+        "i1",
+        "H2",
+    ):
+        assert phrase in notes
+
+    runtime = (COMPONENT / "runtime.py").read_text(encoding="utf-8")
+    static_index = runtime.index("install_georeference_static_anchor_semantics()")
+    bias_index = runtime.index("install_georeference_x3_bias_semantics()")
+    diagnostics_index = runtime.index("install_georeference_diagnostics_semantics()")
+    assert static_index < bias_index < diagnostics_index
+
+
+def test_x390_applies_full_refined_bias_in_swapped_map_axis_order(monkeypatch) -> None:
+    result = _apply(_X390, monkeypatch)
+    assert result["source"] == "x3_rtk_anchor"
+    assert result["anchor_policy"] == "x3_rtk_anchor_bias_primary"
+
+    anchor = result["rtk_anchor"]
+    reference = result["reference"]
+    offset = geo.wgs84_offset_m(
+        anchor["latitude"],
+        anchor["longitude"],
+        reference["latitude"],
+        reference["longitude"],
+    )
+    assert offset is not None
+    east_m, north_m = offset
+    assert math.isclose(east_m, -2.081, abs_tol=0.01)
+    assert math.isclose(north_m, 3.437, abs_tol=0.01)
+    assert math.isclose(math.hypot(east_m, north_m), 4.018, abs_tol=0.02)
+
+    validation = result["rtk_validation"]
+    assert validation["translation_source"] == "RTK_anchor+nrtk_lrtk_bias"
+    correction = validation["bias_correction"]
+    assert correction["applied"] is True
+    assert correction["axis_mapping"] == "east=bias[1], north=bias[0]"
+    assert correction["distance_m"] == 4.018
+    assert 328.0 < correction["bearing_deg_from_north"] < 330.0
+    assert validation["bias"]["calibration_flag"] is True
+    assert validation["bias"]["refined"] is True
+    assert validation["bias"]["usable"] is True
+
+    # Translation changes only; beta13's static tie rotation remains intact.
+    assert abs(result["static_validation"]["rotation_deg"]) < 0.2
+    assert 0.99 < result["static_validation"]["observed_scale"] < 1.01
+
+
+def test_unqualified_bias_falls_back_to_plain_rtk_anchor(monkeypatch) -> None:
+    geometry = deepcopy(_X390)
+    geometry["rtk"]["bias"] = geometry["rtk"]["bias"].replace(
+        "nrtk_lrtk_bias_refined: 1",
+        "nrtk_lrtk_bias_refined: 0",
+    )
+    result = _apply(geometry, monkeypatch)
+    assert result["anchor_policy"] == "x3_rtk_anchor_primary"
+    assert math.isclose(result["reference"]["latitude"], 59.18058352)
+    assert math.isclose(result["reference"]["longitude"], 26.86226353)
+    correction = result["rtk_validation"]["bias_correction"]
+    assert correction["applied"] is False
+    assert "bias_not_refined" in correction["reasons"]
+
+
+def test_bias_std_guard_rejects_uncertain_calibration(monkeypatch) -> None:
+    geometry = deepcopy(_X390)
+    geometry["rtk"]["bias"] = geometry["rtk"]["bias"].replace(
+        "nrtk_lrtk_bias_std: 0.015 0.007 0.019",
+        "nrtk_lrtk_bias_std: 0.015 0.700 0.019",
+    )
+    result = _apply(geometry, monkeypatch)
+    assert result["anchor_policy"] == "x3_rtk_anchor_primary"
+    correction = result["rtk_validation"]["bias_correction"]
+    assert correction["applied"] is False
+    assert "bias_std_too_large" in correction["reasons"]
+
+
+def test_beta14_forces_one_refresh_of_beta13_x3_cache() -> None:
+    source = (COMPONENT / "georeference_x3_bias_semantics.py").read_text(
+        encoding="utf-8"
+    )
+    assert '_PROBE_MARKER = "x3_rtk_bias_v1"' in source
+    assert 'if source == _X3_RTK_SOURCE:' in source
+    assert "self._map_cache_key = None" in source


### PR DESCRIPTION
## Summary
- apply validated X3 `nrtk_lrtk_bias` on top of the beta13 `RTK_anchor` translation
- interpret the observed X3 vendor bias plane as raw `[north, east, vertical]`, matching the swapped Y/X ordering independently seen in the LRTK pile metadata
- for the captured X390 map, apply the full correction of 2.081 m west + 3.437 m north = 4.02 m toward roughly 11 o'clock
- require confirmed calibration, refined bias, low standard deviation and bounded horizontal magnitude; otherwise fall back to the beta13 plain RTK anchor
- preserve static tie rotation/scale, i1 static anchors, H2 explicit-angle anchors and cloud learned validation
- force a one-time map-detail refresh for persisted beta13 X3 caches
- add beta14 diagnostics, regression coverage and release metadata

Field validation target: compare the corrected X3 map against the new Maa- ja Ruumiamet orthophoto underlay.