### PR TITLE
Add H2 and i1 absolute reference diagnostics

### DIFF
--- a/.github/release-notes/0.4.4-beta15.md
+++ b/.github/release-notes/0.4.4-beta15.md
@@ -1,0 +1,13 @@
+title: Navimower 0.4.4-beta15
+
+## Georeference reference diagnostics
+
+- Add read-only absolute-reference diagnostics for the remaining H2 and i1 orthophoto alignment investigation.
+- Compare the active transform against every cached vendor reference at the same local map point: `origin_gps`, `center_gps`, south-west/north-east bounds, explicit `map_north_offset` transform, `RTK_anchor`, persisted cloud learned fit, current private-cloud GPS, and the docked station anchor when available.
+- Report each disagreement only as `candidate_minus_active` East/North metre vectors, distance and bearing. Raw WGS84 coordinates are deliberately not added to Home Assistant Download diagnostics.
+- Add a compact vendor-metadata inventory showing whether RTK anchor/bias/pile, explicit north offset, map GPS ties, learned fit and station metadata are present.
+
+## Field test
+
+- This beta intentionally does **not** change H2, i1 or X3 map placement. Update first, then collect fresh Home Assistant Download diagnostics for H2 and i1 while the Maa- ja Ruumiamet orthophoto comparison is available.
+- X3 keeps the beta14 `RTK_anchor + nrtk_lrtk_bias` correction unchanged.

--- a/custom_components/navimower/georeference_diagnostics_semantics.py
+++ b/custom_components/navimower/georeference_diagnostics_semantics.py
@@ -19,7 +19,8 @@ def _parse(self: NavimowCoordinator, raw: dict[str, Any]) -> dict[str, Any]:
         decorated = deepcopy(georeference)
         decorated["local_frame_check"] = local_frame_diagnostics(self, snapshot)
         geometry = getattr(self, "_map_geometry", None)
-        location = raw.get("location") if isinstance(raw, dict) else None
+        snapshot_raw = snapshot.get("raw") if isinstance(snapshot.get("raw"), dict) else {}
+        location = snapshot_raw.get("location") if isinstance(snapshot_raw.get("location"), dict) else None
         decorated["reference_candidates"] = reference_candidate_diagnostics(
             geometry,
             georeference,

--- a/custom_components/navimower/georeference_diagnostics_semantics.py
+++ b/custom_components/navimower/georeference_diagnostics_semantics.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from typing import Any
 
 from .coordinator_semantics import NavimowCoordinator
+from .georeference_reference_diagnostics import reference_candidate_diagnostics
 from .georeference_tools import local_frame_diagnostics
 
 _INSTALLED = False
@@ -17,6 +18,14 @@ def _parse(self: NavimowCoordinator, raw: dict[str, Any]) -> dict[str, Any]:
     if isinstance(georeference, dict):
         decorated = deepcopy(georeference)
         decorated["local_frame_check"] = local_frame_diagnostics(self, snapshot)
+        geometry = getattr(self, "_map_geometry", None)
+        location = raw.get("location") if isinstance(raw, dict) else None
+        decorated["reference_candidates"] = reference_candidate_diagnostics(
+            geometry,
+            georeference,
+            location,
+            docked=bool(snapshot.get("docked")),
+        )
         snapshot["georeference"] = decorated
         map_data = snapshot.get("map")
         if isinstance(map_data, dict):

--- a/custom_components/navimower/georeference_reference_diagnostics.py
+++ b/custom_components/navimower/georeference_reference_diagnostics.py
@@ -104,41 +104,47 @@ def reference_candidate_diagnostics(
         sw_local = (center_local[0] - width / 2.0, center_local[1] - height / 2.0)
         ne_local = (center_local[0] + width / 2.0, center_local[1] + height / 2.0)
 
+    origin_gps = geo._gps(geometry.get("origin_gps"))  # noqa: SLF001
+    center_gps = geo._gps(geometry.get("center_gps"))  # noqa: SLF001
+    sw_gps = geo._gps(geometry.get("sw_gps"))  # noqa: SLF001
+    ne_gps = geo._gps(geometry.get("ne_gps"))  # noqa: SLF001
+    rtk_anchor = _rtk_anchor(geometry)
+
     candidates: dict[str, Any] = {}
     _add_candidate(
         candidates,
-        "vendor_origin_gps",
+        "vendor_origin_gps_at_local_origin_hypothesis",
         _active_point(active, origin_local),
-        geo._gps(geometry.get("origin_gps")),  # noqa: SLF001
-        meaning="vendor origin_gps at local map (0,0)",
+        origin_gps,
+        meaning="hypothesis check: vendor origin_gps interpreted as local map (0,0)",
     )
     _add_candidate(
         candidates,
         "vendor_center_gps",
         _active_point(active, center_local),
-        geo._gps(geometry.get("center_gps")),  # noqa: SLF001
+        center_gps,
         meaning="vendor center_gps at map_circle_center",
     )
     _add_candidate(
         candidates,
         "vendor_south_west_gps",
         _active_point(active, sw_local),
-        geo._gps(geometry.get("sw_gps")),  # noqa: SLF001
+        sw_gps,
         meaning="vendor sw_gps at derived local south-west corner",
     )
     _add_candidate(
         candidates,
         "vendor_north_east_gps",
         _active_point(active, ne_local),
-        geo._gps(geometry.get("ne_gps")),  # noqa: SLF001
+        ne_gps,
         meaning="vendor ne_gps at derived local north-east corner",
     )
     _add_candidate(
         candidates,
-        "rtk_anchor",
+        "rtk_anchor_at_local_origin_hypothesis",
         _active_point(active, origin_local),
-        _rtk_anchor(geometry),
-        meaning="RTK_anchor interpreted as local map (0,0)",
+        rtk_anchor,
+        meaning="hypothesis check: RTK_anchor interpreted as local map (0,0)",
     )
 
     explicit = geo.georeference_from_geometry(geometry)
@@ -191,16 +197,24 @@ def reference_candidate_diagnostics(
                 meaning="live docked GPS treated as the map station local point",
             )
 
+    relations: dict[str, Any] = {}
+    rtk_minus_origin = _vector(origin_gps, rtk_anchor)
+    if rtk_minus_origin is not None:
+        relations["rtk_anchor_minus_origin_gps"] = rtk_minus_origin
+    center_minus_origin = _vector(origin_gps, center_gps)
+    if center_minus_origin is not None:
+        relations["center_gps_minus_origin_gps"] = center_minus_origin
+
     rtk = geometry.get("rtk") if isinstance(geometry.get("rtk"), dict) else {}
     raw_bias = rtk.get("bias") if isinstance(rtk, dict) else None
     raw_pile = rtk.get("pile") if isinstance(rtk, dict) else None
     metadata = {
         "map_north_offset_present": geo._float(geometry.get("map_north_offset")) is not None,  # noqa: SLF001
-        "origin_gps_present": geo._gps(geometry.get("origin_gps")) is not None,  # noqa: SLF001
-        "center_gps_present": geo._gps(geometry.get("center_gps")) is not None,  # noqa: SLF001
-        "south_west_gps_present": geo._gps(geometry.get("sw_gps")) is not None,  # noqa: SLF001
-        "north_east_gps_present": geo._gps(geometry.get("ne_gps")) is not None,  # noqa: SLF001
-        "rtk_anchor_present": _rtk_anchor(geometry) is not None,
+        "origin_gps_present": origin_gps is not None,
+        "center_gps_present": center_gps is not None,
+        "south_west_gps_present": sw_gps is not None,
+        "north_east_gps_present": ne_gps is not None,
+        "rtk_anchor_present": rtk_anchor is not None,
         "rtk_bias_present": isinstance(raw_bias, str) and "nrtk_lrtk_bias" in raw_bias,
         "rtk_pile_present": isinstance(raw_pile, str) and "LRTK" in raw_pile,
         "learned_fit_present": learned is not None,
@@ -217,6 +231,7 @@ def reference_candidate_diagnostics(
         "active_rotation_deg": round(math.degrees(rotation), 4) if rotation is not None else None,
         "vendor_metadata": metadata,
         "candidate_offsets": candidates,
+        "absolute_reference_relations": relations,
     }
 
 

--- a/custom_components/navimower/georeference_reference_diagnostics.py
+++ b/custom_components/navimower/georeference_reference_diagnostics.py
@@ -1,0 +1,223 @@
+"""Read-only absolute-reference diagnostics for map georeferencing."""
+from __future__ import annotations
+
+import math
+import re
+from typing import Any
+
+from . import georeference as geo
+
+_FLOAT_RE = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
+
+
+def _vector(
+    source: tuple[float, float] | None,
+    target: tuple[float, float] | None,
+) -> dict[str, float] | None:
+    """Return target-minus-source East/North metres and bearing."""
+    if source is None or target is None:
+        return None
+    offset = geo.wgs84_offset_m(source[0], source[1], target[0], target[1])
+    if offset is None:
+        return None
+    east_m, north_m = offset
+    return {
+        "east_m": round(east_m, 3),
+        "north_m": round(north_m, 3),
+        "distance_m": round(math.hypot(east_m, north_m), 3),
+        "bearing_deg_from_north": round(
+            (math.degrees(math.atan2(east_m, north_m)) + 360.0) % 360.0,
+            2,
+        ),
+    }
+
+
+def _active_point(active: Any, local: tuple[float, float] | None) -> tuple[float, float] | None:
+    if not isinstance(active, dict) or local is None:
+        return None
+    return geo.local_xy_to_wgs84(active, local[0], local[1])
+
+
+def _rtk_anchor(geometry: dict[str, Any]) -> tuple[float, float] | None:
+    rtk = geometry.get("rtk")
+    raw = rtk.get("anchor") if isinstance(rtk, dict) else None
+    if not isinstance(raw, str):
+        return None
+    match = re.search(rf"RTK_anchor:\s*({_FLOAT_RE})\s+({_FLOAT_RE})", raw)
+    if match is None:
+        return None
+    latitude = geo._float(match.group(1))  # noqa: SLF001
+    longitude = geo._float(match.group(2))  # noqa: SLF001
+    if latitude is None or longitude is None:
+        return None
+    if not (-90.0 <= latitude <= 90.0 and -180.0 <= longitude <= 180.0):
+        return None
+    return latitude, longitude
+
+
+def _learned_fit(geometry: dict[str, Any]) -> dict[str, Any] | None:
+    calibration = geometry.get("_georeference_calibration")
+    if not isinstance(calibration, dict):
+        return None
+    fit = calibration.get("fit")
+    return fit if isinstance(fit, dict) and geo.georeference_is_valid(fit) else None
+
+
+def _add_candidate(
+    candidates: dict[str, Any],
+    name: str,
+    active_point: tuple[float, float] | None,
+    candidate_point: tuple[float, float] | None,
+    *,
+    meaning: str,
+) -> None:
+    delta = _vector(active_point, candidate_point)
+    if delta is not None:
+        candidates[name] = {
+            "meaning": meaning,
+            "candidate_minus_active": delta,
+        }
+
+
+def reference_candidate_diagnostics(
+    geometry: Any,
+    active: Any,
+    location: Any = None,
+    *,
+    docked: bool = False,
+) -> dict[str, Any]:
+    """Compare all cached absolute map references without changing the map.
+
+    All exported values are relative metre vectors. Raw WGS84 coordinates are
+    deliberately omitted so Home Assistant Download diagnostics stays safe to
+    share while still exposing absolute-frame disagreements.
+    """
+    if not isinstance(geometry, dict) or not isinstance(active, dict):
+        return {"read_only": True, "available": False}
+
+    center_local = geo._xy(geometry.get("map_circle_center"))  # noqa: SLF001
+    origin_local = (0.0, 0.0)
+    width = geo._float(geometry.get("map_width"))  # noqa: SLF001
+    height = geo._float(geometry.get("map_height"))  # noqa: SLF001
+    sw_local = ne_local = None
+    if center_local is not None and width is not None and height is not None:
+        sw_local = (center_local[0] - width / 2.0, center_local[1] - height / 2.0)
+        ne_local = (center_local[0] + width / 2.0, center_local[1] + height / 2.0)
+
+    candidates: dict[str, Any] = {}
+    _add_candidate(
+        candidates,
+        "vendor_origin_gps",
+        _active_point(active, origin_local),
+        geo._gps(geometry.get("origin_gps")),  # noqa: SLF001
+        meaning="vendor origin_gps at local map (0,0)",
+    )
+    _add_candidate(
+        candidates,
+        "vendor_center_gps",
+        _active_point(active, center_local),
+        geo._gps(geometry.get("center_gps")),  # noqa: SLF001
+        meaning="vendor center_gps at map_circle_center",
+    )
+    _add_candidate(
+        candidates,
+        "vendor_south_west_gps",
+        _active_point(active, sw_local),
+        geo._gps(geometry.get("sw_gps")),  # noqa: SLF001
+        meaning="vendor sw_gps at derived local south-west corner",
+    )
+    _add_candidate(
+        candidates,
+        "vendor_north_east_gps",
+        _active_point(active, ne_local),
+        geo._gps(geometry.get("ne_gps")),  # noqa: SLF001
+        meaning="vendor ne_gps at derived local north-east corner",
+    )
+    _add_candidate(
+        candidates,
+        "rtk_anchor",
+        _active_point(active, origin_local),
+        _rtk_anchor(geometry),
+        meaning="RTK_anchor interpreted as local map (0,0)",
+    )
+
+    explicit = geo.georeference_from_geometry(geometry)
+    if explicit is not None:
+        _add_candidate(
+            candidates,
+            "explicit_vendor_transform_at_origin",
+            _active_point(active, origin_local),
+            _active_point(explicit, origin_local),
+            meaning="explicit map_north_offset vendor transform evaluated at local (0,0)",
+        )
+
+    learned = _learned_fit(geometry)
+    if learned is not None:
+        _add_candidate(
+            candidates,
+            "learned_cloud_fit_at_origin",
+            _active_point(active, origin_local),
+            _active_point(learned, origin_local),
+            meaning="persisted cloud learned fit evaluated at local (0,0)",
+        )
+
+    gps = None
+    if isinstance(location, dict):
+        x = geo._float(location.get("posture_x"))  # noqa: SLF001
+        y = geo._float(location.get("posture_y"))  # noqa: SLF001
+        latitude = geo._float(location.get("latitude"))  # noqa: SLF001
+        longitude = geo._float(location.get("longitude"))  # noqa: SLF001
+        local = (x, y) if x is not None and y is not None else None
+        if latitude is not None and longitude is not None:
+            if -90.0 <= latitude <= 90.0 and -180.0 <= longitude <= 180.0:
+                gps = (latitude, longitude)
+        _add_candidate(
+            candidates,
+            "private_cloud_live_gps",
+            _active_point(active, local),
+            gps,
+            meaning="current private-cloud GPS at current private-cloud local X/Y",
+        )
+
+        station = geometry.get("station") if isinstance(geometry.get("station"), dict) else {}
+        station_x = geo._float(station.get("x"))  # noqa: SLF001
+        station_y = geo._float(station.get("y"))  # noqa: SLF001
+        if docked and station_x is not None and station_y is not None:
+            _add_candidate(
+                candidates,
+                "docked_private_cloud_station_anchor",
+                _active_point(active, (station_x, station_y)),
+                gps,
+                meaning="live docked GPS treated as the map station local point",
+            )
+
+    rtk = geometry.get("rtk") if isinstance(geometry.get("rtk"), dict) else {}
+    raw_bias = rtk.get("bias") if isinstance(rtk, dict) else None
+    raw_pile = rtk.get("pile") if isinstance(rtk, dict) else None
+    metadata = {
+        "map_north_offset_present": geo._float(geometry.get("map_north_offset")) is not None,  # noqa: SLF001
+        "origin_gps_present": geo._gps(geometry.get("origin_gps")) is not None,  # noqa: SLF001
+        "center_gps_present": geo._gps(geometry.get("center_gps")) is not None,  # noqa: SLF001
+        "south_west_gps_present": geo._gps(geometry.get("sw_gps")) is not None,  # noqa: SLF001
+        "north_east_gps_present": geo._gps(geometry.get("ne_gps")) is not None,  # noqa: SLF001
+        "rtk_anchor_present": _rtk_anchor(geometry) is not None,
+        "rtk_bias_present": isinstance(raw_bias, str) and "nrtk_lrtk_bias" in raw_bias,
+        "rtk_pile_present": isinstance(raw_pile, str) and "LRTK" in raw_pile,
+        "learned_fit_present": learned is not None,
+        "station_present": isinstance(geometry.get("station"), dict),
+    }
+
+    rotation = geo._float(active.get("rotation_rad"))  # noqa: SLF001
+    return {
+        "read_only": True,
+        "available": True,
+        "convention": "candidate_minus_active; east/north metres; bearing clockwise from north",
+        "active_source": active.get("source"),
+        "active_anchor_policy": active.get("anchor_policy"),
+        "active_rotation_deg": round(math.degrees(rotation), 4) if rotation is not None else None,
+        "vendor_metadata": metadata,
+        "candidate_offsets": candidates,
+    }
+
+
+__all__ = ["reference_candidate_diagnostics"]

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta14"
+  "version": "0.4.4-beta15"
 }

--- a/tests/test_v044_beta14.py
+++ b/tests/test_v044_beta14.py
@@ -45,7 +45,9 @@ def _apply(geometry: dict, monkeypatch) -> dict:
 
 def test_beta14_version_release_notes_and_runtime_order() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.4-beta14"
+    version = str(manifest["version"])
+    assert version.startswith("0.4.4-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 14
     notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta14.md").read_text(
         encoding="utf-8"
     )

--- a/tests/test_v044_beta15.py
+++ b/tests/test_v044_beta15.py
@@ -1,0 +1,119 @@
+"""Regression tests for Navimower 0.4.4-beta15 georeference diagnostics."""
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+from custom_components.navimower import georeference as geo
+from custom_components.navimower.georeference_reference_diagnostics import (
+    reference_candidate_diagnostics,
+)
+from custom_components.navimower.georeference_static_anchor_semantics import (
+    _static_map_georeference,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+_H215 = {
+    "map_circle_center": [-6.547005460295729, 9.331472597744508],
+    "center_gps": [24.638553619384766, 58.384281158447266],
+    "origin_gps": [24.638547897338867, 58.38420104980469],
+    "map_north_offset": 0.5977016091346741,
+    "map_width": 90.0,
+    "map_height": 80.0,
+    "station": {"x": -0.3309, "y": -2.7012},
+    "rtk": {
+        "anchor": "RTK_mode: 1\nRTK_anchor: 58.38420048 24.63854749 38.75341415",
+    },
+}
+
+_I108 = {
+    "map_circle_center": [-11.4679, 1.4973],
+    "center_gps": [24.6380367, 58.3840637],
+    "origin_gps": [24.6382313, 58.3840523],
+    "ne_gps": [24.638504, 58.3843384],
+    "sw_gps": [24.6375675, 58.3837929],
+    "map_north_offset": None,
+    "map_width": 54.7474,
+    "map_height": 61.053,
+}
+
+
+def test_beta15_version_and_release_notes() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.4-beta15"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta15.md").read_text(
+        encoding="utf-8"
+    )
+    for phrase in ("read-only", "H2", "i1", "candidate_minus_active", "does **not** change"):
+        assert phrase in notes
+
+
+def test_h2_reports_rtk_and_explicit_reference_relationships_without_mutation() -> None:
+    geometry = deepcopy(_H215)
+    active = geo.georeference_from_geometry(geometry)
+    assert active is not None
+    geometry_before = deepcopy(geometry)
+    active_before = deepcopy(active)
+
+    diagnostics = reference_candidate_diagnostics(geometry, active)
+
+    assert diagnostics["read_only"] is True
+    assert diagnostics["vendor_metadata"]["map_north_offset_present"] is True
+    assert diagnostics["vendor_metadata"]["rtk_anchor_present"] is True
+    assert diagnostics["vendor_metadata"]["rtk_bias_present"] is False
+
+    relations = diagnostics["absolute_reference_relations"]
+    # H2 origin_gps and RTK_anchor are effectively the same absolute reference.
+    assert relations["rtk_anchor_minus_origin_gps"]["distance_m"] < 0.2
+
+    candidates = diagnostics["candidate_offsets"]
+    assert candidates["vendor_center_gps"]["candidate_minus_active"]["distance_m"] < 0.001
+    assert candidates["explicit_vendor_transform_at_origin"]["candidate_minus_active"]["distance_m"] < 0.001
+    # But H2 origin_gps is not consistent with treating it as local map (0,0),
+    # which is exactly why beta15 labels this only as a hypothesis check.
+    assert candidates["vendor_origin_gps_at_local_origin_hypothesis"]["candidate_minus_active"]["distance_m"] > 1.0
+
+    assert geometry == geometry_before
+    assert active == active_before
+
+
+def test_i1_static_fit_exposes_submetre_vendor_tie_residual_vectors() -> None:
+    active = _static_map_georeference(deepcopy(_I108))
+    assert active is not None
+    diagnostics = reference_candidate_diagnostics(_I108, active)
+
+    assert diagnostics["vendor_metadata"]["map_north_offset_present"] is False
+    assert diagnostics["vendor_metadata"]["rtk_anchor_present"] is False
+    candidates = diagnostics["candidate_offsets"]
+    for name in (
+        "vendor_origin_gps_at_local_origin_hypothesis",
+        "vendor_center_gps",
+        "vendor_south_west_gps",
+        "vendor_north_east_gps",
+    ):
+        assert candidates[name]["candidate_minus_active"]["distance_m"] < 0.25
+
+
+def test_reference_diagnostics_do_not_export_raw_wgs84_coordinates() -> None:
+    active = geo.georeference_from_geometry(_H215)
+    assert active is not None
+    diagnostics = reference_candidate_diagnostics(_H215, active)
+    payload = json.dumps(diagnostics, sort_keys=True)
+    for private_coordinate_fragment in (
+        "58.38420048",
+        "24.63854749",
+        "58.384281158447266",
+        "24.638553619384766",
+    ):
+        assert private_coordinate_fragment not in payload
+
+
+def test_runtime_diagnostics_attach_reference_candidates() -> None:
+    source = (COMPONENT / "georeference_diagnostics_semantics.py").read_text(
+        encoding="utf-8"
+    )
+    assert "reference_candidate_diagnostics" in source
+    assert 'decorated["reference_candidates"]' in source


### PR DESCRIPTION
## Summary
- add read-only georeference reference-candidate diagnostics for H2/i1 orthophoto alignment research
- compare active georeference against vendor origin/center/SW/NE ties, explicit vendor transform, RTK anchor, learned cloud fit, current cloud GPS and docked station anchor where available
- report only relative East/North metre vectors, distance and bearing; do not expose raw WGS84 coordinates
- add direct RTK-anchor vs origin-GPS relation diagnostics and vendor metadata presence inventory
- do not alter active H2, i1 or X3 map placement
- bump to 0.4.4-beta15 with regression tests and release notes

Field workflow: update to beta15, then download fresh H2 and i1 diagnostics while comparing against Maa- ja Ruumiamet orthophoto.