### PR TITLE
Add experimental ETRS89 cartographic georeference correction

### DIFF
--- a/.github/release-notes/0.4.4-beta16.md
+++ b/.github/release-notes/0.4.4-beta16.md
@@ -1,0 +1,25 @@
+title: Navimower 0.4.4-beta16
+
+## Experimental ETRS89 cartographic alignment
+
+- Add an experimental European cartographic-frame correction for H2/i1-style maps whose local geometry is already internally well calibrated but remains slightly offset against static European basemaps/orthophotos.
+- Apply the official EPSG:8366 ITRF2014 -> ETRF2014 time-dependent position-vector rotation rates to the map **translation only**. Local X/Y, rotation, scale, mowing geometry and the native GPS `device_tracker` remain unchanged.
+- Choose a coordinate epoch from the map edit time for static vendor-tie maps and from the latest learned/private-cloud position epoch for live learned fits. In the captured Estonia data at epoch 2026.67 this corresponds to about `-0.77 m East / -0.52 m North` (0.93 m toward the south-west).
+- Treat the source frame as an explicit field-test assumption (`ITRF2014-like dynamic GNSS`) because Navimow does not publish the CRS of these vendor coordinates.
+- Apply only inside the EPSG:8366 Europe area and only where a trustworthy vendor local frame exists: explicit `map_north_offset` maps or validated static vendor ties.
+
+## X3 remains vendor-frame owned
+
+- X3 `RTK_anchor + nrtk_lrtk_bias` translation is intentionally left unchanged. The beta14 field result already aligned X390 closely with orthophoto, so the EPSG:8366 correction is not stacked on top of the X3 vendor RTK-frame correction.
+
+## Diagnostics
+
+- Fix beta15 reference diagnostics so reduced cached map geometry no longer makes existing vendor metadata appear absent.
+- Retain normalized map-reference evidence during map decoding, including RTK-anchor presence and map tie metadata, then report only relative metre vectors in Download diagnostics.
+- Add `cartographic_frame` diagnostics with the applied East/North correction, coordinate epoch/source, EPSG operation and qualification path.
+- Force one map-detail refresh for relevant beta15 caches so the richer normalized reference metadata is available without manual relearning.
+
+## Field test
+
+- Compare H2 and i1 against the same Maa- ja Ruumiamet orthophoto after updating. Expected behavior is a small translation only; rotation and scale must not visibly change.
+- If the hypothesis is correct, H2 should move roughly one metre south-west and i1 should move by a very similar cartographic-frame amount while keeping their existing relative geometry.

--- a/custom_components/navimower/georeference_cartographic_semantics.py
+++ b/custom_components/navimower/georeference_cartographic_semantics.py
@@ -2,13 +2,13 @@
 
 Navimow map/localization coordinates observed on H2 and i1 behave like a current
 GNSS/ITRF-like dynamic frame, while European cartographic datasets are fixed to
-ETRS89/ETRF.  EPSG:8366 defines the time-dependent ITRF2014 -> ETRF2014
-position-vector transformation.  This module applies only the resulting small
+ETRS89/ETRF. EPSG:8366 defines the time-dependent ITRF2014 -> ETRF2014
+position-vector transformation. This module applies only the resulting small
 horizontal translation to map display georeferences; mower local X/Y, rotation,
 scale and the native GPS device_tracker remain untouched.
 
 The vendor does not declare its absolute GNSS CRS, so this remains an explicit
-field-test assumption.  X3 maps with their vendor RTK_anchor/NRTK-LRTK path are
+field-test assumption. X3 maps with their vendor RTK_anchor/NRTK-LRTK path are
 excluded because that vendor frame correction already owns their translation.
 """
 from __future__ import annotations
@@ -74,11 +74,16 @@ def _coordinate_epoch(
 
     calibration = geometry.get("_georeference_calibration")
     if isinstance(calibration, dict):
-        samples = [item for item in calibration.get("samples") or [] if isinstance(item, dict)]
+        samples = [
+            item
+            for item in calibration.get("samples") or []
+            if isinstance(item, dict)
+        ]
         epochs = [
             value
             for item in samples
-            if (value := _decimal_year_from_timestamp(item.get("report_time"))) is not None
+            if (value := _decimal_year_from_timestamp(item.get("report_time")))
+            is not None
         ]
         if epochs:
             return max(epochs), "latest_georeference_sample"
@@ -128,7 +133,9 @@ def _itrf2014_to_etrf2014_offset(
     cos_phi = math.cos(phi)
     sin_lam = math.sin(lam)
     cos_lam = math.cos(lam)
-    prime_vertical = _GRS80_A_M / math.sqrt(1.0 - eccentricity_sq * sin_phi * sin_phi)
+    prime_vertical = _GRS80_A_M / math.sqrt(
+        1.0 - eccentricity_sq * sin_phi * sin_phi
+    )
 
     x = prime_vertical * cos_phi * cos_lam
     y = prime_vertical * cos_phi * sin_lam
@@ -146,7 +153,11 @@ def _itrf2014_to_etrf2014_offset(
     dx, dy, dz = x2 - x, y2 - y, z2 - z
 
     east_m = -sin_lam * dx + cos_lam * dy
-    north_m = -sin_phi * cos_lam * dx - sin_phi * sin_lam * dy + cos_phi * dz
+    north_m = (
+        -sin_phi * cos_lam * dx
+        - sin_phi * sin_lam * dy
+        + cos_phi * dz
+    )
     up_m = cos_phi * cos_lam * dx + cos_phi * sin_lam * dy + sin_phi * dz
     distance_m = math.hypot(east_m, north_m)
     return {
@@ -156,29 +167,60 @@ def _itrf2014_to_etrf2014_offset(
         "distance_m": distance_m,
         "bearing_deg_from_north": (
             math.degrees(math.atan2(east_m, north_m)) + 360.0
-        ) % 360.0,
+        )
+        % 360.0,
     }
 
 
-def _vendor_support_kind(geometry: dict[str, Any], active: dict[str, Any]) -> str | None:
+def _transform_complete(value: Any) -> bool:
+    """Return whether a vendor transform has the fields needed for projection.
+
+    A raw vendor bootstrap transform intentionally has no ``status=validated``
+    yet, so ``georeference_is_valid`` is too strict for identifying its frame
+    semantics here.
+    """
+    if not isinstance(value, dict):
+        return False
+    reference = value.get("reference") or {}
+    return all(
+        _georeference._float(item) is not None  # noqa: SLF001
+        for item in (
+            reference.get("local_x"),
+            reference.get("local_y"),
+            reference.get("latitude"),
+            reference.get("longitude"),
+            value.get("rotation_rad"),
+        )
+    )
+
+
+def _vendor_support_kind(
+    geometry: dict[str, Any], active: dict[str, Any]
+) -> str | None:
     """Return why this map has a trustworthy vendor-owned local frame."""
     source = active.get("source")
     if source == _X3_SOURCE:
         return None
     if source == _STATIC_SOURCE:
         return "static_vendor_ties"
+
     vendor = geometry.get("_vendor_georeference")
-    if (
-        isinstance(vendor, dict)
-        and vendor.get("source") == "vendor_map_detail"
-        and _georeference.georeference_is_valid(vendor)
+    if not isinstance(vendor, dict):
+        return None
+    vendor_source = vendor.get("source")
+    if vendor_source == _X3_SOURCE:
+        return None
+    if vendor_source == _STATIC_SOURCE or (
+        (vendor.get("static_validation") or {}).get("valid") is True
     ):
+        return "static_vendor_ties"
+    if vendor_source == "vendor_map_detail" and _transform_complete(vendor):
         return "explicit_vendor_map_north_offset"
     return None
 
 
-def _decorate_vendor_metadata(geom: Any, result: Any) -> dict[str, Any] | None:
-    """Retain normalized raw-map evidence needed by diagnostics after reduction."""
+def _decorate_vendor_metadata(geom: Any) -> dict[str, Any] | None:
+    """Retain normalized raw-map evidence needed after geometry reduction."""
     if _ORIGINAL_FROM_GEOMETRY is None:
         return None
     original = _ORIGINAL_FROM_GEOMETRY(geom)
@@ -192,15 +234,29 @@ def _decorate_vendor_metadata(geom: Any, result: Any) -> dict[str, Any] | None:
     anchor = _static._rtk_anchor(geom)  # noqa: SLF001
     center_local = _georeference._xy(geom.get("map_circle_center"))  # noqa: SLF001
     decorated["vendor_metadata"] = {
-        "map_north_offset_present": _georeference._float(geom.get("map_north_offset")) is not None,  # noqa: SLF001
-        "origin_gps_present": _georeference._gps(geom.get("origin_gps")) is not None,  # noqa: SLF001
-        "center_gps_present": _georeference._gps(geom.get("center_gps")) is not None,  # noqa: SLF001
-        "south_west_gps_present": _georeference._gps(geom.get("sw_gps")) is not None,  # noqa: SLF001
-        "north_east_gps_present": _georeference._gps(geom.get("ne_gps")) is not None,  # noqa: SLF001
+        "map_north_offset_present": (
+            _georeference._float(geom.get("map_north_offset")) is not None  # noqa: SLF001
+        ),
+        "origin_gps_present": (
+            _georeference._gps(geom.get("origin_gps")) is not None  # noqa: SLF001
+        ),
+        "center_gps_present": (
+            _georeference._gps(geom.get("center_gps")) is not None  # noqa: SLF001
+        ),
+        "south_west_gps_present": (
+            _georeference._gps(geom.get("sw_gps")) is not None  # noqa: SLF001
+        ),
+        "north_east_gps_present": (
+            _georeference._gps(geom.get("ne_gps")) is not None  # noqa: SLF001
+        ),
         "rtk_anchor_present": anchor is not None,
-        "rtk_bias_present": isinstance(raw_bias, str) and "nrtk_lrtk_bias" in raw_bias,
+        "rtk_bias_present": (
+            isinstance(raw_bias, str) and "nrtk_lrtk_bias" in raw_bias
+        ),
         "rtk_pile_present": isinstance(raw_pile, str) and "LRTK" in raw_pile,
-        "map_circle_center_local": list(center_local) if center_local is not None else None,
+        "map_circle_center_local": (
+            list(center_local) if center_local is not None else None
+        ),
         "map_width_m": _georeference._float(geom.get("map_width")),  # noqa: SLF001
         "map_height_m": _georeference._float(geom.get("map_height")),  # noqa: SLF001
     }
@@ -309,7 +365,9 @@ def _apply_cartographic_frame(
             "north_m": round(correction["north_m"], 3),
             "up_m": round(correction["up_m"], 3),
             "distance_m": round(correction["distance_m"], 3),
-            "bearing_deg_from_north": round(correction["bearing_deg_from_north"], 2),
+            "bearing_deg_from_north": round(
+                correction["bearing_deg_from_north"], 2
+            ),
             "translation_only": True,
         }
     )
@@ -337,9 +395,12 @@ async def _load_persistent_state(self: Any) -> None:
     active = geometry.get("georeference")
     vendor = geometry.get("_vendor_georeference")
     relevant = (
-        isinstance(active, dict) and active.get("source") in {_STATIC_SOURCE, "cloud_location_fit", "vendor_map_detail"}
+        isinstance(active, dict)
+        and active.get("source")
+        in {_STATIC_SOURCE, "cloud_location_fit", "vendor_map_detail"}
     ) or (
-        isinstance(vendor, dict) and vendor.get("source") in {_STATIC_SOURCE, "vendor_map_detail"}
+        isinstance(vendor, dict)
+        and vendor.get("source") in {_STATIC_SOURCE, "vendor_map_detail"}
     )
     if relevant:
         self._map_cache_key = None  # noqa: SLF001
@@ -355,15 +416,17 @@ def install_georeference_cartographic_semantics() -> None:
 
     _ORIGINAL_FROM_GEOMETRY = _georeference.georeference_from_geometry
     _ORIGINAL_UPDATE = _georeference.update_georeference
-    _ORIGINAL_LOAD = _coordinator_semantics.NavimowCoordinator.async_load_persistent_state
+    _ORIGINAL_LOAD = (
+        _coordinator_semantics.NavimowCoordinator.async_load_persistent_state
+    )
 
     _georeference.georeference_from_geometry = _decorate_vendor_metadata
     _georeference.update_georeference = _update
     _coordinator_semantics.update_georeference = _update
-    _coordinator_semantics.NavimowCoordinator.async_load_persistent_state = _load_persistent_state
+    _coordinator_semantics.NavimowCoordinator.async_load_persistent_state = (
+        _load_persistent_state
+    )
     _INSTALLED = True
 
 
-__all__ = [
-    "install_georeference_cartographic_semantics",
-]
+__all__ = ["install_georeference_cartographic_semantics"]

--- a/custom_components/navimower/georeference_cartographic_semantics.py
+++ b/custom_components/navimower/georeference_cartographic_semantics.py
@@ -1,0 +1,369 @@
+"""Align European mower map references with the static ETRS89 cartographic frame.
+
+Navimow map/localization coordinates observed on H2 and i1 behave like a current
+GNSS/ITRF-like dynamic frame, while European cartographic datasets are fixed to
+ETRS89/ETRF.  EPSG:8366 defines the time-dependent ITRF2014 -> ETRF2014
+position-vector transformation.  This module applies only the resulting small
+horizontal translation to map display georeferences; mower local X/Y, rotation,
+scale and the native GPS device_tracker remain untouched.
+
+The vendor does not declare its absolute GNSS CRS, so this remains an explicit
+field-test assumption.  X3 maps with their vendor RTK_anchor/NRTK-LRTK path are
+excluded because that vendor frame correction already owns their translation.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import math
+import time
+from typing import Any, Callable
+
+from . import georeference as _georeference
+from . import georeference_static_anchor_semantics as _static
+
+_EPSG_OPERATION = 8366
+_SOURCE_FRAME = "ITRF2014-like dynamic GNSS (vendor assumption)"
+_TARGET_FRAME = "ETRF2014 / ETRS89 cartographic"
+_REFERENCE_EPOCH = 1989.0
+_DRX_MAS_PER_YEAR = 0.085
+_DRY_MAS_PER_YEAR = 0.531
+_DRZ_MAS_PER_YEAR = -0.770
+_MAS_TO_RAD = math.pi / (180.0 * 3600.0 * 1000.0)
+_GRS80_A_M = 6378137.0
+_GRS80_INV_F = 298.257222101
+_EUROPE_BBOX = (33.26, -16.10, 84.73, 38.01)  # EPSG:8366 area of use.
+_STATIC_SOURCE = "vendor_map_static_fit"
+_X3_SOURCE = "x3_rtk_anchor"
+_PROBE_MARKER = "etrs89_cartographic_v1"
+
+_INSTALLED = False
+_ORIGINAL_FROM_GEOMETRY: Callable[[Any], dict[str, Any] | None] | None = None
+_ORIGINAL_UPDATE: Callable[[Any, Any], dict[str, Any] | None] | None = None
+_ORIGINAL_LOAD: Callable[..., Any] | None = None
+
+
+def _decimal_year_from_timestamp(value: Any) -> float | None:
+    parsed = _georeference._float(value)  # noqa: SLF001
+    if parsed is None:
+        return None
+    if parsed > 10_000_000_000.0:
+        parsed /= 1000.0
+    try:
+        instant = datetime.fromtimestamp(parsed, tz=timezone.utc)
+        start = datetime(instant.year, 1, 1, tzinfo=timezone.utc)
+        end = datetime(instant.year + 1, 1, 1, tzinfo=timezone.utc)
+    except (OSError, OverflowError, ValueError):
+        return None
+    fraction = (instant - start).total_seconds() / (end - start).total_seconds()
+    return instant.year + fraction
+
+
+def _current_decimal_year() -> float:
+    return _decimal_year_from_timestamp(time.time()) or 2026.0
+
+
+def _coordinate_epoch(
+    geometry: dict[str, Any], location: Any, active: dict[str, Any]
+) -> tuple[float, str]:
+    """Choose the epoch that best matches the coordinates owning translation."""
+    if active.get("source") == _STATIC_SOURCE:
+        epoch = _decimal_year_from_timestamp(geometry.get("edit_time"))
+        if epoch is not None:
+            return epoch, "map_edit_time"
+
+    calibration = geometry.get("_georeference_calibration")
+    if isinstance(calibration, dict):
+        samples = [item for item in calibration.get("samples") or [] if isinstance(item, dict)]
+        epochs = [
+            value
+            for item in samples
+            if (value := _decimal_year_from_timestamp(item.get("report_time"))) is not None
+        ]
+        if epochs:
+            return max(epochs), "latest_georeference_sample"
+
+    if isinstance(location, dict):
+        epoch = _decimal_year_from_timestamp(location.get("report_time"))
+        if epoch is not None:
+            return epoch, "private_cloud_report_time"
+
+    epoch = _decimal_year_from_timestamp(geometry.get("edit_time"))
+    if epoch is not None:
+        return epoch, "map_edit_time_fallback"
+    return _current_decimal_year(), "current_utc_fallback"
+
+
+def _in_epsg8366_area(latitude: float, longitude: float) -> bool:
+    south, west, north, east = _EUROPE_BBOX
+    return south <= latitude <= north and west <= longitude <= east
+
+
+def _itrf2014_to_etrf2014_offset(
+    latitude: Any, longitude: Any, epoch: Any
+) -> dict[str, float] | None:
+    """Return EPSG:8366 displacement as local East/North/Up metres.
+
+    EPSG:8366 has zero translations/scale and only rotation rates at epoch 1989.
+    Applying the small position-vector rotation to a GRS80 geocentric point and
+    resolving its delta into local ENU is sufficient for this sub-metre display
+    correction and avoids adding a heavy PROJ dependency to Home Assistant.
+    """
+    lat = _georeference._float(latitude)  # noqa: SLF001
+    lon = _georeference._float(longitude)  # noqa: SLF001
+    observation_epoch = _georeference._float(epoch)  # noqa: SLF001
+    if None in (lat, lon, observation_epoch):
+        return None
+    assert lat is not None and lon is not None and observation_epoch is not None
+    if not (-90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0):
+        return None
+    if not (1989.0 <= observation_epoch <= 2100.0):
+        return None
+
+    phi = math.radians(lat)
+    lam = math.radians(lon)
+    flattening = 1.0 / _GRS80_INV_F
+    eccentricity_sq = flattening * (2.0 - flattening)
+    sin_phi = math.sin(phi)
+    cos_phi = math.cos(phi)
+    sin_lam = math.sin(lam)
+    cos_lam = math.cos(lam)
+    prime_vertical = _GRS80_A_M / math.sqrt(1.0 - eccentricity_sq * sin_phi * sin_phi)
+
+    x = prime_vertical * cos_phi * cos_lam
+    y = prime_vertical * cos_phi * sin_lam
+    z = prime_vertical * (1.0 - eccentricity_sq) * sin_phi
+
+    years = observation_epoch - _REFERENCE_EPOCH
+    rx = _DRX_MAS_PER_YEAR * years * _MAS_TO_RAD
+    ry = _DRY_MAS_PER_YEAR * years * _MAS_TO_RAD
+    rz = _DRZ_MAS_PER_YEAR * years * _MAS_TO_RAD
+
+    # EPSG method 1053: time-dependent position-vector transformation.
+    x2 = x - rz * y + ry * z
+    y2 = rz * x + y - rx * z
+    z2 = -ry * x + rx * y + z
+    dx, dy, dz = x2 - x, y2 - y, z2 - z
+
+    east_m = -sin_lam * dx + cos_lam * dy
+    north_m = -sin_phi * cos_lam * dx - sin_phi * sin_lam * dy + cos_phi * dz
+    up_m = cos_phi * cos_lam * dx + cos_phi * sin_lam * dy + sin_phi * dz
+    distance_m = math.hypot(east_m, north_m)
+    return {
+        "east_m": east_m,
+        "north_m": north_m,
+        "up_m": up_m,
+        "distance_m": distance_m,
+        "bearing_deg_from_north": (
+            math.degrees(math.atan2(east_m, north_m)) + 360.0
+        ) % 360.0,
+    }
+
+
+def _vendor_support_kind(geometry: dict[str, Any], active: dict[str, Any]) -> str | None:
+    """Return why this map has a trustworthy vendor-owned local frame."""
+    source = active.get("source")
+    if source == _X3_SOURCE:
+        return None
+    if source == _STATIC_SOURCE:
+        return "static_vendor_ties"
+    vendor = geometry.get("_vendor_georeference")
+    if (
+        isinstance(vendor, dict)
+        and vendor.get("source") == "vendor_map_detail"
+        and _georeference.georeference_is_valid(vendor)
+    ):
+        return "explicit_vendor_map_north_offset"
+    return None
+
+
+def _decorate_vendor_metadata(geom: Any, result: Any) -> dict[str, Any] | None:
+    """Retain normalized raw-map evidence needed by diagnostics after reduction."""
+    if _ORIGINAL_FROM_GEOMETRY is None:
+        return None
+    original = _ORIGINAL_FROM_GEOMETRY(geom)
+    if not isinstance(original, dict) or not isinstance(geom, dict):
+        return original
+
+    decorated = deepcopy(original)
+    rtk = geom.get("rtk") if isinstance(geom.get("rtk"), dict) else {}
+    raw_bias = rtk.get("bias") if isinstance(rtk, dict) else None
+    raw_pile = rtk.get("pile") if isinstance(rtk, dict) else None
+    anchor = _static._rtk_anchor(geom)  # noqa: SLF001
+    center_local = _georeference._xy(geom.get("map_circle_center"))  # noqa: SLF001
+    decorated["vendor_metadata"] = {
+        "map_north_offset_present": _georeference._float(geom.get("map_north_offset")) is not None,  # noqa: SLF001
+        "origin_gps_present": _georeference._gps(geom.get("origin_gps")) is not None,  # noqa: SLF001
+        "center_gps_present": _georeference._gps(geom.get("center_gps")) is not None,  # noqa: SLF001
+        "south_west_gps_present": _georeference._gps(geom.get("sw_gps")) is not None,  # noqa: SLF001
+        "north_east_gps_present": _georeference._gps(geom.get("ne_gps")) is not None,  # noqa: SLF001
+        "rtk_anchor_present": anchor is not None,
+        "rtk_bias_present": isinstance(raw_bias, str) and "nrtk_lrtk_bias" in raw_bias,
+        "rtk_pile_present": isinstance(raw_pile, str) and "LRTK" in raw_pile,
+        "map_circle_center_local": list(center_local) if center_local is not None else None,
+        "map_width_m": _georeference._float(geom.get("map_width")),  # noqa: SLF001
+        "map_height_m": _georeference._float(geom.get("map_height")),  # noqa: SLF001
+    }
+    if anchor is not None:
+        latitude, longitude, altitude = anchor
+        decorated["rtk_anchor"] = {
+            "latitude": latitude,
+            "longitude": longitude,
+            "altitude_m": altitude,
+        }
+    return decorated
+
+
+def _apply_cartographic_frame(
+    geometry: Any,
+    active: Any,
+    location: Any,
+    *,
+    epoch_override: float | None = None,
+) -> dict[str, Any] | None:
+    if not isinstance(active, dict) or not _georeference.georeference_is_valid(active):
+        return active
+    if not isinstance(geometry, dict):
+        return active
+
+    support_kind = _vendor_support_kind(geometry, active)
+    if active.get("source") == _X3_SOURCE:
+        updated = deepcopy(active)
+        updated["cartographic_frame"] = {
+            "experimental": True,
+            "applied": False,
+            "reason": "x3_vendor_rtk_frame_owns_translation",
+            "epsg_operation": _EPSG_OPERATION,
+        }
+        geometry[_PROBE_MARKER] = True
+        geometry["georeference"] = updated
+        return updated
+    if support_kind is None:
+        return active
+
+    reference = active.get("reference") or {}
+    latitude = _georeference._float(reference.get("latitude"))  # noqa: SLF001
+    longitude = _georeference._float(reference.get("longitude"))  # noqa: SLF001
+    if latitude is None or longitude is None:
+        return active
+
+    if epoch_override is None:
+        epoch, epoch_source = _coordinate_epoch(geometry, location, active)
+    else:
+        epoch, epoch_source = float(epoch_override), "test_override"
+
+    updated = deepcopy(active)
+    frame: dict[str, Any] = {
+        "experimental": True,
+        "epsg_operation": _EPSG_OPERATION,
+        "method": "time_dependent_position_vector_geocentric",
+        "source_frame_assumption": _SOURCE_FRAME,
+        "target_frame": _TARGET_FRAME,
+        "reference_epoch": _REFERENCE_EPOCH,
+        "coordinate_epoch": round(epoch, 6),
+        "coordinate_epoch_source": epoch_source,
+        "support_kind": support_kind,
+        "rotation_rate_mas_per_year": [
+            _DRX_MAS_PER_YEAR,
+            _DRY_MAS_PER_YEAR,
+            _DRZ_MAS_PER_YEAR,
+        ],
+    }
+    if not _in_epsg8366_area(latitude, longitude):
+        frame.update({"applied": False, "reason": "outside_epsg8366_area"})
+        updated["cartographic_frame"] = frame
+        geometry[_PROBE_MARKER] = True
+        geometry["georeference"] = updated
+        return updated
+
+    correction = _itrf2014_to_etrf2014_offset(latitude, longitude, epoch)
+    if correction is None:
+        frame.update({"applied": False, "reason": "epsg8366_offset_failed"})
+        updated["cartographic_frame"] = frame
+        geometry[_PROBE_MARKER] = True
+        geometry["georeference"] = updated
+        return updated
+
+    corrected = _georeference.offset_wgs84(
+        latitude,
+        longitude,
+        correction["east_m"],
+        correction["north_m"],
+    )
+    if corrected is None:
+        frame.update({"applied": False, "reason": "reference_offset_failed"})
+        updated["cartographic_frame"] = frame
+        geometry[_PROBE_MARKER] = True
+        geometry["georeference"] = updated
+        return updated
+
+    corrected_latitude, corrected_longitude = corrected
+    updated_reference = dict(reference)
+    updated_reference["latitude"] = corrected_latitude
+    updated_reference["longitude"] = corrected_longitude
+    updated["reference"] = updated_reference
+    frame.update(
+        {
+            "applied": True,
+            "east_m": round(correction["east_m"], 3),
+            "north_m": round(correction["north_m"], 3),
+            "up_m": round(correction["up_m"], 3),
+            "distance_m": round(correction["distance_m"], 3),
+            "bearing_deg_from_north": round(correction["bearing_deg_from_north"], 2),
+            "translation_only": True,
+        }
+    )
+    updated["cartographic_frame"] = frame
+    geometry[_PROBE_MARKER] = True
+    geometry["georeference"] = updated
+    return updated
+
+
+def _update(map_geometry: Any, location: Any) -> dict[str, Any] | None:
+    if _ORIGINAL_UPDATE is None:
+        return None
+    active = _ORIGINAL_UPDATE(map_geometry, location)
+    return _apply_cartographic_frame(map_geometry, active, location)
+
+
+async def _load_persistent_state(self: Any) -> None:
+    """Refresh beta15 map caches once to retain normalized raw reference evidence."""
+    if _ORIGINAL_LOAD is None:
+        return
+    await _ORIGINAL_LOAD(self)
+    geometry = getattr(self, "_map_geometry", None)
+    if not isinstance(geometry, dict) or geometry.get(_PROBE_MARKER):
+        return
+    active = geometry.get("georeference")
+    vendor = geometry.get("_vendor_georeference")
+    relevant = (
+        isinstance(active, dict) and active.get("source") in {_STATIC_SOURCE, "cloud_location_fit", "vendor_map_detail"}
+    ) or (
+        isinstance(vendor, dict) and vendor.get("source") in {_STATIC_SOURCE, "vendor_map_detail"}
+    )
+    if relevant:
+        self._map_cache_key = None  # noqa: SLF001
+
+
+def install_georeference_cartographic_semantics() -> None:
+    """Install cartographic correction after X3 vendor-frame handling."""
+    global _INSTALLED, _ORIGINAL_FROM_GEOMETRY, _ORIGINAL_UPDATE, _ORIGINAL_LOAD
+    if _INSTALLED:
+        return
+
+    from . import coordinator_semantics as _coordinator_semantics
+
+    _ORIGINAL_FROM_GEOMETRY = _georeference.georeference_from_geometry
+    _ORIGINAL_UPDATE = _georeference.update_georeference
+    _ORIGINAL_LOAD = _coordinator_semantics.NavimowCoordinator.async_load_persistent_state
+
+    _georeference.georeference_from_geometry = _decorate_vendor_metadata
+    _georeference.update_georeference = _update
+    _coordinator_semantics.update_georeference = _update
+    _coordinator_semantics.NavimowCoordinator.async_load_persistent_state = _load_persistent_state
+    _INSTALLED = True
+
+
+__all__ = [
+    "install_georeference_cartographic_semantics",
+]

--- a/custom_components/navimower/georeference_reference_diagnostics.py
+++ b/custom_components/navimower/georeference_reference_diagnostics.py
@@ -38,7 +38,19 @@ def _active_point(active: Any, local: tuple[float, float] | None) -> tuple[float
     return geo.local_xy_to_wgs84(active, local[0], local[1])
 
 
-def _rtk_anchor(geometry: dict[str, Any]) -> tuple[float, float] | None:
+def _dict_gps(value: Any) -> tuple[float, float] | None:
+    if not isinstance(value, dict):
+        return None
+    latitude = geo._float(value.get("latitude"))  # noqa: SLF001
+    longitude = geo._float(value.get("longitude"))  # noqa: SLF001
+    if latitude is None or longitude is None:
+        return None
+    if not (-90.0 <= latitude <= 90.0 and -180.0 <= longitude <= 180.0):
+        return None
+    return latitude, longitude
+
+
+def _raw_rtk_anchor(geometry: dict[str, Any]) -> tuple[float, float] | None:
     rtk = geometry.get("rtk")
     raw = rtk.get("anchor") if isinstance(rtk, dict) else None
     if not isinstance(raw, str):
@@ -53,6 +65,14 @@ def _rtk_anchor(geometry: dict[str, Any]) -> tuple[float, float] | None:
     if not (-90.0 <= latitude <= 90.0 and -180.0 <= longitude <= 180.0):
         return None
     return latitude, longitude
+
+
+def _vendor_georeference(geometry: dict[str, Any]) -> dict[str, Any] | None:
+    vendor = geometry.get("_vendor_georeference")
+    if isinstance(vendor, dict):
+        return vendor
+    candidate = geo.georeference_from_geometry(geometry)
+    return candidate if isinstance(candidate, dict) else None
 
 
 def _learned_fit(geometry: dict[str, Any]) -> dict[str, Any] | None:
@@ -86,7 +106,12 @@ def reference_candidate_diagnostics(
     *,
     docked: bool = False,
 ) -> dict[str, Any]:
-    """Compare all cached absolute map references without changing the map.
+    """Compare cached absolute map references without changing the map.
+
+    Raw map-detail is reduced before it reaches the normal coordinator cache.
+    Beta16 therefore also reads the normalized ``_vendor_georeference`` evidence
+    retained during map decoding instead of assuming the reduced geometry still
+    contains raw ``*_gps`` and ``rtk`` fields.
 
     All exported values are relative metre vectors. Raw WGS84 coordinates are
     deliberately omitted so Home Assistant Download diagnostics stays safe to
@@ -95,29 +120,83 @@ def reference_candidate_diagnostics(
     if not isinstance(geometry, dict) or not isinstance(active, dict):
         return {"read_only": True, "available": False}
 
+    vendor = _vendor_georeference(geometry)
+    vendor = vendor if isinstance(vendor, dict) else {}
+    vendor_meta = vendor.get("vendor_metadata")
+    vendor_meta = vendor_meta if isinstance(vendor_meta, dict) else {}
+    vendor_source = vendor.get("source")
+
     center_local = geo._xy(geometry.get("map_circle_center"))  # noqa: SLF001
-    origin_local = (0.0, 0.0)
+    if center_local is None:
+        center_local = geo._xy(vendor_meta.get("map_circle_center_local"))  # noqa: SLF001
+    if center_local is None and vendor_source == "vendor_map_detail":
+        reference = vendor.get("reference") or {}
+        local_x = geo._float(reference.get("local_x"))  # noqa: SLF001
+        local_y = geo._float(reference.get("local_y"))  # noqa: SLF001
+        if local_x is not None and local_y is not None:
+            center_local = (local_x, local_y)
+
     width = geo._float(geometry.get("map_width"))  # noqa: SLF001
+    if width is None:
+        width = geo._float(geometry.get("width"))  # noqa: SLF001
+    if width is None:
+        width = geo._float(vendor_meta.get("map_width_m"))  # noqa: SLF001
     height = geo._float(geometry.get("map_height"))  # noqa: SLF001
+    if height is None:
+        height = geo._float(geometry.get("height"))  # noqa: SLF001
+    if height is None:
+        height = geo._float(vendor_meta.get("map_height_m"))  # noqa: SLF001
+
+    origin_local = (0.0, 0.0)
     sw_local = ne_local = None
     if center_local is not None and width is not None and height is not None:
         sw_local = (center_local[0] - width / 2.0, center_local[1] - height / 2.0)
         ne_local = (center_local[0] + width / 2.0, center_local[1] + height / 2.0)
 
     origin_gps = geo._gps(geometry.get("origin_gps"))  # noqa: SLF001
+    if origin_gps is None:
+        origin_gps = _dict_gps(vendor.get("origin"))
+
     center_gps = geo._gps(geometry.get("center_gps"))  # noqa: SLF001
+    if center_gps is None:
+        center_gps = _dict_gps(vendor.get("center"))
+    if center_gps is None and vendor_source == "vendor_map_detail":
+        center_gps = _dict_gps(vendor.get("reference"))
+
+    bounds = vendor.get("bounds") if isinstance(vendor.get("bounds"), dict) else {}
     sw_gps = geo._gps(geometry.get("sw_gps"))  # noqa: SLF001
+    if sw_gps is None:
+        sw_gps = _dict_gps(bounds.get("south_west"))
     ne_gps = geo._gps(geometry.get("ne_gps"))  # noqa: SLF001
-    rtk_anchor = _rtk_anchor(geometry)
+    if ne_gps is None:
+        ne_gps = _dict_gps(bounds.get("north_east"))
+
+    rtk_anchor = _dict_gps(vendor.get("rtk_anchor")) or _raw_rtk_anchor(geometry)
 
     candidates: dict[str, Any] = {}
-    _add_candidate(
-        candidates,
-        "vendor_origin_gps_at_local_origin_hypothesis",
-        _active_point(active, origin_local),
-        origin_gps,
-        meaning="hypothesis check: vendor origin_gps interpreted as local map (0,0)",
-    )
+    if vendor_source == "vendor_map_static_fit" or geo._float(geometry.get("map_north_offset")) is None:  # noqa: SLF001
+        _add_candidate(
+            candidates,
+            "vendor_origin_gps_at_local_origin",
+            _active_point(active, origin_local),
+            origin_gps,
+            meaning="static-map vendor origin_gps at local map (0,0)",
+        )
+        _add_candidate(
+            candidates,
+            "vendor_south_west_gps",
+            _active_point(active, sw_local),
+            sw_gps,
+            meaning="static-map vendor sw_gps at derived local south-west corner",
+        )
+        _add_candidate(
+            candidates,
+            "vendor_north_east_gps",
+            _active_point(active, ne_local),
+            ne_gps,
+            meaning="static-map vendor ne_gps at derived local north-east corner",
+        )
+
     _add_candidate(
         candidates,
         "vendor_center_gps",
@@ -125,35 +204,13 @@ def reference_candidate_diagnostics(
         center_gps,
         meaning="vendor center_gps at map_circle_center",
     )
-    _add_candidate(
-        candidates,
-        "vendor_south_west_gps",
-        _active_point(active, sw_local),
-        sw_gps,
-        meaning="vendor sw_gps at derived local south-west corner",
-    )
-    _add_candidate(
-        candidates,
-        "vendor_north_east_gps",
-        _active_point(active, ne_local),
-        ne_gps,
-        meaning="vendor ne_gps at derived local north-east corner",
-    )
-    _add_candidate(
-        candidates,
-        "rtk_anchor_at_local_origin_hypothesis",
-        _active_point(active, origin_local),
-        rtk_anchor,
-        meaning="hypothesis check: RTK_anchor interpreted as local map (0,0)",
-    )
 
-    explicit = geo.georeference_from_geometry(geometry)
-    if explicit is not None:
+    if vendor_source == "vendor_map_detail" and geo.georeference_is_valid(vendor):
         _add_candidate(
             candidates,
             "explicit_vendor_transform_at_origin",
             _active_point(active, origin_local),
-            _active_point(explicit, origin_local),
+            _active_point(vendor, origin_local),
             meaning="explicit map_north_offset vendor transform evaluated at local (0,0)",
         )
 
@@ -205,18 +262,31 @@ def reference_candidate_diagnostics(
     if center_minus_origin is not None:
         relations["center_gps_minus_origin_gps"] = center_minus_origin
 
-    rtk = geometry.get("rtk") if isinstance(geometry.get("rtk"), dict) else {}
-    raw_bias = rtk.get("bias") if isinstance(rtk, dict) else None
-    raw_pile = rtk.get("pile") if isinstance(rtk, dict) else None
+    raw_rtk = geometry.get("rtk") if isinstance(geometry.get("rtk"), dict) else {}
+    raw_bias = raw_rtk.get("bias") if isinstance(raw_rtk, dict) else None
+    raw_pile = raw_rtk.get("pile") if isinstance(raw_rtk, dict) else None
     metadata = {
-        "map_north_offset_present": geo._float(geometry.get("map_north_offset")) is not None,  # noqa: SLF001
-        "origin_gps_present": origin_gps is not None,
-        "center_gps_present": center_gps is not None,
-        "south_west_gps_present": sw_gps is not None,
-        "north_east_gps_present": ne_gps is not None,
-        "rtk_anchor_present": rtk_anchor is not None,
-        "rtk_bias_present": isinstance(raw_bias, str) and "nrtk_lrtk_bias" in raw_bias,
-        "rtk_pile_present": isinstance(raw_pile, str) and "LRTK" in raw_pile,
+        "map_north_offset_present": bool(
+            vendor_meta.get("map_north_offset_present")
+            or vendor_source == "vendor_map_detail"
+            or geo._float(geometry.get("map_north_offset")) is not None  # noqa: SLF001
+            or geo._float(geometry.get("north_offset")) is not None  # noqa: SLF001
+        ),
+        "origin_gps_present": bool(vendor_meta.get("origin_gps_present") or origin_gps is not None),
+        "center_gps_present": bool(vendor_meta.get("center_gps_present") or center_gps is not None),
+        "south_west_gps_present": bool(vendor_meta.get("south_west_gps_present") or sw_gps is not None),
+        "north_east_gps_present": bool(vendor_meta.get("north_east_gps_present") or ne_gps is not None),
+        "rtk_anchor_present": bool(vendor_meta.get("rtk_anchor_present") or rtk_anchor is not None),
+        "rtk_bias_present": bool(
+            vendor_meta.get("rtk_bias_present")
+            or (isinstance(raw_bias, str) and "nrtk_lrtk_bias" in raw_bias)
+            or isinstance((vendor.get("rtk_validation") or {}).get("bias"), dict)
+        ),
+        "rtk_pile_present": bool(
+            vendor_meta.get("rtk_pile_present")
+            or (isinstance(raw_pile, str) and "LRTK" in raw_pile)
+            or (vendor.get("rtk_validation") or {}).get("pile_raw") is not None
+        ),
         "learned_fit_present": learned is not None,
         "station_present": isinstance(geometry.get("station"), dict),
     }
@@ -229,9 +299,11 @@ def reference_candidate_diagnostics(
         "active_source": active.get("source"),
         "active_anchor_policy": active.get("anchor_policy"),
         "active_rotation_deg": round(math.degrees(rotation), 4) if rotation is not None else None,
+        "vendor_source": vendor_source,
         "vendor_metadata": metadata,
         "candidate_offsets": candidates,
         "absolute_reference_relations": relations,
+        "cartographic_frame": dict(active.get("cartographic_frame") or {}),
     }
 
 

--- a/custom_components/navimower/georeference_reference_diagnostics.py
+++ b/custom_components/navimower/georeference_reference_diagnostics.py
@@ -8,6 +8,8 @@ from typing import Any
 from . import georeference as geo
 
 _FLOAT_RE = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
+_STATIC_SOURCE = "vendor_map_static_fit"
+_X3_SOURCE = "x3_rtk_anchor"
 
 
 def _vector(
@@ -32,7 +34,9 @@ def _vector(
     }
 
 
-def _active_point(active: Any, local: tuple[float, float] | None) -> tuple[float, float] | None:
+def _active_point(
+    active: Any, local: tuple[float, float] | None
+) -> tuple[float, float] | None:
     if not isinstance(active, dict) or local is None:
         return None
     return geo.local_xy_to_wgs84(active, local[0], local[1])
@@ -65,6 +69,23 @@ def _raw_rtk_anchor(geometry: dict[str, Any]) -> tuple[float, float] | None:
     if not (-90.0 <= latitude <= 90.0 and -180.0 <= longitude <= 180.0):
         return None
     return latitude, longitude
+
+
+def _transform_complete(value: Any) -> bool:
+    """Return whether a raw vendor transform can project local map points."""
+    if not isinstance(value, dict):
+        return False
+    reference = value.get("reference") or {}
+    return all(
+        geo._float(item) is not None  # noqa: SLF001
+        for item in (
+            reference.get("local_x"),
+            reference.get("local_y"),
+            reference.get("latitude"),
+            reference.get("longitude"),
+            value.get("rotation_rad"),
+        )
+    )
 
 
 def _vendor_georeference(geometry: dict[str, Any]) -> dict[str, Any] | None:
@@ -109,7 +130,7 @@ def reference_candidate_diagnostics(
     """Compare cached absolute map references without changing the map.
 
     Raw map-detail is reduced before it reaches the normal coordinator cache.
-    Beta16 therefore also reads the normalized ``_vendor_georeference`` evidence
+    Beta16 therefore also reads normalized ``_vendor_georeference`` evidence
     retained during map decoding instead of assuming the reduced geometry still
     contains raw ``*_gps`` and ``rtk`` fields.
 
@@ -125,11 +146,20 @@ def reference_candidate_diagnostics(
     vendor_meta = vendor.get("vendor_metadata")
     vendor_meta = vendor_meta if isinstance(vendor_meta, dict) else {}
     vendor_source = vendor.get("source")
+    explicit_vendor = (
+        vendor_source == "vendor_map_detail"
+        and _transform_complete(vendor)
+    )
+    static_vendor = vendor_source == _STATIC_SOURCE or (
+        (vendor.get("static_validation") or {}).get("valid") is True
+    )
 
     center_local = geo._xy(geometry.get("map_circle_center"))  # noqa: SLF001
     if center_local is None:
-        center_local = geo._xy(vendor_meta.get("map_circle_center_local"))  # noqa: SLF001
-    if center_local is None and vendor_source == "vendor_map_detail":
+        center_local = geo._xy(  # noqa: SLF001
+            vendor_meta.get("map_circle_center_local")
+        )
+    if center_local is None and explicit_vendor:
         reference = vendor.get("reference") or {}
         local_x = geo._float(reference.get("local_x"))  # noqa: SLF001
         local_y = geo._float(reference.get("local_y"))  # noqa: SLF001
@@ -150,8 +180,14 @@ def reference_candidate_diagnostics(
     origin_local = (0.0, 0.0)
     sw_local = ne_local = None
     if center_local is not None and width is not None and height is not None:
-        sw_local = (center_local[0] - width / 2.0, center_local[1] - height / 2.0)
-        ne_local = (center_local[0] + width / 2.0, center_local[1] + height / 2.0)
+        sw_local = (
+            center_local[0] - width / 2.0,
+            center_local[1] - height / 2.0,
+        )
+        ne_local = (
+            center_local[0] + width / 2.0,
+            center_local[1] + height / 2.0,
+        )
 
     origin_gps = geo._gps(geometry.get("origin_gps"))  # noqa: SLF001
     if origin_gps is None:
@@ -160,10 +196,12 @@ def reference_candidate_diagnostics(
     center_gps = geo._gps(geometry.get("center_gps"))  # noqa: SLF001
     if center_gps is None:
         center_gps = _dict_gps(vendor.get("center"))
-    if center_gps is None and vendor_source == "vendor_map_detail":
+    if center_gps is None and explicit_vendor:
         center_gps = _dict_gps(vendor.get("reference"))
 
-    bounds = vendor.get("bounds") if isinstance(vendor.get("bounds"), dict) else {}
+    bounds = (
+        vendor.get("bounds") if isinstance(vendor.get("bounds"), dict) else {}
+    )
     sw_gps = geo._gps(geometry.get("sw_gps"))  # noqa: SLF001
     if sw_gps is None:
         sw_gps = _dict_gps(bounds.get("south_west"))
@@ -171,10 +209,18 @@ def reference_candidate_diagnostics(
     if ne_gps is None:
         ne_gps = _dict_gps(bounds.get("north_east"))
 
-    rtk_anchor = _dict_gps(vendor.get("rtk_anchor")) or _raw_rtk_anchor(geometry)
+    rtk_anchor = _dict_gps(vendor.get("rtk_anchor")) or _raw_rtk_anchor(
+        geometry
+    )
 
     candidates: dict[str, Any] = {}
-    if vendor_source == "vendor_map_static_fit" or geo._float(geometry.get("map_north_offset")) is None:  # noqa: SLF001
+    raw_static_fallback = (
+        vendor_source is None
+        and geo._float(geometry.get("map_north_offset")) is None  # noqa: SLF001
+        and origin_gps is not None
+        and center_gps is not None
+    )
+    if static_vendor or raw_static_fallback:
         _add_candidate(
             candidates,
             "vendor_origin_gps_at_local_origin",
@@ -205,13 +251,15 @@ def reference_candidate_diagnostics(
         meaning="vendor center_gps at map_circle_center",
     )
 
-    if vendor_source == "vendor_map_detail" and geo.georeference_is_valid(vendor):
+    if explicit_vendor:
         _add_candidate(
             candidates,
             "explicit_vendor_transform_at_origin",
             _active_point(active, origin_local),
             _active_point(vendor, origin_local),
-            meaning="explicit map_north_offset vendor transform evaluated at local (0,0)",
+            meaning=(
+                "explicit map_north_offset vendor transform evaluated at local (0,0)"
+            ),
         )
 
     learned = _learned_fit(geometry)
@@ -242,7 +290,11 @@ def reference_candidate_diagnostics(
             meaning="current private-cloud GPS at current private-cloud local X/Y",
         )
 
-        station = geometry.get("station") if isinstance(geometry.get("station"), dict) else {}
+        station = (
+            geometry.get("station")
+            if isinstance(geometry.get("station"), dict)
+            else {}
+        )
         station_x = geo._float(station.get("x"))  # noqa: SLF001
         station_y = geo._float(station.get("y"))  # noqa: SLF001
         if docked and station_x is not None and station_y is not None:
@@ -262,21 +314,33 @@ def reference_candidate_diagnostics(
     if center_minus_origin is not None:
         relations["center_gps_minus_origin_gps"] = center_minus_origin
 
-    raw_rtk = geometry.get("rtk") if isinstance(geometry.get("rtk"), dict) else {}
+    raw_rtk = (
+        geometry.get("rtk") if isinstance(geometry.get("rtk"), dict) else {}
+    )
     raw_bias = raw_rtk.get("bias") if isinstance(raw_rtk, dict) else None
     raw_pile = raw_rtk.get("pile") if isinstance(raw_rtk, dict) else None
     metadata = {
         "map_north_offset_present": bool(
             vendor_meta.get("map_north_offset_present")
-            or vendor_source == "vendor_map_detail"
+            or explicit_vendor
             or geo._float(geometry.get("map_north_offset")) is not None  # noqa: SLF001
             or geo._float(geometry.get("north_offset")) is not None  # noqa: SLF001
         ),
-        "origin_gps_present": bool(vendor_meta.get("origin_gps_present") or origin_gps is not None),
-        "center_gps_present": bool(vendor_meta.get("center_gps_present") or center_gps is not None),
-        "south_west_gps_present": bool(vendor_meta.get("south_west_gps_present") or sw_gps is not None),
-        "north_east_gps_present": bool(vendor_meta.get("north_east_gps_present") or ne_gps is not None),
-        "rtk_anchor_present": bool(vendor_meta.get("rtk_anchor_present") or rtk_anchor is not None),
+        "origin_gps_present": bool(
+            vendor_meta.get("origin_gps_present") or origin_gps is not None
+        ),
+        "center_gps_present": bool(
+            vendor_meta.get("center_gps_present") or center_gps is not None
+        ),
+        "south_west_gps_present": bool(
+            vendor_meta.get("south_west_gps_present") or sw_gps is not None
+        ),
+        "north_east_gps_present": bool(
+            vendor_meta.get("north_east_gps_present") or ne_gps is not None
+        ),
+        "rtk_anchor_present": bool(
+            vendor_meta.get("rtk_anchor_present") or rtk_anchor is not None
+        ),
         "rtk_bias_present": bool(
             vendor_meta.get("rtk_bias_present")
             or (isinstance(raw_bias, str) and "nrtk_lrtk_bias" in raw_bias)
@@ -295,10 +359,14 @@ def reference_candidate_diagnostics(
     return {
         "read_only": True,
         "available": True,
-        "convention": "candidate_minus_active; east/north metres; bearing clockwise from north",
+        "convention": (
+            "candidate_minus_active; east/north metres; bearing clockwise from north"
+        ),
         "active_source": active.get("source"),
         "active_anchor_policy": active.get("anchor_policy"),
-        "active_rotation_deg": round(math.degrees(rotation), 4) if rotation is not None else None,
+        "active_rotation_deg": (
+            round(math.degrees(rotation), 4) if rotation is not None else None
+        ),
         "vendor_source": vendor_source,
         "vendor_metadata": metadata,
         "candidate_offsets": candidates,

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta15"
+  "version": "0.4.4-beta16"
 }

--- a/custom_components/navimower/runtime.py
+++ b/custom_components/navimower/runtime.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from .capability_extensions import install_capability_extensions
 from .capability_profile import install_capability_profile
 from .capability_semantics import install_capability_semantics
+from .georeference_cartographic_semantics import install_georeference_cartographic_semantics
 from .georeference_diagnostics_semantics import install_georeference_diagnostics_semantics
 from .georeference_semantics import install_georeference_semantics
 from .georeference_static_anchor_semantics import install_georeference_static_anchor_semantics
@@ -35,6 +36,7 @@ def install_runtime_extensions() -> None:
     install_georeference_semantics()
     install_georeference_static_anchor_semantics()
     install_georeference_x3_bias_semantics()
+    install_georeference_cartographic_semantics()
     install_georeference_diagnostics_semantics()
     install_navigation_fallback()
     install_notification_feed()

--- a/tests/test_v044_beta15.py
+++ b/tests/test_v044_beta15.py
@@ -43,7 +43,9 @@ _I108 = {
 
 def test_beta15_version_and_release_notes() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.4-beta15"
+    version = manifest["version"]
+    assert version.startswith("0.4.4-beta")
+    assert int(version.rsplit("beta", 1)[1]) >= 15
     notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta15.md").read_text(
         encoding="utf-8"
     )
@@ -72,9 +74,6 @@ def test_h2_reports_rtk_and_explicit_reference_relationships_without_mutation() 
     candidates = diagnostics["candidate_offsets"]
     assert candidates["vendor_center_gps"]["candidate_minus_active"]["distance_m"] < 0.001
     assert candidates["explicit_vendor_transform_at_origin"]["candidate_minus_active"]["distance_m"] < 0.001
-    # But H2 origin_gps is not consistent with treating it as local map (0,0),
-    # which is exactly why beta15 labels this only as a hypothesis check.
-    assert candidates["vendor_origin_gps_at_local_origin_hypothesis"]["candidate_minus_active"]["distance_m"] > 1.0
 
     assert geometry == geometry_before
     assert active == active_before
@@ -89,7 +88,7 @@ def test_i1_static_fit_exposes_submetre_vendor_tie_residual_vectors() -> None:
     assert diagnostics["vendor_metadata"]["rtk_anchor_present"] is False
     candidates = diagnostics["candidate_offsets"]
     for name in (
-        "vendor_origin_gps_at_local_origin_hypothesis",
+        "vendor_origin_gps_at_local_origin",
         "vendor_center_gps",
         "vendor_south_west_gps",
         "vendor_north_east_gps",

--- a/tests/test_v044_beta16.py
+++ b/tests/test_v044_beta16.py
@@ -1,0 +1,232 @@
+"""Regression tests for Navimower 0.4.4-beta16 cartographic alignment."""
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+import math
+from pathlib import Path
+
+from custom_components.navimower import georeference as geo
+from custom_components.navimower import georeference_cartographic_semantics as cart
+from custom_components.navimower.georeference_reference_diagnostics import (
+    reference_candidate_diagnostics,
+)
+from custom_components.navimower.georeference_static_anchor_semantics import (
+    _static_map_georeference,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+_H215 = {
+    "map_circle_center": [-6.547005460295729, 9.331472597744508],
+    "center_gps": [24.638553619384766, 58.384281158447266],
+    "origin_gps": [24.638547897338867, 58.38420104980469],
+    "map_north_offset": 0.5977016091346741,
+    "map_width": 90.0,
+    "map_height": 80.0,
+    "rtk": {
+        "anchor": "RTK_mode: 1\nRTK_anchor: 58.38420048 24.63854749 38.75341415",
+    },
+}
+
+_I108 = {
+    "map_circle_center": [-11.4679, 1.4973],
+    "center_gps": [24.6380367, 58.3840637],
+    "origin_gps": [24.6382313, 58.3840523],
+    "ne_gps": [24.638504, 58.3843384],
+    "sw_gps": [24.6375675, 58.3837929],
+    "map_north_offset": None,
+    "map_width": 54.7474,
+    "map_height": 61.053,
+}
+
+
+def test_beta16_version_release_notes_and_runtime_order() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.4-beta16"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta16.md").read_text(
+        encoding="utf-8"
+    )
+    for phrase in (
+        "EPSG:8366",
+        "translation only",
+        "0.93 m",
+        "X3",
+        "ITRF2014-like dynamic GNSS",
+    ):
+        assert phrase in notes
+
+    runtime = (COMPONENT / "runtime.py").read_text(encoding="utf-8")
+    x3_index = runtime.index("install_georeference_x3_bias_semantics()")
+    cartographic_index = runtime.index("install_georeference_cartographic_semantics()")
+    diagnostics_index = runtime.index("install_georeference_diagnostics_semantics()")
+    assert x3_index < cartographic_index < diagnostics_index
+
+
+def test_epsg8366_estonia_offset_matches_proj_reference_value() -> None:
+    correction = cart._itrf2014_to_etrf2014_offset(  # noqa: SLF001
+        58.3842,
+        24.63855,
+        2026.67,
+    )
+    assert correction is not None
+    assert math.isclose(correction["east_m"], -0.7663, abs_tol=0.003)
+    assert math.isclose(correction["north_m"], -0.5197, abs_tol=0.003)
+    assert math.isclose(correction["distance_m"], 0.9259, abs_tol=0.004)
+    assert math.isclose(correction["bearing_deg_from_north"], 235.86, abs_tol=0.2)
+
+
+def test_h2_explicit_vendor_frame_gets_translation_only_cartographic_shift() -> None:
+    vendor = geo.georeference_from_geometry(deepcopy(_H215))
+    assert vendor is not None
+    active = deepcopy(vendor)
+    active.update({"schema_version": 2, "source": "cloud_location_fit", "status": "validated"})
+    geometry = {
+        "_vendor_georeference": vendor,
+        "georeference": deepcopy(active),
+        "edit_time": "1788098977",
+    }
+
+    before_reference = deepcopy(active["reference"])
+    before_rotation = active["rotation_rad"]
+    result = cart._apply_cartographic_frame(  # noqa: SLF001
+        geometry,
+        active,
+        None,
+        epoch_override=2026.67,
+    )
+    assert result is not None
+    frame = result["cartographic_frame"]
+    assert frame["applied"] is True
+    assert frame["support_kind"] == "explicit_vendor_map_north_offset"
+    assert frame["translation_only"] is True
+    assert result["source"] == "cloud_location_fit"
+    assert result["rotation_rad"] == before_rotation
+    assert result["reference"]["local_x"] == before_reference["local_x"]
+    assert result["reference"]["local_y"] == before_reference["local_y"]
+
+    displacement = geo.wgs84_offset_m(
+        before_reference["latitude"],
+        before_reference["longitude"],
+        result["reference"]["latitude"],
+        result["reference"]["longitude"],
+    )
+    assert displacement is not None
+    assert math.isclose(displacement[0], -0.766, abs_tol=0.01)
+    assert math.isclose(displacement[1], -0.520, abs_tol=0.01)
+
+
+def test_i1_static_vendor_fit_gets_same_cartographic_frame_correction() -> None:
+    vendor = _static_map_georeference(deepcopy(_I108))
+    assert vendor is not None
+    geometry = {
+        "_vendor_georeference": deepcopy(vendor),
+        "georeference": deepcopy(vendor),
+        "edit_time": "1781273946",
+    }
+    result = cart._apply_cartographic_frame(  # noqa: SLF001
+        geometry,
+        vendor,
+        None,
+        epoch_override=2026.67,
+    )
+    assert result is not None
+    frame = result["cartographic_frame"]
+    assert frame["applied"] is True
+    assert frame["support_kind"] == "static_vendor_ties"
+    assert result["source"] == "vendor_map_static_fit"
+    assert math.isclose(frame["distance_m"], 0.926, abs_tol=0.01)
+
+
+def test_x3_vendor_rtk_translation_is_never_stacked_with_etrs89_shift() -> None:
+    active = {
+        "schema_version": 2,
+        "source": "x3_rtk_anchor",
+        "status": "validated",
+        "reference": {
+            "local_x": 0.0,
+            "local_y": 0.0,
+            "latitude": 59.1806,
+            "longitude": 26.8622,
+        },
+        "rotation_rad": 0.0,
+        "rtk_validation": {
+            "bias_correction": {"applied": True},
+        },
+    }
+    geometry = {"_vendor_georeference": deepcopy(active), "georeference": deepcopy(active)}
+    result = cart._apply_cartographic_frame(  # noqa: SLF001
+        geometry,
+        active,
+        None,
+        epoch_override=2026.67,
+    )
+    assert result is not None
+    assert result["reference"] == active["reference"]
+    assert result["cartographic_frame"]["applied"] is False
+    assert result["cartographic_frame"]["reason"] == "x3_vendor_rtk_frame_owns_translation"
+
+
+def test_epsg8366_correction_is_not_applied_outside_europe() -> None:
+    vendor = {
+        "schema_version": 1,
+        "source": "vendor_map_detail",
+        "status": "validated",
+        "reference": {
+            "local_x": 0.0,
+            "local_y": 0.0,
+            "latitude": 37.7749,
+            "longitude": -122.4194,
+        },
+        "rotation_rad": 0.0,
+    }
+    active = deepcopy(vendor)
+    active["source"] = "cloud_location_fit"
+    geometry = {"_vendor_georeference": vendor}
+    result = cart._apply_cartographic_frame(  # noqa: SLF001
+        geometry,
+        active,
+        None,
+        epoch_override=2026.67,
+    )
+    assert result is not None
+    assert result["reference"] == active["reference"]
+    assert result["cartographic_frame"]["applied"] is False
+    assert result["cartographic_frame"]["reason"] == "outside_epsg8366_area"
+
+
+def test_reference_diagnostics_use_cached_vendor_evidence_after_geometry_reduction() -> None:
+    vendor = geo.georeference_from_geometry(deepcopy(_H215))
+    assert vendor is not None
+    vendor = deepcopy(vendor)
+    vendor["vendor_metadata"] = {
+        "map_north_offset_present": True,
+        "origin_gps_present": True,
+        "center_gps_present": True,
+        "south_west_gps_present": False,
+        "north_east_gps_present": False,
+        "rtk_anchor_present": True,
+        "rtk_bias_present": False,
+        "rtk_pile_present": False,
+        "map_circle_center_local": list(_H215["map_circle_center"]),
+        "map_width_m": 90.0,
+        "map_height_m": 80.0,
+    }
+    vendor["rtk_anchor"] = {
+        "latitude": 58.38420048,
+        "longitude": 24.63854749,
+        "altitude_m": 38.75341415,
+    }
+    geometry = {
+        "_vendor_georeference": vendor,
+        "station": {"x": -0.3309, "y": -2.7012},
+    }
+    diagnostics = reference_candidate_diagnostics(geometry, vendor)
+    metadata = diagnostics["vendor_metadata"]
+    assert metadata["map_north_offset_present"] is True
+    assert metadata["origin_gps_present"] is True
+    assert metadata["center_gps_present"] is True
+    assert metadata["rtk_anchor_present"] is True
+    relation = diagnostics["absolute_reference_relations"]["rtk_anchor_minus_origin_gps"]
+    assert relation["distance_m"] < 0.2


### PR DESCRIPTION
## Summary
- add an experimental EPSG:8366 ITRF2014-like -> ETRF2014/ETRS89 cartographic translation for European H2/i1-style map frames
- keep local X/Y, rotation, scale and the native GPS device_tracker unchanged
- exclude X3 so beta14 RTK_anchor + refined nrtk_lrtk_bias remains authoritative
- derive coordinate epoch from map edit time or current georeference samples
- retain normalized vendor reference evidence and fix beta15 diagnostics after reduced map caching
- add cartographic-frame diagnostics, one-time beta15 cache refresh, tests and beta16 release metadata

Field expectation for the captured Estonia data at epoch 2026.67: about -0.77 m East / -0.52 m North (0.93 m south-west), translation only.