### PR TITLE
Validate beta17 geodesy reset

### DIFF
--- a/.github/validation-beta17.txt
+++ b/.github/validation-beta17.txt
@@ -1,0 +1,1 @@
+Temporary validation trigger for Navimower 0.4.4-beta17 geodesy reset.


### PR DESCRIPTION
Temporary validation PR for the current main tree after the beta17 WGS84 ellipsoid geodesy reset. The only branch-only change is a validation marker file; close without merging after checks complete.