### PR TITLE
Navimower 0.4.4-beta20: refine static-map translation from cloud fit

### DIFF
--- a/.github/release-notes/0.4.4-beta20.md
+++ b/.github/release-notes/0.4.4-beta20.md
@@ -1,0 +1,27 @@
+title: Navimower 0.4.4-beta20
+
+## Refine static-map translation from live cloud evidence
+
+- Keep validated vendor static map geometry authoritative for local X/Y, zone shape, rotation and scale.
+- When a static-map georeference also has a mature WGS84-ellipsoid cloud XY/GPS fit, allow that fit to refine **translation only**.
+- The refinement is evidence-driven rather than model-name hard-coded: it requires at least 8 inlier samples, at least 15 m baseline, <=0.75 m RMS, <=1.5 m max point error, observed scale 0.98-1.02, <=2 degrees rotation disagreement and a translation between 0.25 m and 4.0 m.
+- X3 remains excluded because its vendor `RTK_anchor + nrtk_lrtk_bias` path already owns absolute translation.
+
+## i1 / i108 field evidence
+
+- Fresh beta18/beta19 i108 data showed that the vendor static map ties are internally strong while the paired private-cloud local X/Y + GPS fit disagrees mainly by a common translation of roughly 1.7 m toward clock 4.
+- beta20 uses that measured cloud fit as the translation refinement instead of hard-coding an i1-specific metre/direction offset.
+- The later beta19 EPSG:8366 ETRS89 cartographic translation is still applied separately, after the vendor-frame translation refinement.
+
+## Diagnostics
+
+- Reference candidates are now normalized into the same active cartographic frame before `candidate_minus_active` vectors are reported.
+- This removes the artificial inclusion of the common ETRS89 translation in raw cloud/vendor candidate residuals and makes the remaining model/map-specific translation directly readable.
+- The active georeference exposes `translation_refinement` metadata with the applied vector, quality evidence and guard reason.
+
+## Field test
+
+- On i1/i108, the whole mower + zones + dock group should move together toward the cloud-derived absolute translation while mower position relative to its local map remains unchanged.
+- H2 should remain on its existing explicit vendor-angle path and should not receive this static-map refinement.
+- X3 should remain unchanged by this beta.
+- Capture a new raw export after updating so the refined translation, post-ETRS89 residuals and candidate-frame normalization can be checked independently.

--- a/custom_components/navimower/georeference_diagnostics_frame_semantics.py
+++ b/custom_components/navimower/georeference_diagnostics_frame_semantics.py
@@ -1,0 +1,125 @@
+"""Normalize absolute-reference diagnostics into the active cartographic frame.
+
+The reference-candidate collector compares raw vendor/cloud GPS points with the
+active map reference. Once the active map has received the European ETRS89
+presentation translation, those raw candidates must receive the same translation
+before their residual is interpreted. Otherwise diagnostics artificially include
+the common cartographic shift in every candidate-minus-active vector.
+"""
+from __future__ import annotations
+
+import math
+from typing import Any, Callable
+
+from . import georeference_reference_diagnostics as _reference
+
+_INSTALLED = False
+_ORIGINAL_REFERENCE_DIAGNOSTICS: Callable[..., dict[str, Any]] | None = None
+
+
+def _bearing(east_m: float, north_m: float) -> float:
+    return (math.degrees(math.atan2(east_m, north_m)) + 360.0) % 360.0
+
+
+def _normalized_reference_candidate_diagnostics(
+    geometry: Any,
+    active: Any,
+    location: Any = None,
+    *,
+    docked: bool = False,
+) -> dict[str, Any]:
+    if _ORIGINAL_REFERENCE_DIAGNOSTICS is None:
+        return {"read_only": True, "available": False}
+
+    result = _ORIGINAL_REFERENCE_DIAGNOSTICS(
+        geometry,
+        active,
+        location,
+        docked=docked,
+    )
+    if not isinstance(result, dict):
+        return result
+
+    frame = result.get("cartographic_frame")
+    frame = frame if isinstance(frame, dict) else {}
+    if frame.get("applied") is not True:
+        result["candidate_cartographic_normalization"] = {
+            "applied": False,
+            "reason": "active_cartographic_translation_not_applied",
+        }
+        return result
+
+    try:
+        frame_east = float(frame.get("east_m"))
+        frame_north = float(frame.get("north_m"))
+    except (TypeError, ValueError):
+        result["candidate_cartographic_normalization"] = {
+            "applied": False,
+            "reason": "active_cartographic_translation_missing",
+        }
+        return result
+    if not math.isfinite(frame_east) or not math.isfinite(frame_north):
+        result["candidate_cartographic_normalization"] = {
+            "applied": False,
+            "reason": "active_cartographic_translation_invalid",
+        }
+        return result
+
+    candidates = result.get("candidate_offsets")
+    candidates = candidates if isinstance(candidates, dict) else {}
+    normalized_count = 0
+    for candidate in candidates.values():
+        if not isinstance(candidate, dict):
+            continue
+        delta = candidate.get("candidate_minus_active")
+        if not isinstance(delta, dict):
+            continue
+        try:
+            east = float(delta.get("east_m")) + frame_east
+            north = float(delta.get("north_m")) + frame_north
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(east) or not math.isfinite(north):
+            continue
+        delta.update(
+            {
+                "east_m": round(east, 3),
+                "north_m": round(north, 3),
+                "distance_m": round(math.hypot(east, north), 3),
+                "bearing_deg_from_north": round(_bearing(east, north), 2),
+            }
+        )
+        candidate["comparison_frame"] = "active_cartographic_frame"
+        normalized_count += 1
+
+    result["candidate_cartographic_normalization"] = {
+        "applied": True,
+        "method": "add_active_translation_to_raw_candidate",
+        "east_m": round(frame_east, 3),
+        "north_m": round(frame_north, 3),
+        "candidate_count": normalized_count,
+    }
+    result["convention"] = (
+        "candidate_minus_active in active cartographic frame; east/north metres; "
+        "bearing clockwise from north"
+    )
+    return result
+
+
+def install_georeference_diagnostics_frame_semantics() -> None:
+    """Patch candidate diagnostics after cartographic semantics are installed."""
+    global _INSTALLED, _ORIGINAL_REFERENCE_DIAGNOSTICS
+    if _INSTALLED:
+        return
+
+    from . import georeference_diagnostics_semantics as _diagnostics
+
+    _ORIGINAL_REFERENCE_DIAGNOSTICS = _reference.reference_candidate_diagnostics
+    _reference.reference_candidate_diagnostics = _normalized_reference_candidate_diagnostics
+    # georeference_diagnostics_semantics imports the function directly at module
+    # import time, so update that bound reference as well.
+    _diagnostics.reference_candidate_diagnostics = _normalized_reference_candidate_diagnostics
+    _INSTALLED = True
+
+
+__all__ = ["install_georeference_diagnostics_frame_semantics"]

--- a/custom_components/navimower/georeference_translation_refinement_semantics.py
+++ b/custom_components/navimower/georeference_translation_refinement_semantics.py
@@ -1,0 +1,304 @@
+"""Refine static vendor map translation from trustworthy cloud XY/GPS fits.
+
+Some map generations expose internally excellent static origin/center/bounds ties
+while their common absolute translation disagrees with the mower's paired local
+X/Y + GPS observations. Keep the vendor static map geometry (rotation and local
+shape) authoritative and use a mature learned cloud fit only to refine the
+translation component.
+
+This is deliberately evidence-driven rather than model-name driven. X3 RTK
+anchors are excluded because their vendor RTK/bias path already owns absolute
+translation. The learned fit must pass tighter quality guards than the generic
+fallback georeference before it is allowed to move a static map.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+from typing import Any, Callable
+
+from . import georeference as _georeference
+
+_STATIC_SOURCE = "vendor_map_static_fit"
+_X3_SOURCE = "x3_rtk_anchor"
+_GEOSY_MODEL = "wgs84_ellipsoid_v1"
+
+_MIN_SAMPLE_COUNT = 8
+_MIN_BASELINE_M = 15.0
+_MAX_RMS_ERROR_M = 0.75
+_MAX_POINT_ERROR_M = 1.5
+_MIN_OBSERVED_SCALE = 0.98
+_MAX_OBSERVED_SCALE = 1.02
+_MAX_ROTATION_DIFFERENCE_DEG = 2.0
+_MIN_TRANSLATION_M = 0.25
+_MAX_TRANSLATION_M = 4.0
+
+_INSTALLED = False
+_ORIGINAL_UPDATE: Callable[[Any, Any], dict[str, Any] | None] | None = None
+
+
+def _bearing(east_m: float, north_m: float) -> float:
+    return (math.degrees(math.atan2(east_m, north_m)) + 360.0) % 360.0
+
+
+def _rotation_difference_deg(first: Any, second: Any) -> float | None:
+    first_rotation = _georeference._float(  # noqa: SLF001
+        first.get("rotation_rad") if isinstance(first, dict) else None
+    )
+    second_rotation = _georeference._float(  # noqa: SLF001
+        second.get("rotation_rad") if isinstance(second, dict) else None
+    )
+    if first_rotation is None or second_rotation is None:
+        return None
+    delta = (second_rotation - first_rotation + math.pi) % (2.0 * math.pi) - math.pi
+    return abs(math.degrees(delta))
+
+
+def _learned_fit(map_geometry: dict[str, Any]) -> dict[str, Any] | None:
+    calibration = map_geometry.get("_georeference_calibration")
+    if not isinstance(calibration, dict):
+        return None
+    fit = calibration.get("fit")
+    if not isinstance(fit, dict) or not _georeference.georeference_is_valid(fit):
+        return None
+    return fit
+
+
+def _quality_guard(
+    map_geometry: dict[str, Any],
+    static: dict[str, Any],
+    learned: dict[str, Any],
+) -> tuple[bool, str, dict[str, Any]]:
+    calibration_state = map_geometry.get("_georeference_calibration")
+    calibration_state = calibration_state if isinstance(calibration_state, dict) else {}
+    metrics = learned.get("calibration")
+    metrics = metrics if isinstance(metrics, dict) else {}
+
+    sample_count = int(metrics.get("inlier_count") or metrics.get("sample_count") or 0)
+    baseline_m = _georeference._float(metrics.get("baseline_m"))  # noqa: SLF001
+    rms_error_m = _georeference._float(metrics.get("rms_error_m"))  # noqa: SLF001
+    max_error_m = _georeference._float(metrics.get("max_error_m"))  # noqa: SLF001
+    observed_scale = _georeference._float(metrics.get("observed_scale"))  # noqa: SLF001
+    rotation_difference_deg = _rotation_difference_deg(static, learned)
+    geodesy_model = (
+        learned.get("geodesy_model")
+        or calibration_state.get("geodesy_model")
+        or static.get("geodesy_model")
+    )
+
+    evidence = {
+        "sample_count": sample_count,
+        "baseline_m": baseline_m,
+        "rms_error_m": rms_error_m,
+        "max_error_m": max_error_m,
+        "observed_scale": observed_scale,
+        "rotation_difference_deg": (
+            round(rotation_difference_deg, 3)
+            if rotation_difference_deg is not None
+            else None
+        ),
+        "geodesy_model": geodesy_model,
+        "limits": {
+            "min_sample_count": _MIN_SAMPLE_COUNT,
+            "min_baseline_m": _MIN_BASELINE_M,
+            "max_rms_error_m": _MAX_RMS_ERROR_M,
+            "max_point_error_m": _MAX_POINT_ERROR_M,
+            "observed_scale": [_MIN_OBSERVED_SCALE, _MAX_OBSERVED_SCALE],
+            "max_rotation_difference_deg": _MAX_ROTATION_DIFFERENCE_DEG,
+            "translation_m": [_MIN_TRANSLATION_M, _MAX_TRANSLATION_M],
+        },
+    }
+
+    if geodesy_model != _GEOSY_MODEL:
+        return False, "ellipsoid_geodesy_not_confirmed", evidence
+    if sample_count < _MIN_SAMPLE_COUNT:
+        return False, "insufficient_samples", evidence
+    if baseline_m is None or baseline_m < _MIN_BASELINE_M:
+        return False, "insufficient_baseline", evidence
+    if rms_error_m is None or rms_error_m > _MAX_RMS_ERROR_M:
+        return False, "rms_error_too_large", evidence
+    if max_error_m is None or max_error_m > _MAX_POINT_ERROR_M:
+        return False, "point_error_too_large", evidence
+    if (
+        observed_scale is None
+        or not (_MIN_OBSERVED_SCALE <= observed_scale <= _MAX_OBSERVED_SCALE)
+    ):
+        return False, "observed_scale_outside_guard", evidence
+    if (
+        rotation_difference_deg is None
+        or rotation_difference_deg > _MAX_ROTATION_DIFFERENCE_DEG
+    ):
+        return False, "rotation_disagreement_too_large", evidence
+    return True, "quality_guard_passed", evidence
+
+
+def _translation_at_learned_reference(
+    static: dict[str, Any], learned: dict[str, Any]
+) -> tuple[float, float, float, float] | None:
+    learned_reference = learned.get("reference") or {}
+    anchor_x = _georeference._float(learned_reference.get("local_x"))  # noqa: SLF001
+    anchor_y = _georeference._float(learned_reference.get("local_y"))  # noqa: SLF001
+    if anchor_x is None or anchor_y is None:
+        return None
+
+    static_point = _georeference.local_xy_to_wgs84(static, anchor_x, anchor_y)
+    learned_point = _georeference.local_xy_to_wgs84(learned, anchor_x, anchor_y)
+    if static_point is None or learned_point is None:
+        return None
+
+    offset = _georeference.wgs84_offset_m(
+        static_point[0],
+        static_point[1],
+        learned_point[0],
+        learned_point[1],
+    )
+    if offset is None:
+        return None
+    east_m, north_m = offset
+    return anchor_x, anchor_y, east_m, north_m
+
+
+def _refine_static_translation(
+    map_geometry: dict[str, Any],
+    active: dict[str, Any],
+    location: Any,
+) -> dict[str, Any]:
+    if active.get("source") == _X3_SOURCE:
+        return active
+    if active.get("source") != _STATIC_SOURCE:
+        return active
+
+    learned = _learned_fit(map_geometry)
+    if learned is None:
+        return active
+
+    allowed, reason, evidence = _quality_guard(map_geometry, active, learned)
+    updated = deepcopy(active)
+    metadata: dict[str, Any] = {
+        "candidate_source": "cloud_location_fit",
+        "translation_only": True,
+        "vendor_rotation_preserved": True,
+        "quality": evidence,
+    }
+    if not allowed:
+        metadata.update({"applied": False, "reason": reason})
+        updated["translation_refinement"] = metadata
+        map_geometry["georeference"] = updated
+        return updated
+
+    translation = _translation_at_learned_reference(active, learned)
+    if translation is None:
+        metadata.update({"applied": False, "reason": "translation_projection_failed"})
+        updated["translation_refinement"] = metadata
+        map_geometry["georeference"] = updated
+        return updated
+
+    anchor_x, anchor_y, east_m, north_m = translation
+    distance_m = math.hypot(east_m, north_m)
+    if distance_m < _MIN_TRANSLATION_M:
+        metadata.update(
+            {
+                "applied": False,
+                "reason": "difference_below_refinement_threshold",
+                "east_m": round(east_m, 3),
+                "north_m": round(north_m, 3),
+                "distance_m": round(distance_m, 3),
+                "bearing_deg_from_north": round(_bearing(east_m, north_m), 2),
+            }
+        )
+        updated["translation_refinement"] = metadata
+        map_geometry["georeference"] = updated
+        return updated
+    if distance_m > _MAX_TRANSLATION_M:
+        metadata.update(
+            {
+                "applied": False,
+                "reason": "translation_exceeds_guard",
+                "east_m": round(east_m, 3),
+                "north_m": round(north_m, 3),
+                "distance_m": round(distance_m, 3),
+                "bearing_deg_from_north": round(_bearing(east_m, north_m), 2),
+            }
+        )
+        updated["translation_refinement"] = metadata
+        map_geometry["georeference"] = updated
+        return updated
+
+    reference = active.get("reference") or {}
+    latitude = _georeference._float(reference.get("latitude"))  # noqa: SLF001
+    longitude = _georeference._float(reference.get("longitude"))  # noqa: SLF001
+    if latitude is None or longitude is None:
+        metadata.update({"applied": False, "reason": "static_reference_missing"})
+        updated["translation_refinement"] = metadata
+        map_geometry["georeference"] = updated
+        return updated
+
+    corrected = _georeference.offset_wgs84(
+        latitude,
+        longitude,
+        east_m,
+        north_m,
+    )
+    if corrected is None:
+        metadata.update({"applied": False, "reason": "reference_offset_failed"})
+        updated["translation_refinement"] = metadata
+        map_geometry["georeference"] = updated
+        return updated
+
+    corrected_reference = dict(reference)
+    corrected_reference["latitude"] = corrected[0]
+    corrected_reference["longitude"] = corrected[1]
+    updated["reference"] = corrected_reference
+    updated["anchor_policy"] = "static_map_geometry_cloud_translation_refined"
+    metadata.update(
+        {
+            "applied": True,
+            "reason": "mature_cloud_fit_translation",
+            "anchor_local_x": round(anchor_x, 3),
+            "anchor_local_y": round(anchor_y, 3),
+            "east_m": round(east_m, 3),
+            "north_m": round(north_m, 3),
+            "distance_m": round(distance_m, 3),
+            "bearing_deg_from_north": round(_bearing(east_m, north_m), 2),
+        }
+    )
+    updated["translation_refinement"] = metadata
+
+    # Validate the refined vendor-geometry transform in the same raw vendor GPS
+    # frame before the later ETRS89 presentation translation is stacked on top.
+    checked = _georeference.validate_georeference(
+        updated,
+        location,
+        limit_m=_MAX_POINT_ERROR_M,
+    )
+    if isinstance(checked, dict):
+        updated["cloud_validation"] = dict(checked.get("validation") or {})
+
+    map_geometry["georeference"] = updated
+    return updated
+
+
+def _update(map_geometry: Any, location: Any) -> dict[str, Any] | None:
+    if _ORIGINAL_UPDATE is None:
+        return None
+    active = _ORIGINAL_UPDATE(map_geometry, location)
+    if not isinstance(map_geometry, dict) or not isinstance(active, dict):
+        return active
+    return _refine_static_translation(map_geometry, active, location)
+
+
+def install_georeference_translation_refinement_semantics() -> None:
+    """Install guarded translation refinement after static/X3 vendor semantics."""
+    global _INSTALLED, _ORIGINAL_UPDATE
+    if _INSTALLED:
+        return
+
+    from . import coordinator_semantics as _coordinator_semantics
+
+    _ORIGINAL_UPDATE = _georeference.update_georeference
+    _georeference.update_georeference = _update
+    _coordinator_semantics.update_georeference = _update
+    _INSTALLED = True
+
+
+__all__ = ["install_georeference_translation_refinement_semantics"]

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta19"
+  "version": "0.4.4-beta20"
 }

--- a/custom_components/navimower/runtime.py
+++ b/custom_components/navimower/runtime.py
@@ -10,6 +10,9 @@ from .capability_extensions import install_capability_extensions
 from .capability_profile import install_capability_profile
 from .capability_semantics import install_capability_semantics
 from .georeference_cartographic_semantics import install_georeference_cartographic_semantics
+from .georeference_diagnostics_frame_semantics import (
+    install_georeference_diagnostics_frame_semantics,
+)
 from .georeference_diagnostics_semantics import install_georeference_diagnostics_semantics
 from .georeference_geodesy_semantics import (
     install_georeference_geodesy_semantics,
@@ -17,6 +20,9 @@ from .georeference_geodesy_semantics import (
 )
 from .georeference_semantics import install_georeference_semantics
 from .georeference_static_anchor_semantics import install_georeference_static_anchor_semantics
+from .georeference_translation_refinement_semantics import (
+    install_georeference_translation_refinement_semantics,
+)
 from .georeference_x3_bias_semantics import install_georeference_x3_bias_semantics
 from .navigation_fallback import install_navigation_fallback
 from .notification_feed import install_notification_feed
@@ -43,14 +49,22 @@ def install_runtime_extensions() -> None:
     install_georeference_semantics()
     install_georeference_static_anchor_semantics()
     install_georeference_x3_bias_semantics()
-    # Wrap the vendor/local georeference chain first so persisted spherical fits
-    # are migrated and every fresh transform records the WGS84 ellipsoid model.
+    # Static vendor ties keep rotation/local geometry authoritative. A mature,
+    # tightly validated cloud XY/GPS fit may refine translation only. X3 is
+    # already excluded because its RTK-anchor/bias path owns translation.
+    install_georeference_translation_refinement_semantics()
+    # Wrap the vendor/local georeference chain so persisted spherical fits are
+    # migrated and every fresh transform records the WGS84 ellipsoid model.
     install_georeference_geodesy_state_semantics()
     # European static orthophotos use the ETRS89/ETRF cartographic frame. Apply
     # the small EPSG:8366 translation only after the WGS84 ellipsoid pipeline is
     # complete. The cartographic layer keeps local X/Y, rotation and scale intact
     # and explicitly excludes X3's vendor RTK-anchor/bias path.
     install_georeference_cartographic_semantics()
+    # Candidate diagnostics compare raw vendor/cloud GPS with the cartographic
+    # active map, so normalize candidates into the same presentation frame before
+    # reporting residual vectors.
+    install_georeference_diagnostics_frame_semantics()
     install_georeference_diagnostics_semantics()
     install_navigation_fallback()
     install_notification_feed()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,4 +28,13 @@ def pytest_ignore_collect(collection_path, config) -> bool:  # noqa: ARG001
         beta_name = name.removeprefix("test_v042_").removesuffix(".py")
         if version != f"0.4.2-{beta_name}":
             return True
+
+    # The 0.4.4 georeference investigation intentionally changed temporary
+    # contracts between betas (for example beta17 disabled the cartographic
+    # layer and beta19 restored it). Run only the contract matching the active
+    # 0.4.4 prerelease; permanent behavior belongs in non-versioned tests.
+    if name.startswith("test_v044_beta") and name.endswith(".py"):
+        beta_name = name.removeprefix("test_v044_").removesuffix(".py")
+        if version != f"0.4.4-{beta_name}":
+            return True
     return False

--- a/tests/test_v044_beta20.py
+++ b/tests/test_v044_beta20.py
@@ -1,0 +1,236 @@
+"""Regression tests for Navimower 0.4.4-beta20 translation refinement."""
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+import math
+from pathlib import Path
+
+from custom_components.navimower import georeference as geo
+from custom_components.navimower import georeference_cartographic_semantics as cart
+from custom_components.navimower import georeference_diagnostics_frame_semantics as diag_frame
+from custom_components.navimower import georeference_geodesy_semantics as geodesy
+from custom_components.navimower import georeference_translation_refinement_semantics as refine
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+
+
+def _static_transform() -> dict:
+    return {
+        "schema_version": 2,
+        "source": "vendor_map_static_fit",
+        "status": "validated",
+        "geodesy_model": "wgs84_ellipsoid_v1",
+        "anchor_policy": "static_map_primary",
+        "reference": {
+            "local_x": 0.0,
+            "local_y": 0.0,
+            "latitude": 58.3842,
+            "longitude": 24.63855,
+        },
+        "rotation_rad": 0.31,
+        "static_validation": {"valid": True},
+    }
+
+
+def _learned_transform(east_m: float = 1.457, north_m: float = -0.940) -> dict:
+    target = geodesy.offset_wgs84_ellipsoid(58.3842, 24.63855, east_m, north_m)
+    assert target is not None
+    return {
+        "schema_version": 2,
+        "source": "cloud_location_fit",
+        "status": "validated",
+        "geodesy_model": "wgs84_ellipsoid_v1",
+        "reference": {
+            "local_x": 0.0,
+            "local_y": 0.0,
+            "latitude": target[0],
+            "longitude": target[1],
+        },
+        "rotation_rad": 0.31 + math.radians(0.5),
+        "calibration": {
+            "sample_count": 16,
+            "inlier_count": 16,
+            "baseline_m": 46.6,
+            "rms_error_m": 0.18,
+            "max_error_m": 0.42,
+            "observed_scale": 0.9991,
+        },
+    }
+
+
+def _geometry(static: dict, learned: dict) -> dict:
+    return {
+        "revision": "map-i1",
+        "edit_time": "1781273946",
+        "_vendor_georeference": deepcopy(static),
+        "_georeference_calibration": {
+            "map_revision": "map-i1",
+            "fit": deepcopy(learned),
+            "geodesy_model": "wgs84_ellipsoid_v1",
+            "samples": [],
+        },
+        "georeference": deepcopy(static),
+    }
+
+
+def test_beta20_release_contract_and_runtime_order() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.4-beta20"
+
+    notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta20.md").read_text(
+        encoding="utf-8"
+    )
+    for phrase in (
+        "translation only",
+        "1.7 m",
+        "clock 4",
+        "X3",
+        "ETRS89",
+        "candidate_minus_active",
+    ):
+        assert phrase in notes
+
+    runtime = (COMPONENT / "runtime.py").read_text(encoding="utf-8")
+    x3 = runtime.index("install_georeference_x3_bias_semantics()")
+    refinement = runtime.index("install_georeference_translation_refinement_semantics()")
+    state = runtime.index("install_georeference_geodesy_state_semantics()")
+    cartographic = runtime.index("install_georeference_cartographic_semantics()")
+    frame_diag = runtime.index("install_georeference_diagnostics_frame_semantics()")
+    diagnostics = runtime.index("install_georeference_diagnostics_semantics()")
+    assert x3 < refinement < state < cartographic < frame_diag < diagnostics
+
+
+def test_static_geometry_keeps_rotation_and_uses_learned_translation(monkeypatch) -> None:
+    monkeypatch.setattr(geo, "offset_wgs84", geodesy.offset_wgs84_ellipsoid)
+    monkeypatch.setattr(geo, "wgs84_offset_m", geodesy.wgs84_offset_m_ellipsoid)
+
+    static = _static_transform()
+    learned = _learned_transform()
+    geometry = _geometry(static, learned)
+
+    result = refine._refine_static_translation(geometry, static, None)  # noqa: SLF001
+
+    assert result["source"] == "vendor_map_static_fit"
+    assert result["rotation_rad"] == static["rotation_rad"]
+    assert result["anchor_policy"] == "static_map_geometry_cloud_translation_refined"
+    metadata = result["translation_refinement"]
+    assert metadata["applied"] is True
+    assert math.isclose(metadata["east_m"], 1.457, abs_tol=0.003)
+    assert math.isclose(metadata["north_m"], -0.940, abs_tol=0.003)
+    assert math.isclose(metadata["distance_m"], 1.734, abs_tol=0.004)
+    assert math.isclose(metadata["bearing_deg_from_north"], 122.8, abs_tol=0.3)
+
+    projected = geo.local_xy_to_wgs84(result, 0.0, 0.0)
+    learned_projected = geo.local_xy_to_wgs84(learned, 0.0, 0.0)
+    assert projected is not None and learned_projected is not None
+    residual = geodesy.wgs84_offset_m_ellipsoid(
+        projected[0], projected[1], learned_projected[0], learned_projected[1]
+    )
+    assert residual is not None
+    assert math.hypot(*residual) < 0.01
+
+
+def test_etrs89_stacks_after_cloud_translation_refinement(monkeypatch) -> None:
+    monkeypatch.setattr(geo, "offset_wgs84", geodesy.offset_wgs84_ellipsoid)
+    monkeypatch.setattr(geo, "wgs84_offset_m", geodesy.wgs84_offset_m_ellipsoid)
+
+    static = _static_transform()
+    learned = _learned_transform()
+    geometry = _geometry(static, learned)
+    refined = refine._refine_static_translation(geometry, static, None)  # noqa: SLF001
+    before = deepcopy(refined)
+
+    result = cart._apply_cartographic_frame(  # noqa: SLF001
+        geometry,
+        refined,
+        None,
+        epoch_override=2026.67,
+    )
+    assert result is not None
+    assert result["translation_refinement"]["applied"] is True
+    assert result["rotation_rad"] == static["rotation_rad"]
+    assert result["cartographic_frame"]["applied"] is True
+
+    displacement = geodesy.wgs84_offset_m_ellipsoid(
+        before["reference"]["latitude"],
+        before["reference"]["longitude"],
+        result["reference"]["latitude"],
+        result["reference"]["longitude"],
+    )
+    assert displacement is not None
+    assert math.isclose(displacement[0], -0.766, abs_tol=0.01)
+    assert math.isclose(displacement[1], -0.520, abs_tol=0.01)
+
+
+def test_x3_and_explicit_h2_paths_are_not_translation_refined() -> None:
+    learned = _learned_transform()
+    geometry = _geometry(_static_transform(), learned)
+
+    x3 = _static_transform()
+    x3["source"] = "x3_rtk_anchor"
+    x3["anchor_policy"] = "x3_rtk_anchor_bias_primary"
+    assert refine._refine_static_translation(geometry, x3, None) == x3  # noqa: SLF001
+
+    h2 = _static_transform()
+    h2["source"] = "vendor_map_detail"
+    h2["anchor_policy"] = "explicit_vendor_map_north_offset"
+    assert refine._refine_static_translation(geometry, h2, None) == h2  # noqa: SLF001
+
+
+def test_translation_refinement_requires_mature_fit() -> None:
+    static = _static_transform()
+    learned = _learned_transform()
+    learned["calibration"]["sample_count"] = 5
+    learned["calibration"]["inlier_count"] = 5
+    geometry = _geometry(static, learned)
+
+    result = refine._refine_static_translation(geometry, static, None)  # noqa: SLF001
+    metadata = result["translation_refinement"]
+    assert metadata["applied"] is False
+    assert metadata["reason"] == "insufficient_samples"
+    assert result["reference"] == static["reference"]
+
+
+def test_candidate_diagnostics_remove_common_cartographic_translation(monkeypatch) -> None:
+    raw = {
+        "read_only": True,
+        "available": True,
+        "convention": "candidate_minus_active",
+        "cartographic_frame": {
+            "applied": True,
+            "east_m": -0.762,
+            "north_m": -0.517,
+        },
+        "candidate_offsets": {
+            "private_cloud_live_gps": {
+                "meaning": "current private-cloud GPS",
+                "candidate_minus_active": {
+                    "east_m": 2.219,
+                    "north_m": -0.423,
+                    "distance_m": 2.259,
+                    "bearing_deg_from_north": 100.8,
+                },
+            }
+        },
+    }
+
+    monkeypatch.setattr(
+        diag_frame,
+        "_ORIGINAL_REFERENCE_DIAGNOSTICS",
+        lambda *args, **kwargs: deepcopy(raw),
+    )
+    result = diag_frame._normalized_reference_candidate_diagnostics(  # noqa: SLF001
+        {}, {}, None
+    )
+    delta = result["candidate_offsets"]["private_cloud_live_gps"][
+        "candidate_minus_active"
+    ]
+    assert math.isclose(delta["east_m"], 1.457, abs_tol=0.001)
+    assert math.isclose(delta["north_m"], -0.940, abs_tol=0.001)
+    assert math.isclose(delta["distance_m"], 1.734, abs_tol=0.004)
+    assert math.isclose(delta["bearing_deg_from_north"], 122.8, abs_tol=0.3)
+    normalization = result["candidate_cartographic_normalization"]
+    assert normalization["applied"] is True
+    assert normalization["candidate_count"] == 1


### PR DESCRIPTION
Field-test follow-up to beta19.

- Keep vendor static-map rotation/local geometry authoritative.
- Refine translation only from a mature WGS84-ellipsoid cloud XY/GPS fit under tight quality guards.
- Exclude X3 RTK-anchor/bias maps.
- Keep the ETRS89 cartographic translation as the later, separate presentation-frame step.
- Normalize reference-candidate diagnostics into the active cartographic frame so residual vectors no longer include the common ETRS89 shift.
- Scope historical 0.4.4 beta contract tests to their matching prerelease so contradictory temporary beta contracts do not break later validation.

Expected i108 field result from the fresh evidence is about 1.7 m toward clock 4 before the separate common ETRS89 presentation shift is considered.