### PR TITLE
Validate 0.4.4-beta21 rain capability gating

### DIFF
--- a/tests/test_v044_beta21.py
+++ b/tests/test_v044_beta21.py
@@ -66,6 +66,8 @@ def test_switch_layer_gates_only_detection_and_physical_sensor() -> None:
 
     # Rain forecast and rain delay stay on their existing shared-schema paths.
     assert 'key="weather_rain"' in switch
+    assert 'translation_key="weather_rain"' in switch
+    assert 'write_key="weatherSwitch"' in switch
     assert 'key="rain_delay_mode"' in switch
     assert 'key="rain_detection"' in switch
     assert 'key="rain_sensor"' in switch


### PR DESCRIPTION
Validation-only PR for the beta21 model-aware rain controls. The actual beta21 changes are already on main; this branch adds one extra assertion that Rain forecast keeps its existing `weatherSwitch` path so the repository validation workflow runs against the complete beta21 tree.

Expected behavior:
- i1 and i2 LiDAR: no Rain detection or Rain sensor entities
- Rain forecast unchanged
- rain delay/time and forecast sensitivity unchanged
- H2/X3 split rain controls unchanged
- i2 AWD unchanged pending evidence

This PR may be closed without merge after CI succeeds.