### PR TITLE
Navimower 0.4.4-beta23: provider georeference frames

### DIFF
--- a/.github/release-notes/0.4.4-beta23.md
+++ b/.github/release-notes/0.4.4-beta23.md
@@ -1,4 +1,4 @@
-# Navimower 0.4.4-beta23
+title: Navimower 0.4.4-beta23
 
 ## Provider georeference frames
 

--- a/.github/release-notes/0.4.4-beta23.md
+++ b/.github/release-notes/0.4.4-beta23.md
@@ -1,0 +1,29 @@
+# Navimower 0.4.4-beta23
+
+## Provider georeference frames
+
+- Keep mower local X/Y geometry, zones, dock, mower position and Custom Areas in one stable map frame while exposing separate geographic references for map-underlay providers.
+- Add integration-owned `active`, `web_wgs84` and `regional_cartographic` georeference frames to the authenticated Map API frontend metadata.
+- Advertise each underlay's required reference frame: OpenStreetMap and Google Satellite use `web_wgs84`; Estonia Ortofoto and Hübriid use `regional_cartographic`.
+- Keep the frontend free of mower-model and datum-specific correction logic. The Map Card only chooses an integration-provided frame and falls back to `active` when a preferred frame is not yet trustworthy.
+
+## Dynamic/web frame
+
+- When the active map has the European EPSG:8366 cartographic translation, reconstruct the web/WGS84-like reference by undoing only that final East/North translation. Learned cloud translation refinement, vendor rotation, local X/Y and scale remain untouched.
+- For vendor RTK maps that already own their regional absolute translation, derive the web frame from a mature independent cloud local-XY/GPS fit instead of assuming an Estonia- or Europe-specific offset.
+- The cloud frame is translation-only and requires WGS84 ellipsoid geodesy, at least 8 inliers, at least 15 m baseline, RMS error <= 0.75 m, maximum point error <= 1.5 m, observed scale 0.98-1.02 and rotation agreement within 2 degrees.
+- Reject untrustworthy or implausibly large (>10 m) web-frame translations and let the frontend use the active fallback rather than inventing a global datum correction.
+
+## Regional cartographic frame
+
+- Estonia's Ortofoto/Hübriid use the active cartographic frame when EPSG:8366 was applied.
+- Vendor RTK maps that explicitly own translation keep their already validated active regional reference; no extra ETRS89 correction is stacked on top.
+- No regional-cartographic frame is claimed outside a currently supported regional provider area.
+
+## Multi mower and diagnostics
+
+- Export provider-specific translated site origins for Multi mower views so the whole site underlay can change frame without moving member geometry relative to each other.
+- Diagnostics now include only provider-frame availability, source, quality and relative metre offsets. Exact frame latitude/longitude values are not added to diagnostics.
+- Existing Google Map Tiles API key/session privacy rules are unchanged.
+
+This is the integration half of the provider-frame architecture. Navimower Map Card 0.3.6-beta13 consumes these frames directly and removes the temporary Google-specific inverse-cartographic workaround introduced in beta12.

--- a/custom_components/navimower/georeference_frames.py
+++ b/custom_components/navimower/georeference_frames.py
@@ -1,0 +1,426 @@
+"""Provider-ready geographic reference frames for map underlays.
+
+The mower map itself always stays in one local X/Y frame.  Underlay providers,
+however, can be registered to different geographic reference frames.  Resolve
+those differences in the integration so the frontend never needs model-specific
+or datum-specific geodesy.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+from typing import Any
+
+from . import georeference as _georeference
+from .map_underlay import coordinator_country_code
+
+FRAME_ACTIVE = "active"
+FRAME_WEB_WGS84 = "web_wgs84"
+FRAME_REGIONAL_CARTOGRAPHIC = "regional_cartographic"
+
+_GEOSY_MODEL = "wgs84_ellipsoid_v1"
+_MIN_SAMPLE_COUNT = 8
+_MIN_BASELINE_M = 15.0
+_MAX_RMS_ERROR_M = 0.75
+_MAX_POINT_ERROR_M = 1.5
+_MIN_OBSERVED_SCALE = 0.98
+_MAX_OBSERVED_SCALE = 1.02
+_MAX_ROTATION_DIFFERENCE_DEG = 2.0
+_MAX_WEB_TRANSLATION_M = 10.0
+
+
+def _float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _bearing(east_m: float, north_m: float) -> float:
+    return (math.degrees(math.atan2(east_m, north_m)) + 360.0) % 360.0
+
+
+def _active_georeference(coordinator: Any) -> dict[str, Any] | None:
+    data = getattr(coordinator, "data", None) or {}
+    active = data.get("georeference")
+    if not isinstance(active, dict):
+        map_data = data.get("map") if isinstance(data.get("map"), dict) else {}
+        active = map_data.get("georeference")
+    if not _georeference.georeference_is_valid(active):
+        return None
+    return active
+
+
+def _offset_summary(east_m: float, north_m: float) -> dict[str, float]:
+    distance_m = math.hypot(east_m, north_m)
+    return {
+        "east_m": round(east_m, 3),
+        "north_m": round(north_m, 3),
+        "distance_m": round(distance_m, 3),
+        "bearing_deg_from_north": round(_bearing(east_m, north_m), 2),
+    }
+
+
+def _frame(
+    *,
+    available: bool,
+    source: str,
+    georeference: dict[str, Any] | None = None,
+    offset_from_active: dict[str, Any] | None = None,
+    reason: str | None = None,
+    quality: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "available": bool(available),
+        "source": source,
+    }
+    if reason:
+        result["reason"] = reason
+    if offset_from_active is not None:
+        result["offset_from_active"] = deepcopy(offset_from_active)
+    if quality is not None:
+        result["quality"] = deepcopy(quality)
+    if georeference is not None:
+        result["georeference"] = deepcopy(georeference)
+    return result
+
+
+def _rotation_difference_deg(first: Any, second: Any) -> float | None:
+    first_rotation = _float(first.get("rotation_rad") if isinstance(first, dict) else None)
+    second_rotation = _float(second.get("rotation_rad") if isinstance(second, dict) else None)
+    if first_rotation is None or second_rotation is None:
+        return None
+    delta = (second_rotation - first_rotation + math.pi) % (2.0 * math.pi) - math.pi
+    return abs(math.degrees(delta))
+
+
+def _learned_fit(coordinator: Any) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    geometry = getattr(coordinator, "_map_geometry", None)
+    geometry = geometry if isinstance(geometry, dict) else {}
+    calibration = geometry.get("_georeference_calibration")
+    calibration = calibration if isinstance(calibration, dict) else {}
+    fit = calibration.get("fit")
+    if not isinstance(fit, dict) or not _georeference.georeference_is_valid(fit):
+        return None, calibration
+    return fit, calibration
+
+
+def _learned_quality(
+    active: dict[str, Any],
+    learned: dict[str, Any],
+    calibration_state: dict[str, Any],
+) -> tuple[bool, str, dict[str, Any]]:
+    metrics = learned.get("calibration")
+    metrics = metrics if isinstance(metrics, dict) else {}
+    sample_count = int(metrics.get("inlier_count") or metrics.get("sample_count") or 0)
+    baseline_m = _float(metrics.get("baseline_m"))
+    rms_error_m = _float(metrics.get("rms_error_m"))
+    max_error_m = _float(metrics.get("max_error_m"))
+    observed_scale = _float(metrics.get("observed_scale"))
+    rotation_difference = _rotation_difference_deg(active, learned)
+    geodesy_model = (
+        learned.get("geodesy_model")
+        or calibration_state.get("geodesy_model")
+        or active.get("geodesy_model")
+    )
+    quality = {
+        "sample_count": sample_count,
+        "baseline_m": baseline_m,
+        "rms_error_m": rms_error_m,
+        "max_error_m": max_error_m,
+        "observed_scale": observed_scale,
+        "rotation_difference_deg": (
+            round(rotation_difference, 3) if rotation_difference is not None else None
+        ),
+        "geodesy_model": geodesy_model,
+        "translation_only": True,
+        "limits": {
+            "min_sample_count": _MIN_SAMPLE_COUNT,
+            "min_baseline_m": _MIN_BASELINE_M,
+            "max_rms_error_m": _MAX_RMS_ERROR_M,
+            "max_point_error_m": _MAX_POINT_ERROR_M,
+            "observed_scale": [_MIN_OBSERVED_SCALE, _MAX_OBSERVED_SCALE],
+            "max_rotation_difference_deg": _MAX_ROTATION_DIFFERENCE_DEG,
+            "max_translation_m": _MAX_WEB_TRANSLATION_M,
+        },
+    }
+    if geodesy_model != _GEOSY_MODEL:
+        return False, "ellipsoid_geodesy_not_confirmed", quality
+    if sample_count < _MIN_SAMPLE_COUNT:
+        return False, "insufficient_samples", quality
+    if baseline_m is None or baseline_m < _MIN_BASELINE_M:
+        return False, "insufficient_baseline", quality
+    if rms_error_m is None or rms_error_m > _MAX_RMS_ERROR_M:
+        return False, "rms_error_too_large", quality
+    if max_error_m is None or max_error_m > _MAX_POINT_ERROR_M:
+        return False, "point_error_too_large", quality
+    if observed_scale is None or not (_MIN_OBSERVED_SCALE <= observed_scale <= _MAX_OBSERVED_SCALE):
+        return False, "observed_scale_outside_guard", quality
+    if rotation_difference is None or rotation_difference > _MAX_ROTATION_DIFFERENCE_DEG:
+        return False, "rotation_disagreement_too_large", quality
+    return True, "quality_guard_passed", quality
+
+
+def _translate_reference(
+    active: dict[str, Any], east_m: float, north_m: float
+) -> dict[str, Any] | None:
+    reference = active.get("reference") or {}
+    latitude = _float(reference.get("latitude"))
+    longitude = _float(reference.get("longitude"))
+    if latitude is None or longitude is None:
+        return None
+    corrected = _georeference.offset_wgs84(latitude, longitude, east_m, north_m)
+    if corrected is None:
+        return None
+    result = deepcopy(active)
+    result_reference = dict(reference)
+    result_reference["latitude"] = corrected[0]
+    result_reference["longitude"] = corrected[1]
+    result["reference"] = result_reference
+    return result
+
+
+def _web_from_inverse_cartographic(active: dict[str, Any]) -> dict[str, Any] | None:
+    frame = active.get("cartographic_frame")
+    if not isinstance(frame, dict) or frame.get("applied") is not True:
+        return None
+    east_m = _float(frame.get("east_m"))
+    north_m = _float(frame.get("north_m"))
+    if east_m is None or north_m is None:
+        return None
+    translated = _translate_reference(active, -east_m, -north_m)
+    if translated is None:
+        return None
+    translated["provider_frame"] = {
+        "name": FRAME_WEB_WGS84,
+        "source": "inverse_active_cartographic_translation",
+        "translation_only": True,
+    }
+    return _frame(
+        available=True,
+        source="inverse_active_cartographic_translation",
+        georeference=translated,
+        offset_from_active=_offset_summary(-east_m, -north_m),
+    )
+
+
+def _web_from_learned_translation(
+    coordinator: Any,
+    active: dict[str, Any],
+) -> dict[str, Any]:
+    learned, calibration_state = _learned_fit(coordinator)
+    if learned is None:
+        return _frame(
+            available=False,
+            source="cloud_translation_fit",
+            reason="learned_fit_unavailable",
+        )
+    allowed, reason, quality = _learned_quality(active, learned, calibration_state)
+    if not allowed:
+        return _frame(
+            available=False,
+            source="cloud_translation_fit",
+            reason=reason,
+            quality=quality,
+        )
+
+    reference = active.get("reference") or {}
+    local_x = _float(reference.get("local_x"))
+    local_y = _float(reference.get("local_y"))
+    active_lat = _float(reference.get("latitude"))
+    active_lon = _float(reference.get("longitude"))
+    if None in (local_x, local_y, active_lat, active_lon):
+        return _frame(
+            available=False,
+            source="cloud_translation_fit",
+            reason="active_reference_incomplete",
+            quality=quality,
+        )
+    target = _georeference.local_xy_to_wgs84(learned, local_x, local_y)
+    if target is None:
+        return _frame(
+            available=False,
+            source="cloud_translation_fit",
+            reason="learned_projection_failed",
+            quality=quality,
+        )
+    offset = _georeference.wgs84_offset_m(active_lat, active_lon, target[0], target[1])
+    if offset is None:
+        return _frame(
+            available=False,
+            source="cloud_translation_fit",
+            reason="translation_measurement_failed",
+            quality=quality,
+        )
+    east_m, north_m = offset
+    distance_m = math.hypot(east_m, north_m)
+    if distance_m > _MAX_WEB_TRANSLATION_M:
+        quality = {**quality, "measured_translation_m": round(distance_m, 3)}
+        return _frame(
+            available=False,
+            source="cloud_translation_fit",
+            reason="translation_exceeds_guard",
+            quality=quality,
+            offset_from_active=_offset_summary(east_m, north_m),
+        )
+
+    result = deepcopy(active)
+    result_reference = dict(reference)
+    result_reference["latitude"] = target[0]
+    result_reference["longitude"] = target[1]
+    result["reference"] = result_reference
+    result["provider_frame"] = {
+        "name": FRAME_WEB_WGS84,
+        "source": "cloud_translation_fit",
+        "translation_only": True,
+        "active_rotation_preserved": True,
+    }
+    return _frame(
+        available=True,
+        source="cloud_translation_fit",
+        georeference=result,
+        offset_from_active=_offset_summary(east_m, north_m),
+        quality=quality,
+    )
+
+
+def _vendor_regional_translation_owner(active: dict[str, Any]) -> bool:
+    frame = active.get("cartographic_frame")
+    if not isinstance(frame, dict) or frame.get("applied") is not False:
+        return False
+    reason = str(frame.get("reason") or "")
+    return "vendor_rtk_frame_owns_translation" in reason
+
+
+def build_georeference_frames(coordinator: Any) -> dict[str, Any]:
+    """Return provider-ready frames without changing mower/local-map geometry."""
+    active = _active_georeference(coordinator)
+    if active is None:
+        unavailable = _frame(available=False, source="unavailable", reason="active_georeference_unavailable")
+        return {
+            FRAME_ACTIVE: unavailable,
+            FRAME_WEB_WGS84: deepcopy(unavailable),
+            FRAME_REGIONAL_CARTOGRAPHIC: deepcopy(unavailable),
+        }
+
+    zero = _offset_summary(0.0, 0.0)
+    frames: dict[str, Any] = {
+        FRAME_ACTIVE: _frame(
+            available=True,
+            source="active",
+            georeference=active,
+            offset_from_active=zero,
+        )
+    }
+
+    inverse = _web_from_inverse_cartographic(active)
+    if inverse is not None:
+        frames[FRAME_WEB_WGS84] = inverse
+    elif _vendor_regional_translation_owner(active):
+        frames[FRAME_WEB_WGS84] = _web_from_learned_translation(coordinator, active)
+    else:
+        web = deepcopy(active)
+        web["provider_frame"] = {
+            "name": FRAME_WEB_WGS84,
+            "source": "active",
+            "translation_only": True,
+        }
+        frames[FRAME_WEB_WGS84] = _frame(
+            available=True,
+            source="active",
+            georeference=web,
+            offset_from_active=zero,
+        )
+
+    country_code = coordinator_country_code(coordinator)
+    cartographic = active.get("cartographic_frame")
+    cartographic_applied = isinstance(cartographic, dict) and cartographic.get("applied") is True
+    vendor_regional = _vendor_regional_translation_owner(active)
+    if country_code == "EE" and (cartographic_applied or vendor_regional):
+        regional = deepcopy(active)
+        regional["provider_frame"] = {
+            "name": FRAME_REGIONAL_CARTOGRAPHIC,
+            "source": "active_cartographic" if cartographic_applied else "vendor_rtk_regional",
+            "translation_only": True,
+        }
+        frames[FRAME_REGIONAL_CARTOGRAPHIC] = _frame(
+            available=True,
+            source="active_cartographic" if cartographic_applied else "vendor_rtk_regional",
+            georeference=regional,
+            offset_from_active=zero,
+        )
+    elif country_code == "EE":
+        frames[FRAME_REGIONAL_CARTOGRAPHIC] = _frame(
+            available=False,
+            source="active_fallback",
+            reason="regional_frame_not_confirmed",
+            offset_from_active=zero,
+        )
+    else:
+        frames[FRAME_REGIONAL_CARTOGRAPHIC] = _frame(
+            available=False,
+            source="unavailable",
+            reason="no_regional_cartographic_provider",
+        )
+    return frames
+
+
+def georeference_frame_diagnostics(coordinator: Any) -> dict[str, Any]:
+    """Return frame status/offset evidence without geographic coordinates."""
+    result: dict[str, Any] = {}
+    for name, frame in build_georeference_frames(coordinator).items():
+        result[name] = {
+            key: deepcopy(frame.get(key))
+            for key in ("available", "source", "reason", "offset_from_active", "quality")
+            if key in frame
+        }
+    return result
+
+
+def site_underlay_origins(origin: Any, coordinator: Any) -> dict[str, Any]:
+    """Translate one active Multi-mower site origin into each provider frame."""
+    if not isinstance(origin, dict):
+        return {}
+    latitude = _float(origin.get("latitude"))
+    longitude = _float(origin.get("longitude"))
+    if latitude is None or longitude is None:
+        return {}
+
+    result: dict[str, Any] = {}
+    for name, frame in build_georeference_frames(coordinator).items():
+        if frame.get("available") is not True:
+            result[name] = {
+                "available": False,
+                "source": frame.get("source"),
+                "reason": frame.get("reason"),
+            }
+            continue
+        offset = frame.get("offset_from_active") or {}
+        east_m = _float(offset.get("east_m")) or 0.0
+        north_m = _float(offset.get("north_m")) or 0.0
+        translated = _georeference.offset_wgs84(latitude, longitude, east_m, north_m)
+        if translated is None:
+            result[name] = {
+                "available": False,
+                "source": frame.get("source"),
+                "reason": "site_origin_translation_failed",
+            }
+            continue
+        result[name] = {
+            "available": True,
+            "source": frame.get("source"),
+            "latitude": translated[0],
+            "longitude": translated[1],
+        }
+    return result
+
+
+__all__ = [
+    "FRAME_ACTIVE",
+    "FRAME_REGIONAL_CARTOGRAPHIC",
+    "FRAME_WEB_WGS84",
+    "build_georeference_frames",
+    "georeference_frame_diagnostics",
+    "site_underlay_origins",
+]

--- a/custom_components/navimower/georeference_frames_semantics.py
+++ b/custom_components/navimower/georeference_frames_semantics.py
@@ -1,0 +1,102 @@
+"""Expose provider georeference frames through existing frontend/site APIs."""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Callable
+
+from .georeference_frames import (
+    FRAME_ACTIVE,
+    FRAME_REGIONAL_CARTOGRAPHIC,
+    FRAME_WEB_WGS84,
+    build_georeference_frames,
+    georeference_frame_diagnostics,
+    site_underlay_origins,
+)
+
+_INSTALLED = False
+_ORIGINAL_FRONTEND_METADATA: Callable[[Any], dict[str, Any]] | None = None
+_ORIGINAL_SITE_PAYLOAD: Callable[..., dict[str, Any]] | None = None
+_ORIGINAL_DIAGNOSTICS: Callable[..., Any] | None = None
+
+_PROVIDER_FRAMES = {
+    "openstreetmap": FRAME_WEB_WGS84,
+    "google_satellite": FRAME_WEB_WGS84,
+    "estonia_orthophoto": FRAME_REGIONAL_CARTOGRAPHIC,
+    "estonia_hybrid": FRAME_REGIONAL_CARTOGRAPHIC,
+}
+
+
+def _frontend_metadata(coordinator: Any) -> dict[str, Any]:
+    if _ORIGINAL_FRONTEND_METADATA is None:
+        return {}
+    result = deepcopy(_ORIGINAL_FRONTEND_METADATA(coordinator))
+    frames = build_georeference_frames(coordinator)
+    result["georeference_frames"] = frames
+    underlays = result.get("map_underlays")
+    if not isinstance(underlays, dict):
+        underlays = {}
+        result["map_underlays"] = underlays
+    underlays.setdefault("openstreetmap", {"available": True})
+    for provider, frame_name in _PROVIDER_FRAMES.items():
+        provider_metadata = underlays.setdefault(provider, {})
+        if not isinstance(provider_metadata, dict):
+            provider_metadata = {}
+            underlays[provider] = provider_metadata
+        provider_metadata["reference_frame"] = frame_name
+        provider_metadata["reference_frame_available"] = (
+            (frames.get(frame_name) or {}).get("available") is True
+        )
+        provider_metadata["reference_frame_fallback"] = FRAME_ACTIVE
+    return result
+
+
+def _site_payload(
+    root_entry_id: str,
+    coordinators: dict[str, Any],
+    **kwargs: Any,
+) -> dict[str, Any]:
+    if _ORIGINAL_SITE_PAYLOAD is None:
+        return {}
+    result = _ORIGINAL_SITE_PAYLOAD(root_entry_id, coordinators, **kwargs)
+    root = coordinators.get(root_entry_id)
+    if root is not None:
+        result["underlay_origins"] = site_underlay_origins(result.get("origin"), root)
+        result["underlay_reference_frames"] = dict(_PROVIDER_FRAMES)
+    return result
+
+
+async def _diagnostics(hass: Any, entry: Any) -> dict[str, Any]:
+    if _ORIGINAL_DIAGNOSTICS is None:
+        return {}
+    result = await _ORIGINAL_DIAGNOSTICS(hass, entry)
+    coordinator = ((hass.data.get("navimower") or {}).get(entry.entry_id))
+    if coordinator is not None and isinstance(result, dict):
+        result["georeference_frames"] = georeference_frame_diagnostics(coordinator)
+        notes = result.get("notes")
+        if isinstance(notes, list):
+            notes.append(
+                "Provider georeference-frame diagnostics expose only frame availability, source, quality and relative metre offsets; frame GPS references are omitted."
+            )
+    return result
+
+
+def install_georeference_frames_semantics() -> None:
+    """Install provider-frame API decoration after georeference semantics."""
+    global _INSTALLED, _ORIGINAL_FRONTEND_METADATA, _ORIGINAL_SITE_PAYLOAD, _ORIGINAL_DIAGNOSTICS
+    if _INSTALLED:
+        return
+
+    from . import diagnostics as _diagnostics_module
+    from . import map_api as _map_api
+
+    _ORIGINAL_FRONTEND_METADATA = _map_api._frontend_metadata  # noqa: SLF001
+    _ORIGINAL_SITE_PAYLOAD = _map_api.build_site_payload
+    _ORIGINAL_DIAGNOSTICS = _diagnostics_module.async_get_config_entry_diagnostics
+
+    _map_api._frontend_metadata = _frontend_metadata  # noqa: SLF001
+    _map_api.build_site_payload = _site_payload
+    _diagnostics_module.async_get_config_entry_diagnostics = _diagnostics
+    _INSTALLED = True
+
+
+__all__ = ["install_georeference_frames_semantics"]

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -1,20 +1,11 @@
 {
   "domain": "navimower",
   "name": "Navimower",
-  "codeowners": [
-    "@vahesoo"
-  ],
+  "codeowners": ["@vahesoo"],
   "config_flow": true,
-  "dependencies": [
-    "auth",
-    "http"
-  ],
   "documentation": "https://github.com/vahesoo/NaviMower",
-  "integration_type": "device",
-  "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/vahesoo/NaviMower/issues",
-  "requirements": [
-    "navimow-sdk>=0.1.2"
-  ],
-  "version": "0.4.4-beta22"
+  "iot_class": "cloud_polling",
+  "requirements": [],
+  "version": "0.4.4-beta23"
 }

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -1,11 +1,20 @@
 {
   "domain": "navimower",
   "name": "Navimower",
-  "codeowners": ["@vahesoo"],
+  "codeowners": [
+    "@vahesoo"
+  ],
   "config_flow": true,
+  "dependencies": [
+    "auth",
+    "http"
+  ],
   "documentation": "https://github.com/vahesoo/NaviMower",
-  "issue_tracker": "https://github.com/vahesoo/NaviMower/issues",
+  "integration_type": "device",
   "iot_class": "cloud_polling",
-  "requirements": [],
+  "issue_tracker": "https://github.com/vahesoo/NaviMower/issues",
+  "requirements": [
+    "navimow-sdk>=0.1.2"
+  ],
   "version": "0.4.4-beta23"
 }

--- a/custom_components/navimower/runtime.py
+++ b/custom_components/navimower/runtime.py
@@ -14,6 +14,7 @@ from .georeference_diagnostics_frame_semantics import (
     install_georeference_diagnostics_frame_semantics,
 )
 from .georeference_diagnostics_semantics import install_georeference_diagnostics_semantics
+from .georeference_frames_semantics import install_georeference_frames_semantics
 from .georeference_geodesy_semantics import (
     install_georeference_geodesy_semantics,
     install_georeference_geodesy_state_semantics,
@@ -66,6 +67,10 @@ def install_runtime_extensions() -> None:
     # reporting residual vectors.
     install_georeference_diagnostics_frame_semantics()
     install_georeference_diagnostics_semantics()
+    # Underlay providers may use a different geographic registration from the
+    # mower's active presentation frame. Export provider-ready frames only after
+    # every georeference layer above has finished composing the active transform.
+    install_georeference_frames_semantics()
     install_navigation_fallback()
     install_notification_feed()
     install_raw_mqtt_semantics()

--- a/tests/test_v044_beta23.py
+++ b/tests/test_v044_beta23.py
@@ -1,0 +1,222 @@
+"""Release contract for Navimower 0.4.4-beta23 provider georeference frames."""
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from types import SimpleNamespace
+
+from custom_components.navimower.georeference import offset_wgs84
+from custom_components.navimower.georeference_frames import (
+    FRAME_ACTIVE,
+    FRAME_REGIONAL_CARTOGRAPHIC,
+    FRAME_WEB_WGS84,
+    build_georeference_frames,
+    georeference_frame_diagnostics,
+    site_underlay_origins,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+INTEGRATION = ROOT / "custom_components" / "navimower"
+
+
+def _geo(
+    *,
+    latitude: float = 59.0,
+    longitude: float = 24.0,
+    rotation_rad: float = 0.1,
+    source: str = "vendor_map_static_fit",
+    cartographic_frame: dict | None = None,
+) -> dict:
+    value = {
+        "source": source,
+        "status": "validated",
+        "geodesy_model": "wgs84_ellipsoid_v1",
+        "reference": {
+            "local_x": 0.0,
+            "local_y": 0.0,
+            "latitude": latitude,
+            "longitude": longitude,
+        },
+        "rotation_rad": rotation_rad,
+        "validation": {"valid": True, "status": "validated"},
+    }
+    if cartographic_frame is not None:
+        value["cartographic_frame"] = cartographic_frame
+    return value
+
+
+def _coordinator(active: dict, *, fit: dict | None = None):
+    calibration = {
+        "geodesy_model": "wgs84_ellipsoid_v1",
+        "fit": fit,
+    }
+    return SimpleNamespace(
+        data={"georeference": active},
+        _map_geometry={"_georeference_calibration": calibration},
+    )
+
+
+def test_manifest_release_notes_and_runtime_order() -> None:
+    manifest = json.loads((INTEGRATION / "manifest.json").read_text())
+    assert manifest["version"] == "0.4.4-beta23"
+    notes = (ROOT / ".github" / "release-notes" / "0.4.4-beta23.md").read_text()
+    for token in (
+        "web_wgs84",
+        "regional_cartographic",
+        "OpenStreetMap",
+        "Google Satellite",
+        "15 m baseline",
+        "Multi mower",
+        "Exact frame latitude/longitude values are not added to diagnostics",
+    ):
+        assert token.lower() in notes.lower()
+
+    runtime = (INTEGRATION / "runtime.py").read_text()
+    assert "install_georeference_frames_semantics" in runtime
+    assert runtime.index("install_georeference_cartographic_semantics()") < runtime.index(
+        "install_georeference_frames_semantics()"
+    )
+
+
+def test_cartographic_active_exports_inverse_web_frame() -> None:
+    active = _geo(
+        cartographic_frame={
+            "applied": True,
+            "east_m": -0.762,
+            "north_m": -0.517,
+            "translation_only": True,
+        }
+    )
+    frames = build_georeference_frames(_coordinator(active))
+    assert frames[FRAME_ACTIVE]["available"] is True
+    assert frames[FRAME_REGIONAL_CARTOGRAPHIC]["available"] is True
+    assert frames[FRAME_REGIONAL_CARTOGRAPHIC]["source"] == "active_cartographic"
+
+    web = frames[FRAME_WEB_WGS84]
+    assert web["available"] is True
+    assert web["source"] == "inverse_active_cartographic_translation"
+    assert web["offset_from_active"]["east_m"] == 0.762
+    assert web["offset_from_active"]["north_m"] == 0.517
+    assert web["georeference"]["rotation_rad"] == active["rotation_rad"]
+    assert web["georeference"]["reference"]["local_x"] == 0.0
+    assert web["georeference"]["reference"]["local_y"] == 0.0
+
+
+def test_vendor_rtk_regional_frame_uses_mature_cloud_translation_for_web() -> None:
+    active = _geo(
+        source="x3_rtk_anchor",
+        rotation_rad=0.2,
+        cartographic_frame={
+            "applied": False,
+            "reason": "x3_vendor_rtk_frame_owns_translation",
+        },
+    )
+    target = offset_wgs84(59.0, 24.0, 0.85, 0.01)
+    assert target is not None
+    learned = _geo(
+        latitude=target[0],
+        longitude=target[1],
+        rotation_rad=0.202,
+        source="cloud_location_fit",
+    )
+    learned["calibration"] = {
+        "sample_count": 24,
+        "inlier_count": 24,
+        "baseline_m": 60.75,
+        "rms_error_m": 0.21,
+        "max_error_m": 0.419,
+        "observed_scale": 1.000739,
+    }
+
+    frames = build_georeference_frames(_coordinator(active, fit=learned))
+    regional = frames[FRAME_REGIONAL_CARTOGRAPHIC]
+    assert regional["available"] is True
+    assert regional["source"] == "vendor_rtk_regional"
+    assert regional["offset_from_active"]["distance_m"] == 0.0
+
+    web = frames[FRAME_WEB_WGS84]
+    assert web["available"] is True
+    assert web["source"] == "cloud_translation_fit"
+    assert math.isclose(web["offset_from_active"]["east_m"], 0.85, abs_tol=0.02)
+    assert math.isclose(web["offset_from_active"]["north_m"], 0.01, abs_tol=0.02)
+    assert web["georeference"]["rotation_rad"] == active["rotation_rad"]
+    assert web["quality"]["sample_count"] == 24
+
+
+def test_vendor_rtk_web_frame_waits_for_mature_evidence() -> None:
+    active = _geo(
+        source="x3_rtk_anchor",
+        cartographic_frame={
+            "applied": False,
+            "reason": "x3_vendor_rtk_frame_owns_translation",
+        },
+    )
+    learned = _geo(source="cloud_location_fit", rotation_rad=0.1)
+    learned["calibration"] = {
+        "sample_count": 4,
+        "inlier_count": 4,
+        "baseline_m": 8.0,
+        "rms_error_m": 0.2,
+        "max_error_m": 0.4,
+        "observed_scale": 1.0,
+    }
+    web = build_georeference_frames(_coordinator(active, fit=learned))[FRAME_WEB_WGS84]
+    assert web["available"] is False
+    assert web["reason"] == "insufficient_samples"
+
+
+def test_nonregional_dynamic_active_is_valid_web_fallback() -> None:
+    active = _geo(latitude=40.0, longitude=-74.0, source="cloud_location_fit")
+    frames = build_georeference_frames(_coordinator(active))
+    assert frames[FRAME_WEB_WGS84]["available"] is True
+    assert frames[FRAME_WEB_WGS84]["source"] == "active"
+    assert frames[FRAME_REGIONAL_CARTOGRAPHIC]["available"] is False
+    assert frames[FRAME_REGIONAL_CARTOGRAPHIC]["reason"] == "no_regional_cartographic_provider"
+
+
+def test_multi_site_origins_follow_frame_translation_only() -> None:
+    active = _geo(
+        cartographic_frame={
+            "applied": True,
+            "east_m": -0.762,
+            "north_m": -0.517,
+        }
+    )
+    coordinator = _coordinator(active)
+    origins = site_underlay_origins({"latitude": 59.0, "longitude": 24.0}, coordinator)
+    assert origins[FRAME_ACTIVE]["available"] is True
+    assert origins[FRAME_REGIONAL_CARTOGRAPHIC]["available"] is True
+    assert origins[FRAME_WEB_WGS84]["available"] is True
+    expected = offset_wgs84(59.0, 24.0, 0.762, 0.517)
+    assert expected is not None
+    assert math.isclose(origins[FRAME_WEB_WGS84]["latitude"], expected[0], abs_tol=1e-10)
+    assert math.isclose(origins[FRAME_WEB_WGS84]["longitude"], expected[1], abs_tol=1e-10)
+
+
+def test_diagnostics_and_api_semantics_are_privacy_safe() -> None:
+    active = _geo(
+        cartographic_frame={
+            "applied": True,
+            "east_m": -0.762,
+            "north_m": -0.517,
+        }
+    )
+    diagnostics = georeference_frame_diagnostics(_coordinator(active))
+    text = repr(diagnostics).lower()
+    assert "latitude" not in text
+    assert "longitude" not in text
+    assert diagnostics[FRAME_WEB_WGS84]["offset_from_active"]["distance_m"] > 0.9
+
+    semantics = (INTEGRATION / "georeference_frames_semantics.py").read_text()
+    for token in (
+        '"openstreetmap": FRAME_WEB_WGS84',
+        '"google_satellite": FRAME_WEB_WGS84',
+        '"estonia_orthophoto": FRAME_REGIONAL_CARTOGRAPHIC',
+        '"estonia_hybrid": FRAME_REGIONAL_CARTOGRAPHIC',
+        'result["georeference_frames"] = frames',
+        'result["underlay_origins"] = site_underlay_origins',
+        'provider_metadata["reference_frame"] = frame_name',
+        'provider_metadata["reference_frame_fallback"] = FRAME_ACTIVE',
+    ):
+        assert token in semantics


### PR DESCRIPTION
## Summary

Prepare stable/global map-underlay georeferencing by moving provider frame selection into the integration.

- export `active`, `web_wgs84` and `regional_cartographic` frames through authenticated Map API frontend metadata
- advertise underlay reference frames: OSM/Google -> `web_wgs84`, Estonia Ortofoto/Hübriid -> `regional_cartographic`
- preserve local mower/zone/dock/custom-area geometry; only underlay geographic reference changes
- for normal European cartographic maps, derive web frame by undoing only the final EPSG:8366 translation
- for vendor RTK regional maps, derive web translation from a mature independent cloud XY/GPS fit instead of applying an Estonia/model-specific offset
- keep strict sample/baseline/error/scale/rotation guards and fallback to active when web evidence is not mature
- export provider-specific Multi mower site origins
- add privacy-safe frame diagnostics with only sources, quality and relative metre offsets

This is the integration half of the beta23/beta13 provider-frame architecture.