### PR TITLE
Navimower 0.4.4-beta24: ignore dock zero-pose georef sentinels

### DIFF
--- a/.github/release-notes/0.4.4-beta24.md
+++ b/.github/release-notes/0.4.4-beta24.md
@@ -5,6 +5,8 @@ title: Navimower 0.4.4-beta24
 - Reject inconsistent private-cloud local `(0, 0, 0)` zero-pose reports when the mower simultaneously retains a materially different previous local pose and effectively unchanged previous GPS.
 - Treat that combination as a vendor placeholder/sentinel rather than a real paired local-X/Y + GPS observation.
 - Do not add a zero-pose sentinel to cloud georeference learning and do not let it create a false map-validation mismatch.
+- Remove matching persisted `(0, 0)` calibration samples left behind by older versions once the same retained-GPS sentinel is confirmed, so one poisoned historical sample cannot keep the calibration baseline/state wrong after upgrading.
+- Cleanup is conservative: a stored zero-local sample is removed only while a current zero-pose sentinel is independently confirmed and the stored GPS matches that retained sentinel position.
 - Detection is evidence-driven and does not hard-code H-series, i-series, X-series or any individual mower model.
 
 ## Explicit vendor map fallback

--- a/.github/release-notes/0.4.4-beta24.md
+++ b/.github/release-notes/0.4.4-beta24.md
@@ -1,0 +1,20 @@
+title: Navimower 0.4.4-beta24
+
+## Dock zero-pose georeference guard
+
+- Reject inconsistent private-cloud local `(0, 0, 0)` zero-pose reports when the mower simultaneously retains a materially different previous local pose and effectively unchanged previous GPS.
+- Treat that combination as a vendor placeholder/sentinel rather than a real paired local-X/Y + GPS observation.
+- Do not add a zero-pose sentinel to cloud georeference learning and do not let it create a false map-validation mismatch.
+- Detection is evidence-driven and does not hard-code H-series, i-series, X-series or any individual mower model.
+
+## Explicit vendor map fallback
+
+- When a zero-pose sentinel is the only reason a complete `vendor_map_detail` transform cannot be live-validated, keep the vendor map reference/rotation usable instead of replacing it with an incomplete `cloud_location_fit` learning state.
+- Mark sentinel-time validation as unavailable with reason `zero_pose_sentinel`; the fallback does not pretend the placeholder GPS validated local `(0, 0)`.
+- Preserve an already valid learned/static transform when one exists; the fallback only repairs the otherwise-unusable explicit vendor-map path.
+
+## Map underlays
+
+This restores a trustworthy local-to-geographic transform for affected docked maps so provider frames can remain available to Navimower Map Card. OpenStreetMap and Estonia Ortofoto/Hübriid can therefore render again without weakening their normal georeference checks or adding frontend mower-model offsets.
+
+X3 RTK-anchor/bias ownership, static-map translation refinement and the later ETRS89/cartographic presentation layer keep their existing order and semantics.

--- a/custom_components/navimower/georeference_pose_semantics.py
+++ b/custom_components/navimower/georeference_pose_semantics.py
@@ -1,7 +1,7 @@
 """Reject vendor zero-pose sentinels from georeference learning/validation.
 
 Some mower firmwares report a docked/reset placeholder of local ``(0, 0, 0)``
-while retaining the previous geographic position.  That is not a paired
+while retaining the previous geographic position. That is not a paired
 local-X/Y + GPS observation and must therefore never be allowed to invalidate a
 static map transform or enter the learned cloud fit.
 
@@ -90,6 +90,66 @@ def _sentinel_validation(location: Any) -> dict[str, Any]:
     }
 
 
+def _sample_matches_retained_sentinel(sample: Any, location: Any) -> bool:
+    """Match one previously persisted poisoned sample to a confirmed sentinel."""
+    if not isinstance(sample, dict) or not isinstance(location, dict):
+        return False
+    x = _georeference._float(sample.get("x"))  # noqa: SLF001
+    y = _georeference._float(sample.get("y"))  # noqa: SLF001
+    latitude = _georeference._float(sample.get("latitude"))  # noqa: SLF001
+    longitude = _georeference._float(sample.get("longitude"))  # noqa: SLF001
+    retained_latitude = _georeference._float(location.get("latitude"))  # noqa: SLF001
+    retained_longitude = _georeference._float(location.get("longitude"))  # noqa: SLF001
+    if None in (x, y, latitude, longitude, retained_latitude, retained_longitude):
+        return False
+    assert x is not None and y is not None
+    assert latitude is not None and longitude is not None
+    assert retained_latitude is not None and retained_longitude is not None
+    if abs(x) > _ZERO_POSE_EPS or abs(y) > _ZERO_POSE_EPS:
+        return False
+    offset = _georeference.wgs84_offset_m(
+        retained_latitude,
+        retained_longitude,
+        latitude,
+        longitude,
+    )
+    return (
+        offset is not None
+        and math.hypot(offset[0], offset[1]) <= _MAX_RETAINED_GPS_DISTANCE_M
+    )
+
+
+def _purge_persisted_sentinel_samples(
+    map_geometry: Any,
+    location: Any,
+) -> int:
+    """Remove stale zero-pose poison retained before this guard was installed."""
+    if not isinstance(map_geometry, dict) or not zero_pose_sentinel(location):
+        return 0
+    calibration = map_geometry.get("_georeference_calibration")
+    if not isinstance(calibration, dict):
+        return 0
+    samples = [
+        dict(item) for item in calibration.get("samples") or [] if isinstance(item, dict)
+    ]
+    if not samples:
+        return 0
+    retained = [
+        sample
+        for sample in samples
+        if not _sample_matches_retained_sentinel(sample, location)
+    ]
+    removed = len(samples) - len(retained)
+    if removed <= 0:
+        return 0
+    calibration["samples"] = retained
+    calibration["zero_pose_sentinel_purged_samples"] = (
+        int(calibration.get("zero_pose_sentinel_purged_samples") or 0) + removed
+    )
+    calibration["last_zero_pose_sentinel_purge_count"] = removed
+    return removed
+
+
 def _current_location_sample(location: Any) -> dict[str, Any] | None:
     if zero_pose_sentinel(location):
         return None
@@ -168,6 +228,7 @@ def _recover_vendor_map_detail(
 def _update(map_geometry: Any, location: Any) -> dict[str, Any] | None:
     if _ORIGINAL_UPDATE is None:
         return None
+    _purge_persisted_sentinel_samples(map_geometry, location)
     active = _ORIGINAL_UPDATE(map_geometry, location)
     if not isinstance(map_geometry, dict):
         return active

--- a/custom_components/navimower/georeference_pose_semantics.py
+++ b/custom_components/navimower/georeference_pose_semantics.py
@@ -1,0 +1,196 @@
+"""Reject vendor zero-pose sentinels from georeference learning/validation.
+
+Some mower firmwares report a docked/reset placeholder of local ``(0, 0, 0)``
+while retaining the previous geographic position.  That is not a paired
+local-X/Y + GPS observation and must therefore never be allowed to invalidate a
+static map transform or enter the learned cloud fit.
+
+Detection is evidence-driven rather than model-driven: the current local pose
+must be fully zeroed, the retained previous local pose must be materially away
+from the origin, and current/previous GPS must still describe effectively the
+same point.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+from typing import Any, Callable
+
+from . import georeference as _georeference
+
+_VENDOR_MAP_DETAIL_SOURCE = "vendor_map_detail"
+_ZERO_POSE_EPS = 1e-6
+_MIN_PREVIOUS_LOCAL_DISTANCE_M = 0.5
+_MAX_RETAINED_GPS_DISTANCE_M = 0.10
+
+_INSTALLED = False
+_ORIGINAL_CURRENT_SAMPLE: Callable[[Any], dict[str, Any] | None] | None = None
+_ORIGINAL_VALIDATE: Callable[..., dict[str, Any] | None] | None = None
+_ORIGINAL_UPDATE: Callable[[Any, Any], dict[str, Any] | None] | None = None
+
+
+def zero_pose_sentinel(location: Any) -> bool:
+    """Return whether one location payload is an inconsistent zero-pose sentinel."""
+    if not isinstance(location, dict):
+        return False
+
+    x = _georeference._float(location.get("posture_x"))  # noqa: SLF001
+    y = _georeference._float(location.get("posture_y"))  # noqa: SLF001
+    theta = _georeference._float(location.get("posture_theta"))  # noqa: SLF001
+    last_x = _georeference._float(location.get("last_posture_x"))  # noqa: SLF001
+    last_y = _georeference._float(location.get("last_posture_y"))  # noqa: SLF001
+    latitude = _georeference._float(location.get("latitude"))  # noqa: SLF001
+    longitude = _georeference._float(location.get("longitude"))  # noqa: SLF001
+    last_latitude = _georeference._float(location.get("last_latitude"))  # noqa: SLF001
+    last_longitude = _georeference._float(location.get("last_longitude"))  # noqa: SLF001
+
+    if None in (
+        x,
+        y,
+        theta,
+        last_x,
+        last_y,
+        latitude,
+        longitude,
+        last_latitude,
+        last_longitude,
+    ):
+        return False
+    assert x is not None and y is not None and theta is not None
+    assert last_x is not None and last_y is not None
+    assert latitude is not None and longitude is not None
+    assert last_latitude is not None and last_longitude is not None
+
+    if not (
+        abs(x) <= _ZERO_POSE_EPS
+        and abs(y) <= _ZERO_POSE_EPS
+        and abs(theta) <= _ZERO_POSE_EPS
+    ):
+        return False
+    if math.hypot(last_x, last_y) < _MIN_PREVIOUS_LOCAL_DISTANCE_M:
+        return False
+
+    retained = _georeference.wgs84_offset_m(
+        last_latitude,
+        last_longitude,
+        latitude,
+        longitude,
+    )
+    if retained is None:
+        return False
+    return math.hypot(retained[0], retained[1]) <= _MAX_RETAINED_GPS_DISTANCE_M
+
+
+def _sentinel_validation(location: Any) -> dict[str, Any]:
+    return {
+        "status": "unavailable",
+        "valid": None,
+        "reason": "zero_pose_sentinel",
+        "report_time": location.get("report_time") if isinstance(location, dict) else None,
+    }
+
+
+def _current_location_sample(location: Any) -> dict[str, Any] | None:
+    if zero_pose_sentinel(location):
+        return None
+    if _ORIGINAL_CURRENT_SAMPLE is None:
+        return None
+    return _ORIGINAL_CURRENT_SAMPLE(location)
+
+
+def _validate_georeference(
+    georeference: Any,
+    location: Any,
+    *,
+    limit_m: float = 2.0,
+) -> dict[str, Any] | None:
+    if zero_pose_sentinel(location):
+        if not isinstance(georeference, dict):
+            return None
+        result = deepcopy(georeference)
+        result["validation"] = _sentinel_validation(location)
+        return result
+    if _ORIGINAL_VALIDATE is None:
+        return None
+    return _ORIGINAL_VALIDATE(georeference, location, limit_m=limit_m)
+
+
+def _complete_vendor_map_detail(value: Any) -> bool:
+    if not isinstance(value, dict) or value.get("source") != _VENDOR_MAP_DETAIL_SOURCE:
+        return False
+    reference = value.get("reference") or {}
+    return all(
+        _georeference._float(item) is not None  # noqa: SLF001
+        for item in (
+            reference.get("local_x"),
+            reference.get("local_y"),
+            reference.get("latitude"),
+            reference.get("longitude"),
+            value.get("rotation_rad"),
+        )
+    )
+
+
+def _recover_vendor_map_detail(
+    map_geometry: dict[str, Any],
+    active: Any,
+    location: Any,
+) -> dict[str, Any] | None:
+    """Recover an explicit vendor transform when only sentinel validation blocked it."""
+    if not zero_pose_sentinel(location):
+        return active if isinstance(active, dict) else None
+    if _georeference.georeference_is_valid(active):
+        return active
+
+    vendor = map_geometry.get("_vendor_georeference")
+    if not _complete_vendor_map_detail(vendor):
+        return active if isinstance(active, dict) else None
+    assert isinstance(vendor, dict)
+
+    calibration = map_geometry.get("_georeference_calibration")
+    calibration = calibration if isinstance(calibration, dict) else {}
+    recovered = deepcopy(vendor)
+    recovered.update(
+        {
+            "schema_version": 2,
+            "source": _VENDOR_MAP_DETAIL_SOURCE,
+            "status": "validated",
+            "map_revision": str(map_geometry.get("revision") or ""),
+            "anchor_policy": "vendor_map_detail_zero_pose_fallback",
+            "calibration": _georeference._calibration_summary(calibration),  # noqa: SLF001
+            "validation": _sentinel_validation(location),
+        }
+    )
+    map_geometry["georeference"] = recovered
+    return recovered
+
+
+def _update(map_geometry: Any, location: Any) -> dict[str, Any] | None:
+    if _ORIGINAL_UPDATE is None:
+        return None
+    active = _ORIGINAL_UPDATE(map_geometry, location)
+    if not isinstance(map_geometry, dict):
+        return active
+    return _recover_vendor_map_detail(map_geometry, active, location)
+
+
+def install_georeference_pose_semantics() -> None:
+    """Install zero-pose rejection after static/X3 ownership is established."""
+    global _INSTALLED, _ORIGINAL_CURRENT_SAMPLE, _ORIGINAL_VALIDATE, _ORIGINAL_UPDATE
+    if _INSTALLED:
+        return
+
+    from . import coordinator_semantics as _coordinator_semantics
+
+    _ORIGINAL_CURRENT_SAMPLE = _georeference._current_location_sample  # noqa: SLF001
+    _ORIGINAL_VALIDATE = _georeference.validate_georeference
+    _ORIGINAL_UPDATE = _georeference.update_georeference
+
+    _georeference._current_location_sample = _current_location_sample  # noqa: SLF001
+    _georeference.validate_georeference = _validate_georeference
+    _georeference.update_georeference = _update
+    _coordinator_semantics.update_georeference = _update
+    _INSTALLED = True
+
+
+__all__ = ["install_georeference_pose_semantics", "zero_pose_sentinel"]

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta23"
+  "version": "0.4.4-beta24"
 }

--- a/custom_components/navimower/runtime.py
+++ b/custom_components/navimower/runtime.py
@@ -19,6 +19,7 @@ from .georeference_geodesy_semantics import (
     install_georeference_geodesy_semantics,
     install_georeference_geodesy_state_semantics,
 )
+from .georeference_pose_semantics import install_georeference_pose_semantics
 from .georeference_semantics import install_georeference_semantics
 from .georeference_static_anchor_semantics import install_georeference_static_anchor_semantics
 from .georeference_translation_refinement_semantics import (
@@ -50,6 +51,10 @@ def install_runtime_extensions() -> None:
     install_georeference_semantics()
     install_georeference_static_anchor_semantics()
     install_georeference_x3_bias_semantics()
+    # Some firmwares zero current local X/Y/heading while docked but retain the
+    # previous GPS point. Reject that inconsistent pair before it can enter
+    # learning or invalidate an explicit vendor map transform.
+    install_georeference_pose_semantics()
     # Static vendor ties keep rotation/local geometry authoritative. A mature,
     # tightly validated cloud XY/GPS fit may refine translation only. X3 is
     # already excluded because its RTK-anchor/bias path owns translation.

--- a/tests/test_v044_beta24.py
+++ b/tests/test_v044_beta24.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from custom_components.navimower import georeference_pose_semantics as pose
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "custom_components" / "navimower" / "manifest.json"
+RUNTIME = ROOT / "custom_components" / "navimower" / "runtime.py"
+NOTES = ROOT / ".github" / "release-notes" / "0.4.4-beta24.md"
+
+
+def _sentinel_location() -> dict[str, object]:
+    return {
+        "posture_x": 0.0,
+        "posture_y": 0.0,
+        "posture_theta": 0.0,
+        "last_posture_x": 0.16,
+        "last_posture_y": -2.756,
+        "last_posture_theta": 3.1,
+        "latitude": 58.0,
+        "longitude": 24.0,
+        "last_latitude": 58.0,
+        "last_longitude": 24.0,
+        "report_time": "123456",
+    }
+
+
+def _vendor_map_detail() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "source": "vendor_map_detail",
+        "reference": {
+            "local_x": -6.5,
+            "local_y": 9.3,
+            "latitude": 58.0001,
+            "longitude": 24.0001,
+        },
+        "rotation_rad": 0.5977,
+        "origin": {"latitude": 58.0, "longitude": 24.0},
+    }
+
+
+def test_beta24_release_contract() -> None:
+    manifest = json.loads(MANIFEST.read_text())
+    assert manifest["version"] == "0.4.4-beta24"
+    notes = NOTES.read_text()
+    for token in (
+        "zero-pose",
+        "vendor_map_detail",
+        "OpenStreetMap",
+        "Ortofoto",
+        "model",
+    ):
+        assert token.lower() in notes.lower()
+
+
+def test_zero_pose_sentinel_requires_inconsistent_retained_pose_and_gps() -> None:
+    location = _sentinel_location()
+    assert pose.zero_pose_sentinel(location) is True
+
+    real_origin = dict(location)
+    real_origin["last_posture_x"] = 0.1
+    real_origin["last_posture_y"] = 0.1
+    assert pose.zero_pose_sentinel(real_origin) is False
+
+    moved_gps = dict(location)
+    moved_gps["last_latitude"] = 58.0001
+    assert pose.zero_pose_sentinel(moved_gps) is False
+
+    nonzero_pose = dict(location)
+    nonzero_pose["posture_y"] = -0.2
+    assert pose.zero_pose_sentinel(nonzero_pose) is False
+
+
+def test_sentinel_is_never_accepted_as_learning_sample(monkeypatch) -> None:
+    monkeypatch.setattr(pose, "_ORIGINAL_CURRENT_SAMPLE", lambda _location: {"accepted": True})
+    assert pose._current_location_sample(_sentinel_location()) is None  # noqa: SLF001
+
+    real = _sentinel_location()
+    real["posture_x"] = 1.0
+    assert pose._current_location_sample(real) == {"accepted": True}  # noqa: SLF001
+
+
+def test_sentinel_validation_is_unavailable_not_mismatch(monkeypatch) -> None:
+    monkeypatch.setattr(
+        pose,
+        "_ORIGINAL_VALIDATE",
+        lambda georef, _location, *, limit_m=2.0: {
+            **georef,
+            "validation": {"status": "validated", "valid": True, "limit_m": limit_m},
+        },
+    )
+    checked = pose._validate_georeference(  # noqa: SLF001
+        _vendor_map_detail(),
+        _sentinel_location(),
+        limit_m=2.0,
+    )
+    assert checked is not None
+    assert checked["validation"] == {
+        "status": "unavailable",
+        "valid": None,
+        "reason": "zero_pose_sentinel",
+        "report_time": "123456",
+    }
+
+
+def test_explicit_vendor_transform_recovers_when_sentinel_blocks_validation() -> None:
+    vendor = _vendor_map_detail()
+    geometry = {
+        "revision": "map-revision",
+        "_vendor_georeference": vendor,
+        "_georeference_calibration": {
+            "map_revision": "map-revision",
+            "samples": [{"x": 0.1, "y": -2.7}],
+            "fit": None,
+            "mismatch_count": 0,
+        },
+    }
+    active = {
+        "schema_version": 2,
+        "source": "cloud_location_fit",
+        "status": "learning",
+        "map_revision": "map-revision",
+    }
+
+    recovered = pose._recover_vendor_map_detail(  # noqa: SLF001
+        geometry,
+        active,
+        _sentinel_location(),
+    )
+    assert recovered is not None
+    assert recovered["source"] == "vendor_map_detail"
+    assert recovered["status"] == "validated"
+    assert recovered["anchor_policy"] == "vendor_map_detail_zero_pose_fallback"
+    assert recovered["reference"] == vendor["reference"]
+    assert recovered["rotation_rad"] == vendor["rotation_rad"]
+    assert recovered["validation"]["reason"] == "zero_pose_sentinel"
+    assert geometry["georeference"] is recovered
+
+
+def test_valid_active_transform_is_not_replaced_by_sentinel_fallback() -> None:
+    active = {
+        "schema_version": 2,
+        "source": "cloud_location_fit",
+        "status": "validated",
+        "reference": {
+            "local_x": 1.0,
+            "local_y": 2.0,
+            "latitude": 58.0,
+            "longitude": 24.0,
+        },
+        "rotation_rad": 0.1,
+    }
+    geometry = {
+        "revision": "map-revision",
+        "_vendor_georeference": _vendor_map_detail(),
+    }
+    result = pose._recover_vendor_map_detail(  # noqa: SLF001
+        geometry,
+        active,
+        _sentinel_location(),
+    )
+    assert result is active
+    assert result["source"] == "cloud_location_fit"
+
+
+def test_pose_guard_runs_after_x3_ownership_before_translation_refinement() -> None:
+    runtime = RUNTIME.read_text()
+    x3 = runtime.index("install_georeference_x3_bias_semantics()")
+    guard = runtime.index("install_georeference_pose_semantics()")
+    refinement = runtime.index("install_georeference_translation_refinement_semantics()")
+    geodesy_state = runtime.index("install_georeference_geodesy_state_semantics()")
+    assert x3 < guard < refinement < geodesy_state

--- a/tests/test_v044_beta24.py
+++ b/tests/test_v044_beta24.py
@@ -48,6 +48,7 @@ def test_beta24_release_contract() -> None:
     notes = NOTES.read_text()
     for token in (
         "zero-pose",
+        "persisted",
         "vendor_map_detail",
         "OpenStreetMap",
         "Ortofoto",
@@ -72,6 +73,68 @@ def test_zero_pose_sentinel_requires_inconsistent_retained_pose_and_gps() -> Non
     nonzero_pose = dict(location)
     nonzero_pose["posture_y"] = -0.2
     assert pose.zero_pose_sentinel(nonzero_pose) is False
+
+
+def test_persisted_sentinel_sample_is_removed_before_relearning() -> None:
+    geometry = {
+        "_georeference_calibration": {
+            "samples": [
+                {
+                    "x": 0.12,
+                    "y": -2.75,
+                    "latitude": 58.0,
+                    "longitude": 24.0,
+                    "report_time": "good",
+                },
+                {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "latitude": 58.0,
+                    "longitude": 24.0,
+                    "report_time": "poisoned",
+                },
+                {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "latitude": 58.001,
+                    "longitude": 24.0,
+                    "report_time": "different-place",
+                },
+            ],
+            "fit": None,
+        }
+    }
+    removed = pose._purge_persisted_sentinel_samples(  # noqa: SLF001
+        geometry,
+        _sentinel_location(),
+    )
+    calibration = geometry["_georeference_calibration"]
+    assert removed == 1
+    assert [sample["report_time"] for sample in calibration["samples"]] == [
+        "good",
+        "different-place",
+    ]
+    assert calibration["zero_pose_sentinel_purged_samples"] == 1
+    assert calibration["last_zero_pose_sentinel_purge_count"] == 1
+
+
+def test_no_persisted_sample_cleanup_without_confirmed_sentinel() -> None:
+    geometry = {
+        "_georeference_calibration": {
+            "samples": [
+                {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "latitude": 58.0,
+                    "longitude": 24.0,
+                }
+            ]
+        }
+    }
+    location = _sentinel_location()
+    location["posture_x"] = 0.5
+    assert pose._purge_persisted_sentinel_samples(geometry, location) == 0  # noqa: SLF001
+    assert len(geometry["_georeference_calibration"]["samples"]) == 1
 
 
 def test_sentinel_is_never_accepted_as_learning_sample(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- detect inconsistent private-cloud `(0,0,0)` local-pose placeholders using retained previous local pose + unchanged GPS evidence
- exclude those placeholders from georeference learning and validation
- recover a complete explicit `vendor_map_detail` transform when sentinel-only validation would otherwise leave the map in `cloud_location_fit / learning`
- preserve already-valid learned/static transforms and existing X3/static/cartographic ownership
- add beta24 regression coverage and release notes

## Field evidence

The affected docked H2 payload reports current local pose `(0,0,0)` while retaining a materially different previous local pose and the same geographic point. Treating that as a real XY/GPS pair creates a false ~metre-scale validation mismatch and removes provider frames. The new guard is evidence-driven rather than model-name-driven.

## Expected result

Affected docked maps keep a trustworthy local-to-geographic transform, allowing provider frames and Map Card underlays to remain available without weakening normal georeference checks.