### PR TITLE
Navimower 0.4.4-beta25: keep managed Schedule ownership through charging

### DIFF
--- a/.github/release-notes/0.4.4-beta25.md
+++ b/.github/release-notes/0.4.4-beta25.md
@@ -1,0 +1,13 @@
+title: Navimower 0.4.4-beta25
+
+## Managed Schedule ownership continuity
+
+- Fix a managed-Schedule ownership race where Notification Center could classify the same scheduler-started one-zone task as `observed_without_local_command` after its short command-attribution window expired. That generic attribution is now treated as unknown provenance, not positive external-task evidence, when its zone and start time match a recently confirmed scheduler dispatch.
+- Keep the beta10 safety boundary: different-zone, multi-zone, explicit native/manual/other-HA task evidence, and later same-zone tasks still invalidate stale scheduler ownership and refuse retained-task Resume when ownership cannot be proven.
+- Preserve scheduler ownership through vendor low-battery return/charging so the same zone remains active and can self-resume or use the existing retained-task fallback without a new `reset=true` mowing start.
+- Add a narrow one-time recovery for the beta24 field failure signature: `active_task_rejected_unverified` followed by `mow_start_unconfirmed:<zone>`, with a still-retained generic one-zone task that is paused for charging and has unfinished progress. Recovery restores scheduler ownership and low-battery resume state without sending any mower command.
+- Native Navimow Schedule and Navimower managed Schedule remain mutually exclusive; this beta does not change the standalone Resume action or Map Card Resume control.
+
+### Field-test expectation
+
+After updating from the affected beta24 state, an enabled managed Schedule should recover the retained charging task in the same selected zone, wait for the mower's normal charging/self-resume behavior, and continue without starting that zone from scratch. Diagnostics should show `recovered_unconfirmed_same_zone_charging` if the repair path was used.

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta24"
+  "version": "0.4.4-beta25"
 }

--- a/custom_components/navimower/schedule_ownership_semantics.py
+++ b/custom_components/navimower/schedule_ownership_semantics.py
@@ -247,7 +247,11 @@ async def _recover_unconfirmed_same_zone_charging_task(
         return None
 
     data = controller.coordinator.data or {}
-    if controller._vendor_mowing(data) or not controller._vendor_charging(data):
+    # The field failure can be downloaded after charging has already completed,
+    # when MQTT reports generic idle (vehicleState=1) instead of Charging. The
+    # retained Notification Center charging reason is the interruption proof; the
+    # current mower only needs to still be safely docked and not cutting.
+    if controller._vendor_mowing(data) or data.get("docked") is not True:
         return None
 
     center = getattr(controller.coordinator, "notification_center", None)

--- a/custom_components/navimower/schedule_ownership_semantics.py
+++ b/custom_components/navimower/schedule_ownership_semantics.py
@@ -7,7 +7,9 @@ be enough to adopt or resume a native/manual multi-zone task.
 
 This extension records explicit ownership after a scheduler start is confirmed,
 rejects conflicting live task evidence, and fails closed when upgrading older
-runtime that cannot prove scheduler ownership.
+runtime that cannot prove scheduler ownership. Generic Notification Center
+attribution is treated as unknown provenance rather than positive external-task
+evidence when it matches a recent, explicitly confirmed scheduler dispatch.
 """
 from __future__ import annotations
 
@@ -16,6 +18,7 @@ from typing import Any
 
 from . import schedule_pause_semantics as pause_semantics
 from .navimower_schedule import NavimowerScheduleController, _utc_now
+from .schedule_logic import parse_iso
 
 _INSTALLED = False
 _ORIGINAL_EMPTY_RUNTIME = NavimowerScheduleController._empty_runtime
@@ -25,10 +28,21 @@ _ORIGINAL_CONTINUE_INTERRUPTED_TASK = NavimowerScheduleController._continue_inte
 _ORIGINAL_EVALUATE_LOCKED = NavimowerScheduleController._evaluate_locked
 _ORIGINAL_ADOPT_RETAINED_TASK = pause_semantics._adopt_retained_task
 
+_GENERIC_OBSERVED_TRIGGER = "observed_without_local_command"
+_GENERIC_OBSERVED_MATCH_SECONDS = 180.0
+_RECOVERABLE_SUSPENSION = "mow_start_not_confirmed"
+
 
 def _as_int(value: Any) -> int | None:
     try:
         return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value)
     except (TypeError, ValueError):
         return None
 
@@ -70,6 +84,46 @@ def _scheduler_task_evidence(task: dict[str, Any] | None, zone_id: int) -> bool:
     return trigger.startswith("navimower_schedule") and task_ids == [zone_id]
 
 
+def _generic_observed_matches_owned_dispatch(
+    controller: NavimowerScheduleController,
+    task: dict[str, Any] | None,
+    zone_id: int,
+) -> bool:
+    """Treat a same-start generic observation as unknown, not external conflict.
+
+    Notification Center deliberately emits ``observed_without_local_command`` when
+    it cannot find a *fresh* command trace. That does not prove another controller
+    started the task. Once Schedule has already confirmed and persisted its own
+    one-zone dispatch, a generic task observed shortly afterwards in that same zone
+    is the same task unless stronger live evidence says otherwise.
+
+    The bounded start-time match is important: stale scheduler ownership must still
+    fail closed if a later manual/native task happens to use the same zone.
+    """
+    if task is None:
+        return False
+    runtime = controller._runtime
+    if _as_int(runtime.get("owned_zone_id")) != zone_id:
+        return False
+    if not str(runtime.get("ownership_source") or "").startswith("navimower_schedule"):
+        return False
+    if str(task.get("trigger") or "") != _GENERIC_OBSERVED_TRIGGER:
+        return False
+    if str(task.get("origin") or "") not in {"", "observed"}:
+        return False
+    if _dedupe_ids(task.get("zone_ids")) != [zone_id]:
+        return False
+
+    dispatch = parse_iso(
+        runtime.get("owned_dispatch_started_at") or runtime.get("dispatch_started_at")
+    )
+    started = parse_iso(task.get("started_at"))
+    if dispatch is None or started is None:
+        return False
+    delta = (started - dispatch).total_seconds()
+    return 0.0 <= delta <= _GENERIC_OBSERVED_MATCH_SECONDS
+
+
 def _live_task_conflicts(controller: NavimowerScheduleController, zone_id: int) -> bool:
     """Reject clear evidence that the mower is currently cutting another task."""
     data = controller.coordinator.data or {}
@@ -91,8 +145,12 @@ def _live_task_conflicts(controller: NavimowerScheduleController, zone_id: int) 
     task_ids = _dedupe_ids(task.get("zone_ids"))
     # Scheduler handoffs may leave Notification Center on the previous scheduler
     # zone because mowing never transitioned through idle. That is still scheduler
-    # provenance. Native/manual/other-HA task context is a real conflict.
+    # provenance. A generic same-zone observation can also be the scheduler task
+    # itself when Notification Center's short command-attribution window was missed.
+    # Explicit native/manual/other-HA task context remains a real conflict.
     if task_ids and not trigger.startswith("navimower_schedule"):
+        if _generic_observed_matches_owned_dispatch(controller, task, zone_id):
+            return False
         return True
     return False
 
@@ -144,6 +202,109 @@ def _clear_unverified_context(controller: NavimowerScheduleController, *, reason
     controller._runtime["last_ownership_result"] = reason
     controller.coordinator.clear_pending_activity()
     controller.coordinator.clear_command_target()
+
+
+def _unconfirmed_retry_zone(runtime: dict[str, Any]) -> int | None:
+    """Return the exact zone from the beta24 false-ownership failure signature."""
+    if runtime.get("suspended_reason") != _RECOVERABLE_SUSPENSION:
+        return None
+    if runtime.get("last_ownership_result") != "active_task_rejected_unverified":
+        return None
+    if runtime.get("active_zone_id") is not None or runtime.get("owned_zone_id") is not None:
+        return None
+    if isinstance(runtime.get("pending_command"), dict):
+        return None
+    command = str(runtime.get("last_command") or "")
+    prefix = "mow_start_unconfirmed:"
+    if not command.startswith(prefix):
+        return None
+    zone_id = _as_int(command[len(prefix) :])
+    return zone_id if zone_id is not None and zone_id > 0 else None
+
+
+async def _recover_unconfirmed_same_zone_charging_task(
+    controller: NavimowerScheduleController,
+) -> int | None:
+    """Repair the beta24 ownership-loss state without starting a new mowing task.
+
+    This migration is intentionally narrow. It only repairs a task that Schedule
+    previously rejected as unverified, then retried in the *same* allowed zone,
+    while Notification Center still proves the unfinished one-zone task stopped for
+    charging. No mower command is sent here; the existing low-battery retained-task
+    logic decides later whether the mower self-resumed or needs Resume/continue.
+    """
+    runtime = controller._runtime
+    zone_id = _unconfirmed_retry_zone(runtime)
+    if zone_id is None or zone_id not in controller._selected_zone_ids:
+        return None
+
+    eligible_ids = {
+        _as_int(row.get("id"))
+        for row in controller._eligible_zones()
+        if isinstance(row, dict)
+    }
+    if zone_id not in eligible_ids:
+        return None
+
+    data = controller.coordinator.data or {}
+    if controller._vendor_mowing(data) or not controller._vendor_charging(data):
+        return None
+
+    center = getattr(controller.coordinator, "notification_center", None)
+    if getattr(center, "interrupted_reason", None) != "charging":
+        return None
+    task = _notification_task(controller)
+    if task is None:
+        return None
+    if str(task.get("trigger") or "") != _GENERIC_OBSERVED_TRIGGER:
+        return None
+    if str(task.get("origin") or "") not in {"", "observed"}:
+        return None
+    if _dedupe_ids(task.get("zone_ids")) != [zone_id]:
+        return None
+
+    task_started = parse_iso(task.get("started_at"))
+    paused_at = parse_iso(task.get("charging_paused_at"))
+    failed_at = parse_iso(runtime.get("last_command_at"))
+    if task_started is None or paused_at is None or failed_at is None or failed_at < paused_at:
+        return None
+
+    progress = _as_float(task.get("progress_before_pause"))
+    if progress is None:
+        progress = _as_float(controller._progress_for_zone(zone_id))
+    if progress is None or not 0.0 < progress < 100.0:
+        return None
+
+    row = controller._zone(zone_id) or {}
+    queue_slot = pause_semantics._matching_custom_queue_slot(controller, zone_id)
+    started_text = str(task.get("started_at") or _utc_now())
+
+    runtime["active_zone_id"] = zone_id
+    runtime["active_queue_slot"] = queue_slot
+    runtime["active_cycle_id"] = None
+    runtime["active_zone_baseline_completed_at"] = row.get("last_completed_at")
+    runtime["dispatch_started_at"] = started_text
+    runtime["just_completed_zone_id"] = None
+    runtime["resume_pending"] = True
+    runtime["interrupted_reason"] = "low_battery"
+    runtime["interrupted_zone_id"] = zone_id
+    runtime["interrupted_cycle_id"] = None
+    runtime["progress_before_interrupt"] = progress
+    runtime["charging_limit_reached_at"] = None
+    runtime["pending_command"] = None
+    runtime["retry_not_before"] = None
+    runtime["suspended_reason"] = None
+    runtime["owned_zone_id"] = zone_id
+    runtime["owned_dispatch_started_at"] = started_text
+    runtime["ownership_source"] = "navimower_schedule_recovered_same_zone_charging"
+    runtime["last_ownership_result"] = "recovered_unconfirmed_same_zone_charging"
+    runtime["last_command"] = f"recovered_retained_task:{zone_id}"
+    runtime["last_command_at"] = _utc_now()
+    runtime["last_error"] = None
+    controller.coordinator.clear_pending_activity()
+    controller.coordinator.clear_command_target()
+    await controller._save()
+    return zone_id
 
 
 def _adopt_retained_task(controller: NavimowerScheduleController) -> int | None:
@@ -235,7 +396,9 @@ async def _continue_interrupted_task(
 
 
 async def _evaluate_locked(self: NavimowerScheduleController) -> None:
-    """Fail closed on stale pre-beta10 ownership before normal scheduler decisions."""
+    """Repair the known beta24 state, then enforce strict ownership normally."""
+    await _recover_unconfirmed_same_zone_charging_task(self)
+
     zone_id = _as_int(self._runtime.get("active_zone_id"))
     if zone_id is not None and not isinstance(self._runtime.get("pending_command"), dict):
         if not _ownership_proven(self, zone_id):

--- a/tests/test_schedule_ownership_observed_recovery.py
+++ b/tests/test_schedule_ownership_observed_recovery.py
@@ -65,7 +65,7 @@ def test_beta24_false_ownership_failure_has_narrow_recovery_signature() -> None:
     assert 'zone_id not in controller._selected_zone_ids' in recovery
     assert 'controller._eligible_zones()' in recovery
     assert 'controller._vendor_mowing(data)' in recovery
-    assert 'not controller._vendor_charging(data)' in recovery
+    assert 'data.get("docked") is not True' in recovery
     assert 'getattr(center, "interrupted_reason", None) != "charging"' in recovery
     assert 'str(task.get("trigger") or "") != _GENERIC_OBSERVED_TRIGGER' in recovery
     assert '_dedupe_ids(task.get("zone_ids")) != [zone_id]' in recovery
@@ -73,6 +73,13 @@ def test_beta24_false_ownership_failure_has_narrow_recovery_signature() -> None:
     assert 'runtime.get("last_command_at")' in recovery
     assert 'failed_at < paused_at' in recovery
     assert 'not 0.0 < progress < 100.0' in recovery
+
+
+def test_recovery_accepts_safe_docked_idle_after_charging_completed() -> None:
+    recovery = _function_source("_recover_unconfirmed_same_zone_charging_task")
+    assert '_vendor_charging' not in recovery
+    assert 'data.get("docked") is not True' in recovery
+    assert 'interrupted_reason", None) != "charging"' in recovery
 
 
 def test_recovery_restores_retained_low_battery_ownership_without_new_start() -> None:

--- a/tests/test_schedule_ownership_observed_recovery.py
+++ b/tests/test_schedule_ownership_observed_recovery.py
@@ -1,0 +1,102 @@
+"""Regression guards for managed-schedule ownership attribution and recovery."""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OWNERSHIP = ROOT / "custom_components" / "navimower" / "schedule_ownership_semantics.py"
+SOURCE = OWNERSHIP.read_text(encoding="utf-8")
+
+
+def _function_source(name: str) -> str:
+    tree = ast.parse(SOURCE)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            segment = ast.get_source_segment(SOURCE, node)
+            assert segment is not None
+            return segment
+    raise AssertionError(f"Function {name} not found")
+
+
+def test_ownership_semantics_stay_syntax_valid() -> None:
+    ast.parse(SOURCE)
+
+
+def test_generic_observed_same_start_can_match_confirmed_scheduler_ownership() -> None:
+    helper = _function_source("_generic_observed_matches_owned_dispatch")
+    assert 'runtime.get("owned_zone_id")' in helper
+    assert 'runtime.get("ownership_source")' in helper
+    assert 'startswith("navimower_schedule")' in helper
+    assert '_GENERIC_OBSERVED_TRIGGER' in helper
+    assert '_dedupe_ids(task.get("zone_ids")) != [zone_id]' in helper
+    assert 'runtime.get("owned_dispatch_started_at")' in helper
+    assert 'task.get("started_at")' in helper
+    assert '0.0 <= delta <= _GENERIC_OBSERVED_MATCH_SECONDS' in helper
+
+    conflict = _function_source("_live_task_conflicts")
+    assert 'target_ids != [zone_id]' in conflict
+    assert 'not trigger.startswith("navimower_schedule")' in conflict
+    assert '_generic_observed_matches_owned_dispatch(controller, task, zone_id)' in conflict
+    assert conflict.index('_generic_observed_matches_owned_dispatch') < conflict.rindex('return True')
+
+
+def test_later_or_explicit_external_task_still_fails_closed() -> None:
+    helper = _function_source("_generic_observed_matches_owned_dispatch")
+    assert 'str(task.get("trigger") or "") != _GENERIC_OBSERVED_TRIGGER' in helper
+    assert 'str(task.get("origin") or "") not in {"", "observed"}' in helper
+    assert '_GENERIC_OBSERVED_MATCH_SECONDS = 180.0' in SOURCE
+
+    conflict = _function_source("_live_task_conflicts")
+    external_block = conflict[conflict.index('if task_ids and not trigger.startswith') :]
+    assert 'return True' in external_block
+
+
+def test_beta24_false_ownership_failure_has_narrow_recovery_signature() -> None:
+    signature = _function_source("_unconfirmed_retry_zone")
+    assert '_RECOVERABLE_SUSPENSION' in signature
+    assert 'active_task_rejected_unverified' in signature
+    assert 'runtime.get("active_zone_id") is not None' in signature
+    assert 'runtime.get("owned_zone_id") is not None' in signature
+    assert 'isinstance(runtime.get("pending_command"), dict)' in signature
+    assert 'prefix = "mow_start_unconfirmed:"' in signature
+
+    recovery = _function_source("_recover_unconfirmed_same_zone_charging_task")
+    assert 'zone_id not in controller._selected_zone_ids' in recovery
+    assert 'controller._eligible_zones()' in recovery
+    assert 'controller._vendor_mowing(data)' in recovery
+    assert 'not controller._vendor_charging(data)' in recovery
+    assert 'getattr(center, "interrupted_reason", None) != "charging"' in recovery
+    assert 'str(task.get("trigger") or "") != _GENERIC_OBSERVED_TRIGGER' in recovery
+    assert '_dedupe_ids(task.get("zone_ids")) != [zone_id]' in recovery
+    assert 'task.get("charging_paused_at")' in recovery
+    assert 'runtime.get("last_command_at")' in recovery
+    assert 'failed_at < paused_at' in recovery
+    assert 'not 0.0 < progress < 100.0' in recovery
+
+
+def test_recovery_restores_retained_low_battery_ownership_without_new_start() -> None:
+    recovery = _function_source("_recover_unconfirmed_same_zone_charging_task")
+    assert 'pause_semantics._matching_custom_queue_slot(controller, zone_id)' in recovery
+    assert 'runtime["active_zone_id"] = zone_id' in recovery
+    assert 'runtime["resume_pending"] = True' in recovery
+    assert 'runtime["interrupted_reason"] = "low_battery"' in recovery
+    assert 'runtime["interrupted_zone_id"] = zone_id' in recovery
+    assert 'runtime["suspended_reason"] = None' in recovery
+    assert 'runtime["owned_zone_id"] = zone_id' in recovery
+    assert 'runtime["ownership_source"] = "navimower_schedule_recovered_same_zone_charging"' in recovery
+    assert 'runtime["last_ownership_result"] = "recovered_unconfirmed_same_zone_charging"' in recovery
+    assert 'runtime["last_error"] = None' in recovery
+    assert '_async_send_mow' not in recovery
+    assert 'async_resume_task' not in recovery
+    assert 'mow_zones' not in recovery
+
+
+def test_recovery_runs_before_normal_ownership_and_existing_resume_guard_remains() -> None:
+    evaluate = _function_source("_evaluate_locked")
+    assert 'await _recover_unconfirmed_same_zone_charging_task(self)' in evaluate
+    assert evaluate.index('_recover_unconfirmed_same_zone_charging_task') < evaluate.index('_ownership_proven')
+
+    resume = _function_source("_continue_interrupted_task")
+    assert 'not _ownership_proven(self, zone_id)' in resume
+    assert 'resume_refused_unverified_task' in resume

--- a/tests/test_v044_beta25.py
+++ b/tests/test_v044_beta25.py
@@ -1,0 +1,72 @@
+"""Release-contract guards for Navimower 0.4.4-beta25."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+MANIFEST = COMPONENT / "manifest.json"
+OWNERSHIP = COMPONENT / "schedule_ownership_semantics.py"
+NOTES = ROOT / ".github" / "release-notes" / "0.4.4-beta25.md"
+
+
+def _function_source(name: str) -> str:
+    source = OWNERSHIP.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            segment = ast.get_source_segment(source, node)
+            assert segment is not None
+            return segment
+    raise AssertionError(f"Function {name} not found")
+
+
+def test_beta25_version_and_release_notes() -> None:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.4-beta25"
+    notes = NOTES.read_text(encoding="utf-8")
+    for phrase in (
+        "observed_without_local_command",
+        "active_task_rejected_unverified",
+        "mow_start_unconfirmed:<zone>",
+        "low-battery",
+        "without sending any mower command",
+        "Native Navimow Schedule",
+        "Resume control",
+    ):
+        assert phrase in notes
+
+
+def test_beta25_generic_observation_is_bounded_to_same_scheduler_dispatch() -> None:
+    source = _function_source("_generic_observed_matches_owned_dispatch")
+    assert 'owned_zone_id' in source
+    assert 'ownership_source' in source
+    assert 'startswith("navimower_schedule")' in source
+    assert '_GENERIC_OBSERVED_TRIGGER' in source
+    assert '_dedupe_ids(task.get("zone_ids")) != [zone_id]' in source
+    assert 'owned_dispatch_started_at' in source
+    assert '0.0 <= delta <= _GENERIC_OBSERVED_MATCH_SECONDS' in source
+
+
+def test_beta25_field_state_recovery_never_starts_a_new_cycle() -> None:
+    source = _function_source("_recover_unconfirmed_same_zone_charging_task")
+    assert 'active_task_rejected_unverified' in OWNERSHIP.read_text(encoding="utf-8")
+    assert 'mow_start_unconfirmed:' in OWNERSHIP.read_text(encoding="utf-8")
+    assert 'interrupted_reason", None) != "charging"' in source
+    assert 'runtime["resume_pending"] = True' in source
+    assert 'runtime["interrupted_reason"] = "low_battery"' in source
+    assert 'runtime["owned_zone_id"] = zone_id' in source
+    assert 'runtime["suspended_reason"] = None' in source
+    assert 'recovered_unconfirmed_same_zone_charging' in source
+    assert '_async_send_mow' not in source
+    assert 'async_resume_task' not in source
+    assert 'start_new_mowing_cycle' not in source
+
+
+def test_beta25_keeps_strict_resume_refusal_for_unverified_tasks() -> None:
+    source = _function_source("_continue_interrupted_task")
+    assert 'not _ownership_proven(self, zone_id)' in source
+    assert 'resume_refused_unverified_task' in source
+    assert 'vendor Resume was refused' in source


### PR DESCRIPTION
Fixes the managed-Schedule ownership loss seen in the beta24 field diagnostic.

The mower had a real one-zone managed task, but Notification Center conservatively labeled the same start as `observed_without_local_command`. The strict ownership guard treated that unknown attribution as positive external-task evidence, cleared scheduler ownership, and later allowed a new reset start attempt after the mower returned to charge.

This PR:
- accepts a generic observed one-zone task as the same scheduler task only when it matches an explicitly confirmed scheduler-owned zone and starts within the bounded command-attribution window;
- continues to reject different-zone, multi-zone, explicit external, and later same-zone task evidence;
- adds a narrow migration for the exact beta24 failure signature (`active_task_rejected_unverified` + `mow_start_unconfirmed:<zone>` + retained one-zone charging interruption with unfinished progress), restoring low-battery retained-task state without sending any mower command;
- preserves existing native-vs-managed Schedule exclusion and the strict Resume refusal for unverified retained tasks;
- bumps the prerelease to 0.4.4-beta25 and adds permanent plus release-scoped regressions.

Field expectation: the affected mower should recover the retained charging task after update and continue the same zone without a new `reset=true` cycle.