### PR TITLE
Fix stale gate intent latch for same-zone mowing commands

### DIFF
--- a/.github/release-notes/0.4.4-beta27.md
+++ b/.github/release-notes/0.4.4-beta27.md
@@ -1,0 +1,14 @@
+title: Navimower 0.4.4-beta27
+
+## Gate intent stale-latch safety
+
+- Fix a field failure where `Gate required` could remain asserted after an old cross-zone target briefly created a gate transition latch, even though the mower was physically mowing and still targeting the same zone.
+- Treat a fresh explicit one-zone Home Assistant/Navimower Schedule command for the mower's current physical zone as authoritative over an older conflicting gate latch. A stale opposite-zone vendor target can no longer keep or immediately re-arm that latch during command hand-over.
+- Keep the existing in-flight gate latch behavior for real zone crossings, including tolerance for brief MQTT target flips while the mower is actually travelling between connected zones.
+- Bound the new same-zone command guard to 120 seconds and retire it earlier as soon as the vendor target confirms the commanded current zone, the mower changes physical zone, a return-to-dock target appears, or a new command targets another zone.
+- Add diagnostic evidence when a stale vendor target is suppressed (`same_zone_command_guard`) and when a conflicting latch is cancelled (`stale_intent_cancelled`).
+- Add dependency-free regression coverage for the observed Yard2 `36 -> 37` stale-latch case and verify that managed Schedule dispatches its one-zone command through the protected target-intent path.
+
+### Field-test expectation
+
+When Navimower Schedule starts a new cycle in the mower's current zone, `Gate required` must remain off unless a later confirmed target actually requires crossing the configured gate. In the reproduced Yard2 case, diagnostics should no longer be able to settle into `current_zone_id: 36`, `target_zone_id: 36`, `intent_confirmed: false` together with a stale `required: true`, `from_zone_id: 36`, `to_zone_id: 37` gate state. The existing Home Assistant gate interlock automation does not need to change.

--- a/custom_components/navimower/gate_intent_safety.py
+++ b/custom_components/navimower/gate_intent_safety.py
@@ -1,0 +1,240 @@
+"""Cancel stale gate intent when a fresh local command keeps the mower in-zone.
+
+A gate transition latch intentionally survives brief vendor target flips while a
+mower is travelling between zones.  That safety becomes harmful when a new,
+explicit one-zone Home Assistant command starts in the mower's *current* zone:
+an older opposite-zone target can otherwise leave the previous latch asserted
+for the rest of the mowing task.
+
+This layer treats that explicit same-zone command as authoritative.  It clears
+any conflicting old latch immediately and keeps a short-lived command guard
+until the vendor target confirms the same zone.  During that hand-over a stale
+vendor target is display/debug evidence only and cannot re-arm the physical gate.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from . import coordinator as _coordinator
+from .const import COMMAND_TARGET_TTL_SECONDS
+
+
+_GUARD_SOURCE = "same_zone_command_guard"
+_HA_TARGET_SOURCES = {"ha_command", "ha_command_confirmed"}
+
+
+def _as_int(value: Any) -> int | None:
+    """Return an integer value without leaking vendor type quirks."""
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _single_zone(values: Any) -> int | None:
+    """Return the sole positive zone id, otherwise ``None``."""
+    parsed: list[int] = []
+    for value in values or []:
+        zone_id = _as_int(value)
+        if zone_id is not None and zone_id > 0 and zone_id not in parsed:
+            parsed.append(zone_id)
+    return parsed[0] if len(parsed) == 1 else None
+
+
+def _latch_conflicts_with_zone(latch: Any, zone_id: Any) -> bool:
+    """Return whether ``latch`` leaves ``zone_id`` for a different zone."""
+    if not isinstance(latch, dict):
+        return False
+    zone = _as_int(zone_id)
+    from_id = _as_int(latch.get("from_zone_id"))
+    to_id = _as_int(latch.get("to_zone_id"))
+    return bool(
+        zone is not None
+        and from_id == zone
+        and to_id is not None
+        and to_id != zone
+    )
+
+
+def _clear_conflicting_latches(coordinator: Any, zone_id: int) -> list[str]:
+    """Drop latches that contradict an authoritative same-zone command."""
+    removed: list[str] = []
+    for slug, latch in list(coordinator._gate_latches.items()):  # noqa: SLF001
+        if not _latch_conflicts_with_zone(latch, zone_id):
+            continue
+        coordinator._gate_latches.pop(slug, None)  # noqa: SLF001
+        coordinator._cancel_gate_release(slug)  # noqa: SLF001
+        removed.append(str(slug))
+    return removed
+
+
+def _clear_gate_state_rows(
+    result: dict[str, Any],
+    slugs: list[str],
+    *,
+    zone_id: int,
+    reason: str,
+) -> None:
+    """Keep the current navigation snapshot consistent after latch removal."""
+    states = result.get("gate_states") or {}
+    for slug in slugs:
+        state = states.get(slug)
+        if not isinstance(state, dict):
+            continue
+        state.update(
+            {
+                "required": False,
+                "close_delay_remaining": None,
+                "from_zone_id": None,
+                "from_zone_name": None,
+                "to_zone_id": None,
+                "to_zone_name": None,
+                "target_zone_id": zone_id,
+                "target_source": result.get("target_zone_source"),
+                "stale_intent_cancelled": True,
+                "stale_intent_cancel_reason": reason,
+            }
+        )
+
+
+def _no_gate_required(result: dict[str, Any]) -> bool:
+    return not any(
+        isinstance(state, dict) and state.get("required") is True
+        for state in (result.get("gate_states") or {}).values()
+    )
+
+
+def install_gate_intent_safety() -> None:
+    """Install same-zone command arbitration once per interpreter."""
+    cls = _coordinator.NavimowCoordinator
+    if getattr(cls, "_gate_intent_safety_installed", False):
+        return
+
+    original_set_command_target = cls.set_command_target
+    original_navigation = cls._navigation_fields
+
+    def set_command_target(
+        self: Any,
+        zone_ids: list[int],
+        *,
+        source: str = "ha_mow_command",
+    ) -> None:
+        ids = _coordinator._dedupe_zone_ids(zone_ids)  # noqa: SLF001
+        command_zone = _single_zone(ids)
+        current_zone = _as_int(
+            (self.data or {}).get("current_physical_zone_id")
+        )
+
+        if command_zone is not None and current_zone == command_zone:
+            removed = _clear_conflicting_latches(self, command_zone)
+            self._same_zone_command_gate_guard = {  # noqa: SLF001
+                "zone_id": command_zone,
+                "started_at": time.monotonic(),
+                "source": str(source),
+                "cleared_latches": removed,
+            }
+        else:
+            # A new command for another zone is positive replacement intent and
+            # must immediately release any previous same-zone suppression.
+            self._same_zone_command_gate_guard = None  # noqa: SLF001
+
+        original_set_command_target(self, zone_ids, source=source)
+
+    def navigation_fields(
+        self: Any, snapshot: dict[str, Any]
+    ) -> dict[str, Any]:
+        result = original_navigation(self, snapshot)
+        guard = getattr(self, "_same_zone_command_gate_guard", None)
+        if not isinstance(guard, dict):
+            return result
+
+        zone_id = _as_int(guard.get("zone_id"))
+        started_at = guard.get("started_at")
+        try:
+            age = time.monotonic() - float(started_at)
+        except (TypeError, ValueError):
+            age = COMMAND_TARGET_TTL_SECONDS + 1
+
+        if (
+            zone_id is None
+            or age < 0
+            or age > COMMAND_TARGET_TTL_SECONDS
+        ):
+            self._same_zone_command_gate_guard = None  # noqa: SLF001
+            return result
+
+        current_zone = _as_int(result.get("current_physical_zone_id"))
+        if current_zone is not None and current_zone != zone_id:
+            self._same_zone_command_gate_guard = None  # noqa: SLF001
+            return result
+
+        target_ids = _coordinator._dedupe_zone_ids(  # noqa: SLF001
+            result.get("target_zone_ids")
+        )
+        target_source = str(result.get("target_zone_source") or "")
+
+        # Returning-to-dock and any later explicit command are real replacement
+        # intents. ``set_command_target`` already clears the guard for the latter;
+        # the returning check protects mower-owned return transitions as well.
+        if target_source == "returning_to_dock":
+            self._same_zone_command_gate_guard = None  # noqa: SLF001
+            return result
+
+        # Once a non-HA source reports the commanded current zone, vendor state
+        # has caught up. Clear the old latch one final time, publish a consistent
+        # OFF snapshot, then retire the guard.
+        if target_ids == [zone_id] and target_source not in _HA_TARGET_SOURCES:
+            removed = _clear_conflicting_latches(self, zone_id)
+            if removed:
+                self._last_target_zone_ids = [zone_id]  # noqa: SLF001
+                _clear_gate_state_rows(
+                    result,
+                    removed,
+                    zone_id=zone_id,
+                    reason="vendor_confirmed_same_zone_command",
+                )
+                if _no_gate_required(result):
+                    result["zone_transition"] = False
+            self._same_zone_command_gate_guard = None  # noqa: SLF001
+            return result
+
+        # The local one-zone command still owns intent during vendor hand-over.
+        # A contradictory non-HA target may be an old packet (the field failure
+        # that created a 36->37 latch while Schedule had just dispatched 36).
+        # Remove any latch original navigation just re-created and expose the
+        # authoritative same-zone target until vendor state converges.
+        if target_ids and target_ids != [zone_id] and target_source not in _HA_TARGET_SOURCES:
+            removed = _clear_conflicting_latches(self, zone_id)
+            self._last_target_zone_ids = [zone_id]  # noqa: SLF001
+            stale_target_ids = list(target_ids)
+            result["target_zone_ids"] = [zone_id]
+            current_name = str(result.get("current_physical_zone") or "").strip()
+            if current_name and current_name not in {
+                "Between zones",
+                "Outside mapped zones",
+                "Position unavailable",
+            }:
+                result["target_zone"] = current_name
+            result["target_zone_source"] = _GUARD_SOURCE
+            result["same_zone_command_guard"] = {
+                "active": True,
+                "zone_id": zone_id,
+                "age_seconds": round(age, 1),
+                "command_source": guard.get("source"),
+                "suppressed_target_zone_ids": stale_target_ids,
+            }
+            _clear_gate_state_rows(
+                result,
+                removed,
+                zone_id=zone_id,
+                reason="stale_vendor_target_after_same_zone_command",
+            )
+            if _no_gate_required(result):
+                result["zone_transition"] = False
+
+        return result
+
+    cls.set_command_target = set_command_target
+    cls._navigation_fields = navigation_fields
+    cls._gate_intent_safety_installed = True

--- a/custom_components/navimower/gate_intent_safety.py
+++ b/custom_components/navimower/gate_intent_safety.py
@@ -1,14 +1,14 @@
 """Cancel stale gate intent when a fresh local command keeps the mower in-zone.
 
 A gate transition latch intentionally survives brief vendor target flips while a
-mower is travelling between zones.  That safety becomes harmful when a new,
+mower is travelling between zones. That safety becomes harmful when a new,
 explicit one-zone Home Assistant command starts in the mower's *current* zone:
 an older opposite-zone target can otherwise leave the previous latch asserted
 for the rest of the mowing task.
 
-This layer treats that explicit same-zone command as authoritative.  It clears
+This layer treats that explicit same-zone command as authoritative. It clears
 any conflicting old latch immediately and keeps a short-lived command guard
-until the vendor target confirms the same zone.  During that hand-over a stale
+until the vendor target confirms the same zone. During that hand-over a stale
 vendor target is display/debug evidence only and cannot re-arm the physical gate.
 """
 from __future__ import annotations
@@ -17,11 +17,11 @@ import time
 from typing import Any
 
 from . import coordinator as _coordinator
-from .const import COMMAND_TARGET_TTL_SECONDS
 
 
 _GUARD_SOURCE = "same_zone_command_guard"
 _HA_TARGET_SOURCES = {"ha_command", "ha_command_confirmed"}
+_SAME_ZONE_COMMAND_GATE_GUARD_SECONDS = 120.0
 
 
 def _as_int(value: Any) -> int | None:
@@ -154,12 +154,12 @@ def install_gate_intent_safety() -> None:
         try:
             age = time.monotonic() - float(started_at)
         except (TypeError, ValueError):
-            age = COMMAND_TARGET_TTL_SECONDS + 1
+            age = _SAME_ZONE_COMMAND_GATE_GUARD_SECONDS + 1
 
         if (
             zone_id is None
             or age < 0
-            or age > COMMAND_TARGET_TTL_SECONDS
+            or age > _SAME_ZONE_COMMAND_GATE_GUARD_SECONDS
         ):
             self._same_zone_command_gate_guard = None  # noqa: SLF001
             return result
@@ -204,7 +204,11 @@ def install_gate_intent_safety() -> None:
         # that created a 36->37 latch while Schedule had just dispatched 36).
         # Remove any latch original navigation just re-created and expose the
         # authoritative same-zone target until vendor state converges.
-        if target_ids and target_ids != [zone_id] and target_source not in _HA_TARGET_SOURCES:
+        if (
+            target_ids
+            and target_ids != [zone_id]
+            and target_source not in _HA_TARGET_SOURCES
+        ):
             removed = _clear_conflicting_latches(self, zone_id)
             self._last_target_zone_ids = [zone_id]  # noqa: SLF001
             stale_target_ids = list(target_ids)

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta26"
+  "version": "0.4.4-beta27"
 }

--- a/custom_components/navimower/runtime.py
+++ b/custom_components/navimower/runtime.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from .capability_extensions import install_capability_extensions
 from .capability_profile import install_capability_profile
 from .capability_semantics import install_capability_semantics
+from .gate_intent_safety import install_gate_intent_safety
 from .georeference_cartographic_semantics import install_georeference_cartographic_semantics
 from .georeference_diagnostics_frame_semantics import (
     install_georeference_diagnostics_frame_semantics,
@@ -77,6 +78,9 @@ def install_runtime_extensions() -> None:
     # every georeference layer above has finished composing the active transform.
     install_georeference_frames_semantics()
     install_navigation_fallback()
+    # Same-zone HA/Schedule commands arbitrate stale gate target latches after
+    # position fallback has produced the final navigation context.
+    install_gate_intent_safety()
     install_notification_feed()
     install_raw_mqtt_semantics()
     install_schedule_pause_semantics()

--- a/tests/test_navigation_intent.py
+++ b/tests/test_navigation_intent.py
@@ -7,6 +7,9 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 COORDINATOR = ROOT / "custom_components" / "navimower" / "coordinator.py"
+GATE_SAFETY = ROOT / "custom_components" / "navimower" / "gate_intent_safety.py"
+RUNTIME = ROOT / "custom_components" / "navimower" / "runtime.py"
+SCHEDULE = ROOT / "custom_components" / "navimower" / "navimower_schedule.py"
 SERVICES = ROOT / "custom_components" / "navimower" / "services.py"
 MOWER = ROOT / "custom_components" / "navimower" / "lawn_mower.py"
 
@@ -66,8 +69,64 @@ result = resolve(
 )
 assert result == ([13], "ha_command_confirmed", True), result
 
+# Reproduce the field failure from 2026-09-05: the mower is physically in zone
+# 36 and Schedule explicitly dispatches zone 36, while an older 36 -> 37 gate
+# latch remains cached. The safety layer must classify and clear that latch.
+gate_source = GATE_SAFETY.read_text(encoding="utf-8")
+gate_tree = ast.parse(gate_source)
+gate_selected = [
+    node
+    for node in gate_tree.body
+    if isinstance(node, ast.FunctionDef)
+    and node.name in {
+        "_as_int",
+        "_single_zone",
+        "_latch_conflicts_with_zone",
+        "_clear_conflicting_latches",
+    }
+]
+gate_module = ast.Module(body=gate_selected, type_ignores=[])
+ast.fix_missing_locations(gate_module)
+gate_namespace: dict[str, Any] = {"Any": Any}
+exec(compile(gate_module, "gate_intent_safety.py", "exec"), gate_namespace)
+
+single_zone = gate_namespace["_single_zone"]
+conflicts = gate_namespace["_latch_conflicts_with_zone"]
+clear_latches = gate_namespace["_clear_conflicting_latches"]
+
+assert single_zone([36]) == 36
+assert single_zone([36, 36]) == 36
+assert single_zone([36, 37]) is None
+assert conflicts({"from_zone_id": 36, "to_zone_id": 37}, 36) is True
+assert conflicts({"from_zone_id": 36, "to_zone_id": 37}, 37) is False
+assert conflicts({"from_zone_id": 36, "to_zone_id": 36}, 36) is False
+
+class FakeCoordinator:
+    def __init__(self) -> None:
+        self._gate_latches = {
+            "gate": {"from_zone_id": 36, "to_zone_id": 37},
+            "other": {"from_zone_id": 37, "to_zone_id": 36},
+        }
+        self.cancelled: list[str] = []
+
+    def _cancel_gate_release(self, slug: str) -> None:
+        self.cancelled.append(slug)
+
+fake = FakeCoordinator()
+removed = clear_latches(fake, 36)
+assert removed == ["gate"], removed
+assert "gate" not in fake._gate_latches
+assert "other" in fake._gate_latches
+assert fake.cancelled == ["gate"]
+
+runtime_source = RUNTIME.read_text(encoding="utf-8")
+schedule_source = SCHEDULE.read_text(encoding="utf-8")
 services_source = SERVICES.read_text(encoding="utf-8")
 mower_source = MOWER.read_text(encoding="utf-8")
+assert "install_gate_intent_safety" in runtime_source
+assert "_SAME_ZONE_COMMAND_GATE_GUARD_SECONDS = 120.0" in gate_source
+assert "stale_vendor_target_after_same_zone_command" in gate_source
+assert "self.coordinator.set_command_target([zone_id], source=source)" in schedule_source
 assert "set_command_target" in services_source
 assert "set_pending_activity" in services_source
 assert "set_pending_activity" in mower_source


### PR DESCRIPTION
## Summary

Fixes the gate-intent failure reproduced on 2026-09-05 where an old `36 -> 37` target could leave `Gate required` asserted while the mower was physically mowing zone 36 and the current task target was also zone 36.

## Changes

- add a bounded same-zone command guard for explicit one-zone HA/Navimower Schedule commands
- clear conflicting stale gate latches when the new command targets the mower's current physical zone
- suppress an immediately stale opposite vendor target only during the 120-second command hand-over window
- preserve normal in-flight gate latch behavior for genuine cross-zone travel
- expose diagnostic evidence when stale intent is cancelled/suppressed
- add dependency-free regression coverage for the observed Yard2 `36 -> 37` case
- bump integration version to `0.4.4-beta27` and add release notes

## Field expectation

A state with `current_zone_id: 36`, `target_zone_id: 36`, and no confirmed cross-zone intent must no longer retain a stale `required: true`, `from_zone_id: 36`, `to_zone_id: 37` gate state. The existing Home Assistant gate interlock automation does not need to change.