### PR TITLE
Navimower 0.4.4-beta29: keep Last completed monotonic

### DIFF
--- a/.github/release-notes/0.4.4-beta29.md
+++ b/.github/release-notes/0.4.4-beta29.md
@@ -1,0 +1,34 @@
+title: Navimower 0.4.4-beta29
+
+## Monotonic per-zone completion timestamps
+
+This beta targets issue #279, where a zone's `Last completed` sensor could briefly show the newest completion and later snap back to an older timestamp.
+
+### Last completed can no longer move backwards
+
+- Treat `last_completed_at` as monotonic historical state.
+- After the strict fresh per-zone coverage path proposes a completion, compare the candidate with the already persisted timestamp before publishing it.
+- Reject any strictly older candidate and keep the complete newer persisted completion tuple (`timestamp`, progress, source, confirmation and cycle id).
+- Preserve current-cycle completion confirmation when only the vendor timestamp candidate was stale.
+- Expose the rejected evidence through completion diagnostics with reason `older_than_persisted_completion`, including candidate/persisted timestamps, sources, confirmations and cycle ids.
+
+### Safer startup repair
+
+- Keep the legacy cleanup for genuinely unverified beta-era completion timestamps.
+- Do not delete a modern completion solely because it is within 60 seconds of a reset boundary when it is fully verified as:
+  - progress `100`,
+  - source `private_zone_coverage`, and
+  - a `coverage_100_*` confirmation.
+- When a legacy/unverified completion is removed, clear the complete completion metadata tuple rather than leaving stale source/confirmation fields behind, and record `last_completion_repair` diagnostics.
+
+### Regression coverage
+
+- Add dependency-free tests proving that an older completion cannot replace a newer one.
+- Verify that equal/newer completions still pass normally.
+- Verify that a strict coverage-confirmed completion survives a nearby reset boundary during startup.
+- Verify that old unverified/reset-boundary beta records are still repaired.
+- Verify runtime installation order after the history layer and before Map API publication.
+
+### Field test requested for issue #279
+
+Please update to `0.4.4-beta29` and watch the affected zone's `Last completed` sensor across another full mowing completion and subsequent cloud refreshes/restarts. If the timestamp still changes backwards, please attach a fresh Navimower diagnostics export while leaving the issue open for follow-up.

--- a/custom_components/navimower/completion_semantics.py
+++ b/custom_components/navimower/completion_semantics.py
@@ -1,0 +1,218 @@
+"""Stable semantics for per-zone completion timestamps.
+
+`last_completed_at` is historical state: once a newer confirmed completion has
+been published it must never move backwards because a stale vendor cycle arrives
+later. This layer also narrows the legacy startup repair so a modern completion
+confirmed from fresh per-zone coverage is not deleted merely because it is close
+to a reset boundary.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from . import history as _history
+
+
+_COMPLETION_FIELDS = (
+    "last_completed_at",
+    "last_completed_progress",
+    "last_completed_source",
+    "last_completed_confirmation",
+    "last_completed_cycle_id",
+)
+_VERIFIED_COMPLETION_SOURCE = "private_zone_coverage"
+_VERIFIED_CONFIRMATION_PREFIX = "coverage_100_"
+
+
+def _verified_completion(record: dict[str, Any] | None) -> bool:
+    """Return whether a persisted completion came from the strict coverage path."""
+    row = record or {}
+    return bool(
+        _history._as_int(row.get("last_completed_progress")) == 100  # noqa: SLF001
+        and str(row.get("last_completed_source") or "")
+        == _VERIFIED_COMPLETION_SOURCE
+        and str(row.get("last_completed_confirmation") or "").startswith(
+            _VERIFIED_CONFIRMATION_PREFIX
+        )
+        and _history._iso_ms(row.get("last_completed_at")) is not None  # noqa: SLF001
+    )
+
+
+def _completion_regression(
+    previous: dict[str, Any] | None,
+    candidate: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Describe a strict timestamp regression, otherwise return ``None``."""
+    old = previous or {}
+    new = candidate or {}
+    old_ms = _history._iso_ms(old.get("last_completed_at"))  # noqa: SLF001
+    new_ms = _history._iso_ms(new.get("last_completed_at"))  # noqa: SLF001
+    if old_ms is None or new_ms is None or new_ms >= old_ms:
+        return None
+    return {
+        "reason": "older_than_persisted_completion",
+        "candidate_at": new.get("last_completed_at"),
+        "persisted_at": old.get("last_completed_at"),
+        "candidate_source": new.get("last_completed_source"),
+        "candidate_confirmation": new.get("last_completed_confirmation"),
+        "candidate_cycle_id": new.get("last_completed_cycle_id"),
+        "persisted_source": old.get("last_completed_source"),
+        "persisted_confirmation": old.get("last_completed_confirmation"),
+        "persisted_cycle_id": old.get("last_completed_cycle_id"),
+    }
+
+
+def _preserve_newest_completion(
+    previous: dict[str, Any] | None,
+    candidate: dict[str, Any] | None,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    """Return candidate state unless it would move Last completed backwards."""
+    old = dict(previous or {})
+    new = dict(candidate or {})
+    rejection = _completion_regression(old, new)
+    if rejection is None:
+        return new, None
+    for key in _COMPLETION_FIELDS:
+        if key in old:
+            new[key] = deepcopy(old[key])
+        else:
+            new.pop(key, None)
+    new["last_completion_rejection"] = deepcopy(rejection)
+    return new, rejection
+
+
+def _near_reset_boundary(
+    completed_ms: int,
+    zone_id: int | None,
+    reset_boundaries: dict[int, list[int]],
+) -> bool:
+    if zone_id is None:
+        return False
+    return any(
+        abs(completed_ms - boundary) <= 60_000
+        for boundary in reset_boundaries.get(zone_id, [])
+    )
+
+
+def _should_repair_legacy_completion(
+    record: dict[str, Any],
+    *,
+    zone_id: int | None,
+    reset_boundaries: dict[int, list[int]],
+) -> bool:
+    """Repair only completion rows that do not carry modern strict evidence."""
+    completed_ms = _history._iso_ms(record.get("last_completed_at"))  # noqa: SLF001
+    if completed_ms is None:
+        return False
+    if _verified_completion(record):
+        return False
+    unverified = _history._as_int(record.get("last_completed_progress")) is None  # noqa: SLF001
+    return bool(
+        unverified
+        or _near_reset_boundary(completed_ms, zone_id, reset_boundaries)
+    )
+
+
+def install_completion_semantics() -> None:
+    """Install monotonic completion publication and conservative startup repair."""
+    cls = _history.NavimowerHistory
+    if getattr(cls, "_completion_semantics_installed", False):
+        return
+
+    original_confirm = cls._confirm_coverage_completions_locked
+
+    def confirm_coverage_completions_locked(
+        self: Any,
+        snapshot: dict[str, Any],
+        pose_time: Any,
+    ) -> None:
+        with self._lock:  # noqa: SLF001
+            before = deepcopy(self._zone_history)  # noqa: SLF001
+        original_confirm(self, snapshot, pose_time)
+
+        rejected: list[dict[str, Any]] = []
+        with self._lock:  # noqa: SLF001
+            for zone_key, candidate in list(self._zone_history.items()):  # noqa: SLF001
+                previous = before.get(str(zone_key))
+                if not isinstance(candidate, dict) or not isinstance(previous, dict):
+                    continue
+                protected, rejection = _preserve_newest_completion(
+                    previous,
+                    candidate,
+                )
+                if rejection is None:
+                    continue
+                zone_id = _history._as_int(protected.get("id")) or _history._as_int(zone_key)  # noqa: SLF001
+                rejection = {**rejection, "zone_id": zone_id}
+                protected["last_completion_rejection"] = deepcopy(rejection)
+                self._zone_history[str(zone_key)] = protected  # noqa: SLF001
+                rejected.append(rejection)
+
+            if rejected:
+                active = self._cache.get(self._active_id or "")  # noqa: SLF001
+                if isinstance(active, dict):
+                    # Preserve current-cycle completion confirmation: only the
+                    # historical timestamp candidate was stale. Diagnostics make
+                    # the rejected vendor evidence visible for field reports.
+                    active["last_completion_rejection"] = deepcopy(rejected[-1])
+                    self._update_active_metadata_locked(active)  # noqa: SLF001
+                    self._schedule_active_save()  # noqa: SLF001
+
+        if rejected:
+            self._schedule_index_save()  # noqa: SLF001
+            for rejection in rejected:
+                _history._LOGGER.info(  # noqa: SLF001
+                    "Rejected older Navimower completion for zone %s: candidate %s < persisted %s",
+                    rejection.get("zone_id"),
+                    rejection.get("candidate_at"),
+                    rejection.get("persisted_at"),
+                )
+
+    async def repair_unverified_zone_completions(self: Any) -> None:
+        """Remove only legacy/unverified completion timestamps at startup."""
+        repaired = 0
+        with self._lock:  # noqa: SLF001
+            reset_boundaries: dict[int, list[int]] = {}
+            for session in self._cache.values():  # noqa: SLF001
+                for item in (session or {}).get("zone_cycle_boundaries") or []:
+                    if not isinstance(item, dict):
+                        continue
+                    zone_id = _history._as_int(item.get("zone_id"))  # noqa: SLF001
+                    at_ms = _history._as_int(item.get("at_ms"))  # noqa: SLF001
+                    if zone_id is not None and at_ms is not None:
+                        reset_boundaries.setdefault(zone_id, []).append(at_ms)
+
+            for key, original in list(self._zone_history.items()):  # noqa: SLF001
+                record = dict(original)
+                zone_id = _history._as_int(record.get("id")) or _history._as_int(key)  # noqa: SLF001
+                if not _should_repair_legacy_completion(
+                    record,
+                    zone_id=zone_id,
+                    reset_boundaries=reset_boundaries,
+                ):
+                    continue
+                removed = {
+                    field: record.get(field)
+                    for field in _COMPLETION_FIELDS
+                    if record.get(field) is not None
+                }
+                for field in _COMPLETION_FIELDS:
+                    record.pop(field, None)
+                record["last_completion_repair"] = {
+                    "reason": "legacy_unverified_completion",
+                    "removed": removed,
+                }
+                self._zone_history[str(key)] = record  # noqa: SLF001
+                repaired += 1
+
+        if repaired:
+            await self._index_store.async_save(self._index_data())  # noqa: SLF001
+            _history._LOGGER.info(  # noqa: SLF001
+                "Removed %d legacy/unverified Navimower zone completion timestamp(s)",
+                repaired,
+            )
+
+    cls._confirm_coverage_completions_locked = confirm_coverage_completions_locked
+    cls._async_repair_unverified_zone_completions = repair_unverified_zone_completions
+    cls._completion_semantics_installed = True

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta28"
+  "version": "0.4.4-beta29"
 }

--- a/custom_components/navimower/runtime.py
+++ b/custom_components/navimower/runtime.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from .capability_extensions import install_capability_extensions
 from .capability_profile import install_capability_profile
 from .capability_semantics import install_capability_semantics
+from .completion_semantics import install_completion_semantics
 from .georeference_cartographic_semantics import install_georeference_cartographic_semantics
 from .georeference_diagnostics_frame_semantics import (
     install_georeference_diagnostics_frame_semantics,
@@ -83,9 +84,10 @@ def install_runtime_extensions() -> None:
     # Navigation intent is the single post-fallback owner of target freshness,
     # same-zone command arbitration and strict cloud gate confirmations.
     install_navigation_intent()
-    # Point-light history reads and phased Map API responses are installed after
-    # navigation has finalized the physical/task context.
+    # Point-light history reads and completion semantics are installed before the
+    # phased Map API so all published map/sensor state sees the protected history.
     install_history_performance()
+    install_completion_semantics()
     install_map_api_performance()
     install_notification_feed()
     install_raw_mqtt_semantics()

--- a/tests/test_completion_semantics.py
+++ b/tests/test_completion_semantics.py
@@ -1,0 +1,191 @@
+"""Dependency-free regressions for monotonic Last completed semantics."""
+from __future__ import annotations
+
+import ast
+from copy import deepcopy
+from datetime import datetime, UTC
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+SEMANTICS = COMPONENT / "completion_semantics.py"
+RUNTIME = COMPONENT / "runtime.py"
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _iso_ms(value: Any) -> int | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return int(parsed.timestamp() * 1000)
+    except (TypeError, ValueError, OverflowError, OSError):
+        return None
+
+
+class _HistoryStub:
+    _as_int = staticmethod(_as_int)
+    _iso_ms = staticmethod(_iso_ms)
+
+
+def _load_helpers() -> dict[str, Any]:
+    source = SEMANTICS.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    selected = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name
+        in {
+            "_verified_completion",
+            "_completion_regression",
+            "_preserve_newest_completion",
+            "_near_reset_boundary",
+            "_should_repair_legacy_completion",
+        }
+    ]
+    module = ast.Module(body=selected, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace: dict[str, Any] = {
+        "Any": Any,
+        "deepcopy": deepcopy,
+        "_history": _HistoryStub,
+        "_COMPLETION_FIELDS": (
+            "last_completed_at",
+            "last_completed_progress",
+            "last_completed_source",
+            "last_completed_confirmation",
+            "last_completed_cycle_id",
+        ),
+        "_VERIFIED_COMPLETION_SOURCE": "private_zone_coverage",
+        "_VERIFIED_CONFIRMATION_PREFIX": "coverage_100_",
+    }
+    exec(compile(module, SEMANTICS.name, "exec"), namespace)
+    return namespace
+
+
+def _record(stamp: str, *, cycle: str = "cycle-new") -> dict[str, Any]:
+    return {
+        "id": 36,
+        "name": "Yard2",
+        "last_completed_at": stamp,
+        "last_completed_progress": 100,
+        "last_completed_source": "private_zone_coverage",
+        "last_completed_confirmation": "coverage_100_after_incomplete",
+        "last_completed_cycle_id": cycle,
+    }
+
+
+def test_last_completed_never_moves_backwards() -> None:
+    helpers = _load_helpers()
+    preserve = helpers["_preserve_newest_completion"]
+
+    previous = _record("2026-09-05T12:30:00+00:00", cycle="cycle-2")
+    stale = _record("2026-09-03T15:20:00+00:00", cycle="cycle-3")
+    protected, rejection = preserve(previous, stale)
+
+    assert protected["last_completed_at"] == previous["last_completed_at"]
+    assert protected["last_completed_cycle_id"] == "cycle-2"
+    assert protected["last_completed_source"] == "private_zone_coverage"
+    assert rejection is not None
+    assert rejection["reason"] == "older_than_persisted_completion"
+    assert rejection["candidate_at"] == stale["last_completed_at"]
+    assert rejection["persisted_at"] == previous["last_completed_at"]
+
+
+def test_newer_and_equal_completion_are_allowed() -> None:
+    helpers = _load_helpers()
+    preserve = helpers["_preserve_newest_completion"]
+
+    previous = _record("2026-09-05T12:30:00+00:00", cycle="cycle-2")
+    equal = _record("2026-09-05T12:30:00+00:00", cycle="cycle-3")
+    newer = _record("2026-09-06T07:10:00+00:00", cycle="cycle-4")
+
+    equal_result, equal_rejection = preserve(previous, equal)
+    newer_result, newer_rejection = preserve(previous, newer)
+
+    assert equal_result["last_completed_cycle_id"] == "cycle-3"
+    assert equal_rejection is None
+    assert newer_result["last_completed_at"] == newer["last_completed_at"]
+    assert newer_result["last_completed_cycle_id"] == "cycle-4"
+    assert newer_rejection is None
+
+
+def test_verified_coverage_completion_survives_nearby_reset_boundary() -> None:
+    helpers = _load_helpers()
+    verified = helpers["_verified_completion"]
+    should_repair = helpers["_should_repair_legacy_completion"]
+
+    row = _record("2026-09-06T07:10:00+00:00")
+    stamp = _iso_ms(row["last_completed_at"])
+    assert stamp is not None
+    assert verified(row) is True
+    assert (
+        should_repair(
+            row,
+            zone_id=36,
+            reset_boundaries={36: [stamp + 15_000]},
+        )
+        is False
+    )
+
+
+def test_legacy_unverified_completion_is_still_repaired() -> None:
+    helpers = _load_helpers()
+    should_repair = helpers["_should_repair_legacy_completion"]
+
+    stamp_text = "2026-09-06T07:10:00+00:00"
+    stamp = _iso_ms(stamp_text)
+    assert stamp is not None
+
+    missing_progress = {
+        "id": 36,
+        "last_completed_at": stamp_text,
+    }
+    assert (
+        should_repair(
+            missing_progress,
+            zone_id=36,
+            reset_boundaries={},
+        )
+        is True
+    )
+
+    beta_reset_stamp = {
+        "id": 36,
+        "last_completed_at": stamp_text,
+        "last_completed_progress": 100,
+        "last_completed_source": "legacy_vendor_timestamp",
+    }
+    assert (
+        should_repair(
+            beta_reset_stamp,
+            zone_id=36,
+            reset_boundaries={36: [stamp - 30_000]},
+        )
+        is True
+    )
+
+
+def test_runtime_installs_completion_semantics_after_history_layer() -> None:
+    runtime = RUNTIME.read_text(encoding="utf-8")
+    assert "from .completion_semantics import install_completion_semantics" in runtime
+    history_index = runtime.index("install_history_performance()")
+    completion_index = runtime.index("install_completion_semantics()")
+    map_index = runtime.index("install_map_api_performance()")
+    assert history_index < completion_index < map_index
+
+    semantics = SEMANTICS.read_text(encoding="utf-8")
+    assert "older_than_persisted_completion" in semantics
+    assert "legacy_unverified_completion" in semantics
+    assert "private_zone_coverage" in semantics
+    assert "coverage_100_" in semantics


### PR DESCRIPTION
## Summary

Targeted follow-up for issue #279. Keep per-zone `Last completed` historical state monotonic and narrow the legacy startup repair so a modern strict coverage-confirmed timestamp cannot be removed merely because it is close to a reset boundary.

## Changes

- reject a strictly older `last_completed_at` candidate after coverage completion arbitration
- preserve the complete newer persisted completion tuple (timestamp, progress, source, confirmation, cycle id)
- retain current-cycle completion confirmation when only the vendor timestamp candidate is stale
- expose rejected evidence as `older_than_persisted_completion` diagnostics
- preserve verified `private_zone_coverage` + `coverage_100_*` completion rows during startup repair
- continue repairing genuinely legacy/unverified beta-era completion timestamps
- clear the complete legacy completion metadata tuple when a repair is required
- add permanent dependency-free regressions for older/equal/newer candidates and startup reset-boundary behavior

Issue #279 remains open after release so the reporter can verify the fix against a real mowing cycle.