### PR TITLE
Harden Download diagnostics privacy; remove retired H5 report blocks

### DIFF
--- a/custom_components/navimower/diagnostics.py
+++ b/custom_components/navimower/diagnostics.py
@@ -10,28 +10,16 @@ from homeassistant.core import HomeAssistant
 
 from .capability_profile import build_capability_profile
 from .const import DOMAIN, OPT_GOOGLE_MAPS_API_KEY
-from .diagnostics_sanitize import sanitize
+from .diagnostics_sanitize import REDACTION_VERSION, sanitize
 from .map_underlay import map_underlay_diagnostics
 from .private_cloud_region import private_cloud_region_diagnostics
 from .state_semantics import error_transition_diagnostics
 
-# Historical source-level regression markers only. These lines document the H5
-# research paths retired by beta29; they are deliberately inert text, not imports
-# or executable discovery. Keeping the markers lets old beta regression tests
-# continue to verify that the original research modules remain read-only.
-_RETIRED_H5_DISCOVERY_HISTORY = r'''
-from .maintenance_h5_discovery import probe_maintenance_h5
-await hass.async_add_executor_job
-"maintenance_h5_discovery": maintenance_h5_discovery
-probe_maintenance_h5, coordinator.client
-from .error_h5_discovery import probe_error_h5
-probe_error_h5,
-"command_discovery": deepcopy(error_command_discovery)
-ERROR_DISCOVERY_TIMEOUT_SECONDS = 30.0
-async with asyncio.timeout(ERROR_DISCOVERY_TIMEOUT_SECONDS):
-"timed_out": True
-public H5 error discovery exceeded the diagnostics timeout
-'''
+# Omit retired research blocks even when an older runtime cache still has them.
+# This is a report-only projection; it never changes or clears the source cache.
+_RETIRED_RESEARCH_KEYS = frozenset({
+    "maintenance_h5_discovery", "error_h5_discovery", "command_discovery",
+})
 
 
 def _selected(data: dict[str, Any], keys: tuple[str, ...]) -> dict[str, Any]:
@@ -58,22 +46,10 @@ def _mqtt_navigation_diagnostics(coordinator: Any, data: dict[str, Any]) -> dict
     location = getattr(coordinator, "_mqtt_location", None)
     location = location if isinstance(location, dict) else {}
     keys = (
-        "vehicle_state",
-        "action",
-        "sub_action",
-        "work_action",
-        "work_sub_action",
-        "work_mode",
-        "work_target_zone",
-        "mow_boundary",
-        "partition_ids",
-        "mow_progress",
-        "work_progress",
-        "mowing_percentage",
-        "mow_start_type",
-        "task_delay",
-        "pose_time",
-        "state_time",
+        "vehicle_state", "action", "sub_action", "work_action", "work_sub_action",
+        "work_mode", "work_target_zone", "mow_boundary", "partition_ids",
+        "mow_progress", "work_progress", "mowing_percentage", "mow_start_type",
+        "task_delay", "pose_time", "state_time",
     )
     cached = {key: deepcopy(location.get(key)) for key in keys if key in location}
     return {
@@ -109,7 +85,6 @@ def _polygon_diagnostics(polygons: Any) -> list[dict[str, Any]]:
                 points.append([x, y])
         if len(points) < 3:
             continue
-
         cross_sum = 0.0
         centroid_x_sum = 0.0
         centroid_y_sum = 0.0
@@ -122,24 +97,16 @@ def _polygon_diagnostics(polygons: Any) -> list[dict[str, Any]]:
         signed_area = cross_sum / 2.0
         area = abs(signed_area)
         if abs(cross_sum) > 1e-9:
-            centroid = [
-                centroid_x_sum / (3.0 * cross_sum),
-                centroid_y_sum / (3.0 * cross_sum),
-            ]
+            centroid = [centroid_x_sum / (3.0 * cross_sum), centroid_y_sum / (3.0 * cross_sum)]
         else:
-            centroid = [
-                sum(point[0] for point in points) / len(points),
-                sum(point[1] for point in points) / len(points),
-            ]
-        result.append(
-            {
-                "index": index,
-                "point_count": len(points),
-                "area_m2": round(area, 4),
-                "centroid": [round(centroid[0], 4), round(centroid[1], 4)],
-                "polygon": points,
-            }
-        )
+            centroid = [sum(point[0] for point in points) / len(points), sum(point[1] for point in points) / len(points)]
+        result.append({
+            "index": index,
+            "point_count": len(points),
+            "area_m2": round(area, 4),
+            "centroid": [round(centroid[0], 4), round(centroid[1], 4)],
+            "polygon": points,
+        })
     return result
 
 
@@ -147,26 +114,25 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant,
     entry: ConfigEntry,
 ) -> dict[str, Any]:
-    """Return a fast, cached-only sanitized diagnostics snapshot.
+    """Return a cached-only support report without invoking research or commands.
 
-    Download diagnostics makes no extra vendor or H5 requests. Runtime
-    coordinator caches contain the information needed for normal troubleshooting
-    and map/custom-area experiments.
+    Credential, account, network and geographic identifiers are redacted. Local
+    X/Y geometry and operational state remain available for troubleshooting.
+    The explicit unredacted development export is separate and unchanged.
     """
     coordinator = (hass.data.get(DOMAIN) or {}).get(entry.entry_id)
     if coordinator is None:
-        return {
+        report = {
             "format": "navimower-diagnostics-v2",
+            "redaction_version": REDACTION_VERSION,
             "created_utc": datetime.now(UTC).isoformat(),
             "read_only": True,
             "diagnostics_source": "home_assistant_download",
             "cached_only": True,
             "note": "integration not loaded; only the stored entry is available",
-            "entry": {
-                "data": sanitize(dict(entry.data)),
-                "options": _diagnostic_options(entry),
-            },
+            "entry": {"data": dict(entry.data), "options": _diagnostic_options(entry)},
         }
+        return sanitize(report, sensitive_values=(entry.data, entry.options), exclude_keys=_RETIRED_RESEARCH_KEYS)
 
     data = deepcopy(coordinator.data or {})
     map_data = data.get("map") if isinstance(data.get("map"), dict) else {}
@@ -185,242 +151,149 @@ async def async_get_config_entry_diagnostics(
     mqtt_bridge = getattr(coordinator, "mqtt_bridge", None)
     mqtt_health = (
         mqtt_bridge.diagnostic_health()
-        if mqtt_bridge is not None and hasattr(mqtt_bridge, "diagnostic_health")
-        else None
+        if mqtt_bridge is not None and hasattr(mqtt_bridge, "diagnostic_health") else None
     )
     mqtt_inventory = (
         mqtt_bridge.diagnostic_inventory()
-        if mqtt_bridge is not None and hasattr(mqtt_bridge, "diagnostic_inventory")
-        else None
+        if mqtt_bridge is not None and hasattr(mqtt_bridge, "diagnostic_inventory") else None
     )
     mqtt_discovery = (
         mqtt_bridge.diagnostic_discovery()
-        if mqtt_bridge is not None and hasattr(mqtt_bridge, "diagnostic_discovery")
-        else None
+        if mqtt_bridge is not None and hasattr(mqtt_bridge, "diagnostic_discovery") else None
     )
-    private_polling = (
-        coordinator.polling_diagnostics()
-        if hasattr(coordinator, "polling_diagnostics")
-        else None
-    )
-    problem_history = (
-        coordinator.problem_diagnostics()
-        if hasattr(coordinator, "problem_diagnostics")
-        else None
-    )
+    private_polling = coordinator.polling_diagnostics() if hasattr(coordinator, "polling_diagnostics") else None
+    problem_history = coordinator.problem_diagnostics() if hasattr(coordinator, "problem_diagnostics") else None
     notification_center = getattr(coordinator, "notification_center", None)
     notification_center_diagnostics = (
         notification_center.diagnostics()
-        if notification_center is not None
-        and hasattr(notification_center, "diagnostics")
-        else None
+        if notification_center is not None and hasattr(notification_center, "diagnostics") else None
     )
     navimower_schedule = getattr(coordinator, "navimower_schedule", None)
     navimower_schedule_diagnostics = (
         navimower_schedule.diagnostics()
-        if navimower_schedule is not None and hasattr(navimower_schedule, "diagnostics")
-        else None
+        if navimower_schedule is not None and hasattr(navimower_schedule, "diagnostics") else None
     )
-
-    history_index = (
-        coordinator.history.sessions_index_payload()
-        if getattr(coordinator, "history", None) is not None
-        else {}
-    )
+    history_index = coordinator.history.sessions_index_payload() if getattr(coordinator, "history", None) is not None else {}
     sessions = history_index.get("sessions") if isinstance(history_index, dict) else []
     sessions = sessions if isinstance(sessions, list) else []
     cycle = (
         coordinator.history.cycle_diagnostics()
-        if getattr(coordinator, "history", None) is not None
-        and hasattr(coordinator.history, "cycle_diagnostics")
-        else None
+        if getattr(coordinator, "history", None) is not None and hasattr(coordinator.history, "cycle_diagnostics") else None
     )
-
     map_version = map_data.get("map_version") or raw_index2.get("mapVersion")
     edit_map_info = raw_index2.get("editMapInfo")
     if not isinstance(edit_map_info, dict):
         edit_map_info = {}
 
-    return {
+    report = {
         "format": "navimower-diagnostics-v2",
+        "redaction_version": REDACTION_VERSION,
         "created_utc": datetime.now(UTC).isoformat(),
         "read_only": True,
         "diagnostics_source": "home_assistant_download",
         "cached_only": True,
-        "entry": {
-            "data": sanitize(deepcopy(dict(entry.data))),
-            "options": _diagnostic_options(entry),
+        "entry": {"data": dict(entry.data), "options": _diagnostic_options(entry)},
+        "mower": _selected(data, (
+            "name", "model", "vehicle_type", "state", "state_code", "activity",
+            "docked", "docked_source", "error", "error_text", "error_code",
+            "error_title", "error_content", "error_kind", "problem_source", "last_problem",
+        )),
+        "connectivity": _selected(data, (
+            "private_cloud_connected", "private_cloud_error", "oauth_configured",
+            "oauth_connected", "oauth_error", "mqtt_configured", "mqtt_connected",
+            "mqtt_error", "mqtt_stream_state", "mqtt_recovery_count", "mqtt_vehicle_state",
+            "mqtt_state_age", "mqtt_action", "mqtt_action_age",
+        )),
+        "private_cloud_region": private_cloud_region_diagnostics(coordinator),
+        "capabilities": capabilities,
+        "positioning": _selected(data, (
+            "x", "y", "heading", "pose_source", "mqtt_pose_age", "current_physical_zone",
+            "current_physical_zone_id", "current_physical_zone_source",
+            "current_physical_zone_source_age", "current_physical_zone_stale",
+            "current_channel", "current_channel_id", "current_channel_source",
+            "current_channel_pose_age", "current_channel_stale", "target_zone_ids", "target_zone_source",
+        )),
+        "mqtt_navigation": _mqtt_navigation_diagnostics(coordinator, data),
+        "mqtt_inventory": mqtt_inventory,
+        "mqtt_discovery": mqtt_discovery,
+        "telemetry": _selected(data, (
+            "battery", "battery_source", "battery_source_age", "battery_mqtt",
+            "battery_mqtt_age", "battery_private_cloud", "mowing_progress",
+            "mowing_progress_source", "mowing_progress_source_age", "task_progress_private_cloud",
+            "task_progress_source", "active_zone_progress", "active_zone_progress_source",
+            "active_zone_progress_source_age", "active_zone_progress_zone_id", "coverage_source_age",
+            "session_area", "session_area_source", "total_area", "total_area_source",
+            "coverage", "coverage_source", "zone_states", "totals",
+        )),
+        "settings": settings,
+        "navimower_schedule": navimower_schedule_diagnostics,
+        "georeference": data.get("georeference"),
+        "map_underlay": map_underlay_diagnostics(coordinator),
+        "map_edit": {
+            "state_code": data.get("state_code"),
+            "mqtt_vehicle_state": data.get("mqtt_vehicle_state"),
+            "map_version": map_version,
+            "location_map_edit_time": raw_location.get("map_edit_time"),
+            "edit_map_info": edit_map_info,
+            "edit_session_active": bool(str(edit_map_info.get("editMapUid") or "")),
         },
-        "mower": sanitize(
-            _selected(
-                data,
-                (
-                    "name", "model", "vehicle_type", "state", "state_code",
-                    "activity", "docked", "docked_source", "error", "error_text",
-                    "error_code", "error_title", "error_content", "error_kind",
-                    "problem_source", "last_problem",
-                ),
-            )
-        ),
-        "connectivity": sanitize(
-            _selected(
-                data,
-                (
-                    "private_cloud_connected", "private_cloud_error",
-                    "oauth_configured", "oauth_connected", "oauth_error",
-                    "mqtt_configured", "mqtt_connected", "mqtt_error",
-                    "mqtt_stream_state", "mqtt_recovery_count", "mqtt_vehicle_state",
-                    "mqtt_state_age", "mqtt_action", "mqtt_action_age",
-                ),
-            )
-        ),
-        "private_cloud_region": sanitize(private_cloud_region_diagnostics(coordinator)),
-        "capabilities": sanitize(deepcopy(capabilities)),
-        "maintenance_h5_discovery": {
-            "ok": True,
-            "read_only": True,
-            "beta_only": True,
-            "paused": True,
-            "removed_from_download": True,
-            "reason": "retired from normal diagnostics in 0.4.3-beta29",
-            "mutation_calls_executed": False,
+        "map": {
+            "id": map_data.get("id"), "map_id": map_data.get("map_id"),
+            "map_base_id": map_data.get("map_base_id"), "edit_time": map_data.get("edit_time"),
+            "revision": map_data.get("revision"), "map_version": map_version,
+            "name": map_data.get("name"), "version": map_data.get("version"),
+            "modified_count": map_data.get("modified_count"), "area": map_data.get("area"),
+            "zone_count": len(map_data.get("zones") or []),
+            "off_limit_count": len(map_data.get("off_limit_areas") or []),
+            "off_limit_areas": _polygon_diagnostics(map_data.get("off_limit_areas") or []),
+            "vf_off_count": len(map_data.get("vf_off_areas") or []),
+            "channel_count": len(map_data.get("channels") or []),
+            "doodle_count": len(map_data.get("doodles") or []),
+            "zone_details": deepcopy(data.get("zone_details") or []),
         },
-        "positioning": sanitize(
-            _selected(
-                data,
-                (
-                    "x", "y", "heading", "pose_source", "mqtt_pose_age",
-                    "current_physical_zone", "current_physical_zone_id",
-                    "current_physical_zone_source", "current_physical_zone_source_age",
-                    "current_physical_zone_stale", "current_channel", "current_channel_id",
-                    "current_channel_source", "current_channel_pose_age",
-                    "current_channel_stale", "target_zone_ids", "target_zone_source",
-                ),
-            )
-        ),
-        "mqtt_navigation": sanitize(_mqtt_navigation_diagnostics(coordinator, data)),
-        "mqtt_inventory": sanitize(deepcopy(mqtt_inventory)),
-        "mqtt_discovery": sanitize(deepcopy(mqtt_discovery)),
-        "telemetry": sanitize(
-            _selected(
-                data,
-                (
-                    "battery", "battery_source", "battery_source_age", "battery_mqtt",
-                    "battery_mqtt_age", "battery_private_cloud", "mowing_progress",
-                    "mowing_progress_source", "mowing_progress_source_age",
-                    "task_progress_private_cloud", "task_progress_source",
-                    "active_zone_progress", "active_zone_progress_source",
-                    "active_zone_progress_source_age", "active_zone_progress_zone_id",
-                    "coverage_source_age", "session_area", "session_area_source",
-                    "total_area", "total_area_source", "coverage", "coverage_source",
-                    "zone_states", "totals",
-                ),
-            )
-        ),
-        "settings": sanitize(deepcopy(settings)),
-        "navimower_schedule": sanitize(deepcopy(navimower_schedule_diagnostics)),
-        "georeference": sanitize(deepcopy(data.get("georeference"))),
-        "map_underlay": sanitize(map_underlay_diagnostics(coordinator)),
-        "map_edit": sanitize(
-            {
-                "state_code": data.get("state_code"),
-                "mqtt_vehicle_state": data.get("mqtt_vehicle_state"),
-                "map_version": map_version,
-                "location_map_edit_time": raw_location.get("map_edit_time"),
-                "edit_map_info": deepcopy(edit_map_info),
-                "edit_session_active": bool(str(edit_map_info.get("editMapUid") or "")),
-            }
-        ),
-        "map": sanitize(
-            {
-                "id": map_data.get("id"),
-                "map_id": map_data.get("map_id"),
-                "map_base_id": map_data.get("map_base_id"),
-                "edit_time": map_data.get("edit_time"),
-                "revision": map_data.get("revision"),
-                "map_version": map_version,
-                "name": map_data.get("name"),
-                "version": map_data.get("version"),
-                "modified_count": map_data.get("modified_count"),
-                "area": map_data.get("area"),
-                "zone_count": len(map_data.get("zones") or []),
-                "off_limit_count": len(map_data.get("off_limit_areas") or []),
-                "off_limit_areas": _polygon_diagnostics(map_data.get("off_limit_areas") or []),
-                "vf_off_count": len(map_data.get("vf_off_areas") or []),
-                "channel_count": len(map_data.get("channels") or []),
-                "doodle_count": len(map_data.get("doodles") or []),
-                "zone_details": deepcopy(data.get("zone_details") or []),
-            }
-        ),
-        "history": sanitize(
-            {
-                "retained_session_count": len(sessions),
-                "sessions": deepcopy(sessions),
-                "cycle": deepcopy(cycle),
-                "trail_active": data.get("trail_active"),
-                "trail_point_count": len(data.get("trail") or []),
-            }
-        ),
-        "problem_history": sanitize(deepcopy(problem_history)),
-        "error_investigation": sanitize(
-            {
-                "policy": "private_cloud_canonical_mqtt_transition_trigger",
-                "transition": error_transition_diagnostics(coordinator),
-                "raw_index2_vehicle_state": raw_index2.get("vehicle_state"),
-                "raw_auth_vehicle_state": raw_auth.get("vehicle_state"),
-                "raw_index2_error_data": deepcopy(raw_index2.get("error_data") or []),
-                "vendor_notification_raw_cache": deepcopy(
-                    getattr(coordinator, "_notification_raw_cache", None)
-                ),
-                "vendor_notification_normalized_cache": deepcopy(
-                    getattr(coordinator, "_notification_cache", None)
-                ),
-                "command_discovery": {
-                    "paused": True,
-                    "removed_from_download": True,
-                    "reason": "Clear/Resume/Reboot H5 discovery retired in 0.4.3-beta29",
-                },
-            }
-        ),
-        "latest_notification": sanitize(
-            {
-                "title": data.get("notification_title"),
-                "content": data.get("notification_content"),
-                "created_at": data.get("notification_created_at"),
-                "read": data.get("notification_read"),
-                "level": data.get("notification_level"),
-                "type": data.get("notification_type"),
-                "style": data.get("notification_style"),
-                "variable": deepcopy(data.get("notification_variable")),
-                "notification_code": data.get("notification_code"),
-                "origin": data.get("notification_origin"),
-                "kind": data.get("notification_kind"),
-                "confidence": data.get("notification_confidence"),
-                "count": data.get("notification_count"),
-                "vendor_count": data.get("notification_vendor_count"),
-                "local_count": data.get("notification_local_count"),
-                "source": data.get("notification_source"),
-                "source_age": data.get("notification_source_age"),
-                "vendor_source_age": data.get("notification_vendor_source_age"),
-                "last_error": data.get("notification_error"),
-                "recent": deepcopy(data.get("notification_history") or []),
-            }
-        ),
-        "notification_center": sanitize(deepcopy(notification_center_diagnostics)),
+        "history": {
+            "retained_session_count": len(sessions), "sessions": sessions, "cycle": cycle,
+            "trail_active": data.get("trail_active"), "trail_point_count": len(data.get("trail") or []),
+        },
+        "problem_history": problem_history,
+        "error_investigation": {
+            "policy": "private_cloud_canonical_mqtt_transition_trigger",
+            "transition": error_transition_diagnostics(coordinator),
+            "raw_index2_vehicle_state": raw_index2.get("vehicle_state"),
+            "raw_auth_vehicle_state": raw_auth.get("vehicle_state"),
+            "raw_index2_error_data": deepcopy(raw_index2.get("error_data") or []),
+            "vendor_notification_raw_cache": deepcopy(getattr(coordinator, "_notification_raw_cache", None)),
+            "vendor_notification_normalized_cache": deepcopy(getattr(coordinator, "_notification_cache", None)),
+        },
+        "latest_notification": {
+            "title": data.get("notification_title"), "content": data.get("notification_content"),
+            "created_at": data.get("notification_created_at"), "read": data.get("notification_read"),
+            "level": data.get("notification_level"), "type": data.get("notification_type"),
+            "style": data.get("notification_style"), "variable": deepcopy(data.get("notification_variable")),
+            "notification_code": data.get("notification_code"), "origin": data.get("notification_origin"),
+            "kind": data.get("notification_kind"), "confidence": data.get("notification_confidence"),
+            "count": data.get("notification_count"), "vendor_count": data.get("notification_vendor_count"),
+            "local_count": data.get("notification_local_count"), "source": data.get("notification_source"),
+            "source_age": data.get("notification_source_age"), "vendor_source_age": data.get("notification_vendor_source_age"),
+            "last_error": data.get("notification_error"), "recent": deepcopy(data.get("notification_history") or []),
+        },
+        "notification_center": notification_center_diagnostics,
         "last_resume_command": None,
-        "private_polling": sanitize(deepcopy(private_polling)),
-        "mqtt_health": sanitize(deepcopy(mqtt_health)),
-        "raw": sanitize(raw_for_diagnostics),
+        "private_polling": private_polling,
+        "mqtt_health": mqtt_health,
+        "raw": raw_for_diagnostics,
         "notes": [
-            "0.4.3-beta42 adds cached MQTT navigation fields and passive MQTT discovery output for controlled gate-transition research.",
-            "Download diagnostics remain cached-only and make no extra vendor or H5 requests.",
-            "Georeference diagnostics expose local map transform and validation metadata while physical GPS coordinates remain redacted.",
-            "Map underlay diagnostics expose only configured/availability/session status; the Google API key and Google session token are never exported.",
-            "Enable Passive MQTT discovery temporarily when raw event/location samples are needed; samples are sanitized by the existing discovery pipeline.",
-            "Clear/Resume/Reboot discovery, Mowing Reports research and Maintenance research payloads are retired from normal diagnostics.",
-            "index2.mapVersion is the fast vendor map revision signal; a change forces location/map-list and map geometry refresh in the same private-cloud poll.",
-            "Off-limit polygons remain local map X/Y coordinates and are included for temporary-off-limit custom-area experiments.",
-            "Map edit diagnostics retain state, official MQTT mapping state and editMapInfo so calibration/edit sessions can be compared without extra requests.",
-            "Account, mower, network and physical GPS identifiers are sanitized/redacted.",
+            "Download diagnostics is cached-only: no extra vendor requests, commands or research crawls.",
+            "Credential and identifying field names are matched across snake_case, camelCase and acronym variants.",
+            "URL credentials, paths, query strings and fragments are omitted; only service origins remain.",
+            "Georeference diagnostics retain local transform/validation context; geographic coordinates are redacted.",
+            "Map underlay diagnostics retain availability/session status, not Google keys or session tokens.",
+            "Local X/Y geometry, names and activity times remain useful support data: review them before sharing.",
+            "The explicit navimower.export_raw_data development export is separate and remains unredacted.",
         ],
     }
+    return sanitize(
+        report,
+        sensitive_values=(entry.data, entry.options, data, {"vehicle_sn": getattr(coordinator, "sn", None)}),
+        exclude_keys=_RETIRED_RESEARCH_KEYS,
+    )

--- a/custom_components/navimower/diagnostics_sanitize.py
+++ b/custom_components/navimower/diagnostics_sanitize.py
@@ -1,141 +1,232 @@
-"""Sanitization helpers for Home Assistant Download diagnostics."""
+"""Sanitization helpers for support diagnostics, never the explicit raw export.
+
+Use word boundaries as well as known aliases: ``editMapUid`` must be hidden,
+while ``mapping``, ``map_id`` and capability ranges must remain useful. This
+follows the diagnostics-hardening direction of navimow_pro v0.5.1, with extra
+handling for acronym keys, JSON strings, URLs and free-text credentials.
+"""
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 import hashlib
+import ipaddress
 import json
+import math
+import re
 from typing import Any
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import quote, urlsplit, urlunsplit
+
+REDACTED = "<redacted>"
+REDACTION_VERSION = 3
+_MAX_DEPTH = 32
+_MAX_STRING = 16_384
 
 _EXACT_SENSITIVE_KEYS = {
-    "access_token",
-    "refresh_token",
-    "token",
-    "password",
-    "pwd",
-    "pwdinfo",
-    "secret",
-    "authorization",
-    "cookie",
-    "email",
-    "phone",
-    "uid",
-    "uuid",
-    "auth_uid",
-    "user_id",
-    "userid",
-    "username",
-    "user_name",
-    "vehicle_sn",
-    "serial",
-    "serial_number",
-    "sn",
-    "device_id",
-    "oauth_device_id",
-    "client_id",
-    "ssid",
-    "bssid",
-    "mac",
-    "ip",
-    "ip_address",
-    "iccid",
-    "pin_code",
-    "pincode",
-    "rtk",
-    "anchor",
-    "anti_theft_point",
-    "antitheftpoint",
-    "latitude",
-    "longitude",
-    "last_latitude",
-    "last_longitude",
-    "origin_gps",
-    "center_gps",
-    "ne_gps",
-    "sw_gps",
+    "access_token", "refresh_token", "token", "password", "passwd", "pwd",
+    "pwdinfo", "secret", "authorization", "cookie", "email", "phone", "uid",
+    "uuid", "auth_uid", "user_id", "userid", "username", "user_name",
+    "vehicle_sn", "serial", "serial_number", "sn", "device_id",
+    "oauth_device_id", "client_id", "ssid", "bssid", "mac", "ip",
+    "ip_address", "iccid", "imei", "imsi", "msisdn", "pin", "pin_code",
+    "pincode", "rtk", "anchor", "anti_theft_point", "antitheftpoint",
+    "latitude", "longitude", "last_latitude", "last_longitude", "origin_gps",
+    "center_gps", "ne_gps", "sw_gps", "api_key", "session_key",
+    "client_key", "private_key", "encryption_key", "signing_key",
 }
+_SENSITIVE_WORDS = frozenset({
+    "latitude", "longitude", "lat", "lng", "lon", "gps", "coord", "coords",
+    "token", "serial", "sn", "uid", "uuid", "imei", "iccid", "iccids",
+    "imsi", "msisdn", "email", "mail", "username", "password", "passwd",
+    "pwd", "pin", "pincode", "secret", "theft", "authorization", "cookie",
+    "ssid", "bssid", "mac", "ip", "phone",
+})
+_ACRONYM_BOUNDARY = re.compile(r"([A-Z]+)([A-Z][a-z])")
+_CAMEL_BOUNDARY = re.compile(r"([a-z0-9])([A-Z])")
+_WORD_BOUNDARY = re.compile(r"[^A-Za-z0-9]+")
+_COMPACT_SENSITIVE_KEYS = frozenset(
+    re.sub(r"[^a-z0-9]", "", key.lower()) for key in _EXACT_SENSITIVE_KEYS
+)
+_URL = re.compile(r"[A-Za-z][A-Za-z0-9+.-]*://[^\s<>\"']+")
+_EMAIL = re.compile(r"(?i)(?<![\w.+-])[\w.+-]+@[a-z0-9.-]+\.[a-z]{2,}(?![\w.-])")
+_BEARER = re.compile(r"(?i)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/-]+=*")
+_UUID = re.compile(r"(?i)\b[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\b")
+_MAC = re.compile(r"(?i)(?<![0-9a-f])(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}(?![0-9a-f])")
+_IPV4 = re.compile(r"(?<![\w.])(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?![\w.])")
+_JWT = re.compile(r"(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?![A-Za-z0-9_-])")
+_OPAQUE = re.compile(r"[A-Za-z0-9_+/=-]{256,}\Z")
+_LITERAL_SKIP = frozenset({REDACTED, "**REDACTED**", "<redacted-url>", "unknown", "unavailable", "Bearer", "bearer", "private_cloud"})
+_ASSIGNMENT = re.compile(
+    r"(?P<prefix>(?P<key>[A-Za-z][A-Za-z0-9_.-]*)[\"']?\s*[:=]\s*)"
+    r"(?P<value>\"[^\"\r\n]*\"|'[^'\r\n]*'|[^\s,;}\]]+)"
+)
+
+
+def _key_words(key: str) -> tuple[str, ...]:
+    text = _ACRONYM_BOUNDARY.sub(r"\1_\2", str(key))
+    text = _CAMEL_BOUNDARY.sub(r"\1_\2", text)
+    return tuple(word.lower() for word in _WORD_BOUNDARY.split(text) if word)
 
 
 def _is_sensitive_key(key: str) -> bool:
-    normalized = str(key).strip().lower().replace("-", "_")
-    if normalized in _EXACT_SENSITIVE_KEYS:
+    words = _key_words(key)
+    compact = "".join(words)
+    if compact in _COMPACT_SENSITIVE_KEYS or _SENSITIVE_WORDS.intersection(words):
         return True
-    if "token" in normalized or "password" in normalized or "secret" in normalized:
+    # Preserve the previous protection for unseparated credential names too.
+    if any(marker in compact for marker in ("token", "password", "secret", "latitude", "longitude")):
         return True
-    if normalized == "api_key" or normalized.endswith("_api_key"):
+    word_set = set(words)
+    if "key" in word_set and word_set.intersection({"api", "session", "client", "private", "encryption", "signing"}):
         return True
-    if normalized.endswith("_uid") or normalized.endswith("_uuid"):
-        return True
-    if "latitude" in normalized or "longitude" in normalized:
-        return True
-    if normalized.endswith("_gps") or normalized.startswith("gps_"):
-        return True
-    if normalized.endswith("_ssid") or normalized.endswith("_bssid"):
-        return True
-    return False
+    return bool("id" in word_set and word_set.intersection({"device", "user", "client", "account", "vehicle", "mower"}))
 
 
 def _safe_url(value: str) -> str:
-    """Keep only the non-sensitive location portion of a URL-like value."""
+    """Keep the service origin only; paths may contain signed or identifying data."""
     try:
         parsed = urlsplit(value)
-    except ValueError:
-        return "<redacted-url>"
-    if not parsed.scheme:
-        return "<redacted-url>"
-    host = parsed.hostname or parsed.netloc or ""
-    try:
+        if not parsed.scheme or not parsed.hostname:
+            return "<redacted-url>"
+        host = parsed.hostname
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            pass
+        else:
+            host = "redacted-host"
         port = f":{parsed.port}" if parsed.port else ""
-    except ValueError:
-        port = ""
-    location = f"{host}{port}" if host else parsed.netloc
-    return urlunsplit((parsed.scheme, location, parsed.path, "", ""))
+        return urlunsplit((parsed.scheme, f"{host}{port}", "", "", ""))
+    except (TypeError, ValueError):
+        return "<redacted-url>"
 
 
 def _large_value_summary(value: str) -> dict[str, Any]:
     raw = value.encode("utf-8", errors="replace")
-    return {
-        "_omitted": "large_string",
-        "length": len(value),
-        "sha256": hashlib.sha256(raw).hexdigest(),
-    }
+    return {"_omitted": "large_string", "length": len(value), "sha256": hashlib.sha256(raw).hexdigest()}
 
 
-def sanitize(value: Any, *, key: str | None = None) -> Any:
-    """Recursively redact account, mower, network and GPS identifiers."""
-    if key is not None and _is_sensitive_key(key):
-        return "<redacted>"
+def _json_value(value: str) -> Any:
+    if value.lstrip()[:1] not in ("{", "["):
+        return None
+    try:
+        return json.loads(value)
+    except (ValueError, TypeError, RecursionError):
+        return None
 
+
+def _sensitive_literals(value: Any, *, depth: int = 0, sensitive: bool = False) -> set[str]:
+    """Find repeated identifiers before field redaction removes their context.
+
+    Do not globally replace short PINs or numeric GPS values: doing so could
+    corrupt unrelated error codes and measurements. Those are removed by field
+    names and labelled-text rules. Long textual credentials and identifiers are
+    also removed if echoed elsewhere, including dictionary keys and URLs.
+    """
+    if depth >= _MAX_DEPTH:
+        return set()
+    out: set[str] = set()
     if isinstance(value, Mapping):
-        return {str(k): sanitize(v, key=str(k)) for k, v in value.items()}
-
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        return [sanitize(item) for item in value]
-
-    if isinstance(value, (bytes, bytearray)):
-        raw = bytes(value)
-        return {
-            "_omitted": "bytes",
-            "length": len(raw),
-            "sha256": hashlib.sha256(raw).hexdigest(),
-        }
-
-    if isinstance(value, str):
-        stripped = value.strip()
-        if "://" in stripped:
-            return _safe_url(stripped)
-        if stripped[:1] in ("{", "["):
-            try:
-                decoded = json.loads(stripped)
-            except (TypeError, ValueError):
-                decoded = None
+        for key, child in value.items():
+            out.update(_sensitive_literals(child, depth=depth + 1, sensitive=sensitive or _is_sensitive_key(str(key))))
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for child in value:
+            out.update(_sensitive_literals(child, depth=depth + 1, sensitive=sensitive))
+    elif isinstance(value, str):
+        if sensitive and 6 <= len(value) <= _MAX_STRING and value not in _LITERAL_SKIP:
+            out.add(value)
+            out.add(quote(value, safe=""))
+        elif len(value) <= _MAX_STRING:
+            decoded = _json_value(value)
             if decoded is not None:
-                return sanitize(decoded)
-        if len(value) > 16_384:
-            return _large_value_summary(value)
-        return value
+                out.update(_sensitive_literals(decoded, depth=depth + 1))
+    return out
 
-    if value is None or isinstance(value, (bool, int, float)):
-        return value
 
-    return repr(value)
+def _safe_text(value: str, literals: tuple[str, ...]) -> str:
+    text = _URL.sub(lambda match: _safe_url(match.group()), value)
+    text = _BEARER.sub(lambda match: f"{match.group(1)} {REDACTED}", text)
+    text = _JWT.sub(REDACTED, text)
+    text = _EMAIL.sub(REDACTED, text)
+    text = _UUID.sub(REDACTED, text)
+    text = _MAC.sub(REDACTED, text)
+
+    def address(match: re.Match[str]) -> str:
+        try:
+            ipaddress.ip_address(match.group())
+        except ValueError:
+            return match.group()
+        return REDACTED
+
+    text = _IPV4.sub(address, text)
+    text = _ASSIGNMENT.sub(
+        lambda match: match.group("prefix") + REDACTED
+        if _is_sensitive_key(match.group("key")) else match.group(),
+        text,
+    )
+    for literal in literals:
+        text = text.replace(literal, REDACTED)
+    return text
+
+
+def sanitize(
+    value: Any,
+    *,
+    key: str | None = None,
+    sensitive_values: Any = (),
+    exclude_keys: frozenset[str] = frozenset(),
+) -> Any:
+    """Return a new redacted JSON-safe object without modifying live/raw state.
+
+    ``sensitive_values`` supplies additional local context (for example entry
+    tokens) for values already removed from individual report sections. The
+    optional exclusions are used only by Download diagnostics to omit retired
+    research blocks; the explicit raw-data export does not call this function.
+    """
+    literals = tuple(sorted(
+        _sensitive_literals(value) | _sensitive_literals(sensitive_values),
+        key=lambda item: (-len(item), item),
+    ))
+    omitted_keys = {"".join(_key_words(item)) for item in exclude_keys}
+
+    def walk(current: Any, field: str | None = None, depth: int = 0) -> Any:
+        if field is not None and _is_sensitive_key(field):
+            return REDACTED
+        if depth >= _MAX_DEPTH:
+            return {"_omitted": "max_depth"}
+        if isinstance(current, Mapping):
+            result: dict[str, Any] = {}
+            for raw_key, child in current.items():
+                child_key = str(raw_key)
+                if "".join(_key_words(child_key)) in omitted_keys:
+                    continue
+                safe_key = _safe_text(child_key, literals)
+                if safe_key in result:
+                    # Distinct private identifiers can redact to the same key.
+                    suffix = 2
+                    while f"{safe_key}#{suffix}" in result:
+                        suffix += 1
+                    safe_key = f"{safe_key}#{suffix}"
+                result[safe_key] = walk(child, child_key, depth + 1)
+            return result
+        if isinstance(current, Sequence) and not isinstance(current, (str, bytes, bytearray)):
+            return [walk(child, depth=depth + 1) for child in current]
+        if isinstance(current, (bytes, bytearray)):
+            raw = bytes(current)
+            return {"_omitted": "bytes", "length": len(raw), "sha256": hashlib.sha256(raw).hexdigest()}
+        if isinstance(current, str):
+            if len(current) > _MAX_STRING:
+                return _large_value_summary(current)
+            decoded = _json_value(current)
+            if decoded is not None:
+                return walk(decoded, depth=depth + 1)
+            if _OPAQUE.fullmatch(current.strip()):
+                return {**_large_value_summary(current), "_omitted": "opaque_string"}
+            return _safe_text(current, literals)
+        if isinstance(current, float) and not math.isfinite(current):
+            return None
+        if current is None or isinstance(current, (bool, int, float)):
+            return current
+        # repr() can contain credentials or a complete private object dump.
+        return {"_omitted": "unsupported_type", "type": type(current).__name__}
+
+    return walk(value, key)

--- a/docs/DIAGNOSTICS_PRIVACY.md
+++ b/docs/DIAGNOSTICS_PRIVACY.md
@@ -1,0 +1,87 @@
+# Download diagnostics and the explicit raw development export
+
+## Scope of this cleanup
+
+The privacy cleanup changes Home Assistant **Download diagnostics**, not the
+mower protocol, authentication, runtime telemetry, mapping, schedule or the
+explicit `navimower.export_raw_data` action.
+
+It follows the field-name redaction approach described in
+[navimow_pro v0.5.1](https://github.com/ilguala/navimow_pro/releases/tag/v0.5.1).
+The upstream author's [response to issue #13](https://github.com/ilguala/navimow_pro/issues/13)
+acknowledges diagnostic disclosure and asks for concrete details about the other
+concerns. This cleanup does not claim vendor approval or settle those questions.
+
+## Download diagnostics
+
+The report continues to use `format: navimower-diagnostics-v2` and additionally
+identifies its redaction policy with `redaction_version: 3`.
+
+Field names are checked across snake_case, camelCase, acronyms and known compact
+aliases. This includes credentials, account/device identifiers, anti-theft PINs,
+SIM identifiers, geographic coordinates and edit-session user IDs. For example,
+`editMapUid`, `newPINCode`, `vehicleSn`, `deviceId`, `sessionKey` and `apiKey` no
+longer avoid redaction through spelling variations.
+
+Words are not arbitrary substrings: `mapping` and `spinning` must not be treated
+as PIN fields. Map/zone/task IDs, feature flags, cutting-height ranges, coverage,
+completion timestamps, command state and freshness metadata remain useful.
+
+The report also handles nested JSON strings, common labelled credentials in
+free text, Bearer/Basic credentials, email addresses, UUIDs, MAC addresses and
+IPv4 addresses. Repeated known textual identifiers are removed from other
+values and dictionary keys. URL user information, paths, query strings and
+fragments are removed; only the service origin is retained. Large strings,
+opaque encoded strings, binary values and unsupported Python objects are
+summarized rather than exposing an arbitrary object representation.
+
+Redaction is applied to the complete assembled report, including unloaded-entry
+reports, config options, cached MQTT samples and nested vendor responses. It
+creates a new object and does not mutate the original runtime caches or entry.
+
+### No H5 research in ordinary diagnostics
+
+The inactive maintenance/error H5 placeholder blocks and historical executable-
+looking string markers are removed from the Download handler. Retired
+`maintenance_h5_discovery`, `error_h5_discovery` and `command_discovery` blocks
+are omitted recursively even when an older cache still contains them.
+
+Ordinary Download diagnostics stays cached-only: no research crawler, new
+vendor request, mower command or raw-export action is invoked. The standalone
+research modules are not removed by this change; they are not imported or
+executed by Download diagnostics.
+
+### Data that deliberately remains
+
+Local map X/Y coordinates, local polygons, user-chosen mower/zone names and
+activity times remain available for the existing map, gate and schedule support
+workflow. This is **not a promise of complete anonymity**. Review those fields
+before posting a report, especially names containing personal information.
+Redaction tests cannot prove that every future opaque vendor payload is safe.
+
+## Raw export remains unchanged
+
+`navimower.export_raw_data` is a separate, explicitly invoked development action.
+It retains exact vendor payloads, local/geographic map data and identifiers in a
+file below `/config/navimower_diagnostics/raw`. Its existing warning not to post
+it publicly still applies. This cleanup does not add automatic uploads, new
+confirmation steps, permission changes or filtering to that action.
+
+Only synthetic test fixtures belong in the public test suite. Private field
+captures used during development are not committed or published by the tests.
+
+## Previously shared files
+
+A software update does not sanitize a file that was already downloaded or
+shared. Review older public diagnostics and replace/remove affected uploads.
+If a usable credential was disclosed, revoke or rotate it as appropriate;
+removing a link is not a guarantee that existing copies disappear. The upstream
+v0.5.1 incident is not, by itself, evidence that a Navimower user credential has
+been publicly disclosed.
+
+## Verification
+
+Permanent tests execute the real redactor and the loaded/unloaded Download
+handler with synthetic caches. They check naming variants, false positives,
+JSON/text/URL handling, retained support fields, non-mutation and absence of
+research/vendor calls. They do not use live mower accounts or private captures.

--- a/tests/diagnostics_contract.py
+++ b/tests/diagnostics_contract.py
@@ -1,0 +1,56 @@
+"""Shared assertions for the current support-report contract.
+
+Keep historical runtime regressions, but do not force obsolete diagnostic
+crawlers or inert source-marker strings back into production code.
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+COMPONENT = Path(__file__).resolve().parents[1] / "custom_components" / "navimower"
+
+
+def load_redactor():
+    spec = importlib.util.spec_from_file_location(
+        "navimower_contract_redactor", COMPONENT / "diagnostics_sanitize.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def assert_cached_diagnostics_only(source: str) -> None:
+    """Check imports/calls/returned objects, not comments pretending to be code."""
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            assert "h5_discovery" not in (node.module or "")
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in {"probe_error_h5", "probe_maintenance_h5", "async_export_raw_data"}
+            elif isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in {"async_add_executor_job", "urlopen", "async_send"}
+        if isinstance(node, ast.Dict):
+            emitted_keys = {
+                key.value for key in node.keys
+                if isinstance(key, ast.Constant) and isinstance(key.value, str)
+            }
+            assert not emitted_keys.intersection({
+                "maintenance_h5_discovery", "error_h5_discovery", "command_discovery"
+            })
+    handler = next(
+        node for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name == "async_get_config_entry_diagnostics"
+    )
+    returns = [node for node in ast.walk(handler) if isinstance(node, ast.Return)]
+    assert len(returns) == 2, "loaded and unloaded reports must both be protected"
+    for node in returns:
+        assert isinstance(node.value, ast.Call)
+        assert isinstance(node.value.func, ast.Name) and node.value.func.id == "sanitize"
+        assert any(keyword.arg == "exclude_keys" for keyword in node.value.keywords)
+    assert '"cached_only": True' in source
+    assert "_RETIRED_H5_DISCOVERY_HISTORY" not in source

--- a/tests/test_beta42_mqtt_navigation_diagnostics.py
+++ b/tests/test_beta42_mqtt_navigation_diagnostics.py
@@ -1,25 +1,59 @@
-"""Regression checks for beta42 gate-transition diagnostics."""
+"""Regression checks for gate-transition diagnostics independent of formatting.
+
+The completed report is now sanitized once so repeated identifiers can be
+removed across sections. Do not require a per-section sanitizer expression.
+"""
 from __future__ import annotations
 
+import ast
+from copy import deepcopy
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 DIAGNOSTICS = ROOT / "custom_components" / "navimower" / "diagnostics.py"
-source = DIAGNOSTICS.read_text(encoding="utf-8")
 
-for marker in (
-    "def _mqtt_navigation_diagnostics",
-    '"cached_location": cached',
-    '"work_sub_action"',
-    '"work_target_zone"',
-    '"mow_boundary"',
-    '"partition_ids"',
-    '"gate_states"',
-    '"gate_arrival_guards"',
-    '"mqtt_navigation": sanitize(_mqtt_navigation_diagnostics(coordinator, data))',
-    'mqtt_bridge.diagnostic_inventory()',
-    'mqtt_bridge.diagnostic_discovery()',
-):
-    assert marker in source, marker
 
-print("beta42 MQTT navigation diagnostic tests passed")
+def test_mqtt_navigation_snapshot_preserves_gate_evidence_without_aliasing():
+    tree = ast.parse(DIAGNOSTICS.read_text(encoding="utf-8"))
+    function = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_mqtt_navigation_diagnostics"
+    )
+    module = ast.Module(body=[function], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {"Any": Any, "deepcopy": deepcopy}
+    exec(compile(module, str(DIAGNOSTICS), "exec"), namespace)
+    location = {
+        "work_sub_action": 2,
+        "work_target_zone": 37,
+        "mow_boundary": True,
+        "partition_ids": [36, 37],
+        "unrelated_large_payload": "not a navigation field",
+    }
+    data = {
+        "mqtt_pose_age": 3.0,
+        "current_physical_zone_id": 36,
+        "target_zone_ids": [37],
+        "target_zone_source": "mqtt_work_target",
+        "gate_states": {"gate": {"required": True}},
+        "gate_arrival_guards": {"gate": {"to_zone_id": 37}},
+    }
+    snapshot = namespace["_mqtt_navigation_diagnostics"](
+        SimpleNamespace(_mqtt_location=location), data
+    )
+    assert snapshot["cached_location"] == {
+        key: value for key, value in location.items()
+        if key != "unrelated_large_payload"
+    }
+    assert snapshot["physical_zone_id"] == 36
+    assert snapshot["target_zone_ids"] == [37]
+    assert snapshot["pose_age_s"] == 3.0
+    assert snapshot["gate_states"] == data["gate_states"]
+    assert snapshot["gate_arrival_guards"] == data["gate_arrival_guards"]
+    snapshot["cached_location"]["partition_ids"].append(99)
+    snapshot["gate_states"]["gate"]["required"] = False
+    assert location["partition_ids"] == [36, 37]
+    assert data["gate_states"]["gate"]["required"] is True

--- a/tests/test_diagnostics_privacy.py
+++ b/tests/test_diagnostics_privacy.py
@@ -1,0 +1,228 @@
+"""Behavioral diagnostics privacy regressions using synthetic data only.
+
+No actual account, mower identifier, garden geometry or uploaded diagnostics is
+committed. These tests execute the sanitizer and the loaded/unloaded Download
+handler rather than relying on inert research-code markers.
+"""
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+COMPONENT = Path(__file__).resolve().parents[1] / "custom_components" / "navimower"
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+sanitizer = _load("_privacy_sanitizer", COMPONENT / "diagnostics_sanitize.py")
+
+
+@pytest.mark.parametrize("key", [
+    "last_latitude", "lastLongitude", "GPSLatitude", "gpsLAT", "gpsCoords",
+    "nextGpsPosition", "pin_code", "pinCode", "newPINCode", "iccid", "simICCID",
+    "imei", "imsi", "msisdn", "antiTheftPoint", "antiTheftRadius", "editMapUid",
+    "editMapUID", "vehicleSn", "vehicleSN", "serialNumber", "deviceId",
+    "oauthDeviceID", "userID", "accountId", "mowerId", "vehicleId", "clientId",
+    "apiKey", "api_key", "sessionKey", "session_key", "privateKey", "signingKey",
+    "clientKey", "encryptionKey", "futureApiKey", "newAccessToken", "accesstoken",
+    "session_secret", "SESSION_SECRET", "authORIZATION", "cookie", "setCookie",
+    "email", "userName", "wifiSSID", "wifiBSSID", "ipAddress", "macAddress",
+    "nested.user_id", "phoneNumber", "pwdInfo", "password", "last_longitude",
+])
+def test_sensitive_names_are_redacted_at_every_nesting(key):
+    source = {"outer": [{key: "synthetic-sensitive-value"}]}
+    original = deepcopy(source)
+    assert sanitizer.sanitize(source) == {"outer": [{key: sanitizer.REDACTED}]}
+    assert source == original
+
+
+@pytest.mark.parametrize("key", [
+    "mapping", "spinning", "map_id", "mapId", "mapVersion", "partitionIds",
+    "zone_id", "task_id", "countryCode", "isCutterHeight", "mowingHeightList",
+    "map_area_limit", "height", "mowingPathWidth", "chargingLimit", "startPlan",
+    "active_zone_id", "last_completed_at", "mqtt_pose_age", "work_target_zone",
+    "mqtt_connected", "source", "error_code", "code", "type", "headlight",
+])
+def test_support_fields_are_not_redacted_by_short_substrings(key):
+    assert sanitizer.sanitize({key: [30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80]}) == {
+        key: [30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80]
+    }
+
+
+def test_nested_json_and_case_variants():
+    source = {"payload": json.dumps({"nested": [{"editMapUID": "private-map-editor", "pinCode": 4321}], "mapId": 17})}
+    clean = sanitizer.sanitize(source)
+    assert clean["payload"]["nested"][0] == {"editMapUID": sanitizer.REDACTED, "pinCode": sanitizer.REDACTED}
+    assert clean["payload"]["mapId"] == 17
+
+
+def test_free_text_credentials_and_network_values():
+    source = {"error": "denied Bearer synthetic.jwt.value email demo@example.invalid apiKey=abc123 pin_code=4321 from 192.0.2.4 12:34:56:78:90:ab"}
+    text = sanitizer.sanitize(source)["error"]
+    for private in ("synthetic.jwt.value", "demo@example.invalid", "abc123", "4321", "192.0.2.4", "12:34:56:78:90:ab"):
+        assert private not in text
+    assert "denied" in text
+
+
+def test_url_origin_only_without_losing_surrounding_message():
+    source = {"error": "request https://alice:password@api.example.invalid/devices/private-id?token=private-token#private failed"}
+    assert sanitizer.sanitize(source)["error"] == "request https://api.example.invalid failed"
+    assert sanitizer.sanitize({"url": "https://[2001:db8::1]:443/private"})["url"] == "https://redacted-host:443"
+    assert sanitizer.sanitize({"url": "https://api.example.invalid:bad/private"})["url"] == "<redacted-url>"
+
+
+def test_known_identifiers_echoed_in_values_and_dictionary_keys():
+    source = {
+        "vehicleSn": "DEMO-MOWER-ONLY",
+        "error": "problem on DEMO-MOWER-ONLY",
+        "topics": {
+            "/downlink/vehicle/DEMO-MOWER-ONLY/state": {"code": 6108},
+        },
+    }
+    clean = sanitizer.sanitize(source)
+    assert "DEMO-MOWER-ONLY" not in json.dumps(clean)
+    assert clean["topics"]["/downlink/vehicle/<redacted>/state"]["code"] == 6108
+    context_clean = sanitizer.sanitize({"error": "token echo DEMO-TOKEN-ONLY"}, sensitive_values={"accessToken": "DEMO-TOKEN-ONLY"})
+    assert "DEMO-TOKEN-ONLY" not in context_clean["error"]
+
+
+def test_dictionary_redaction_collisions_preserve_both_records():
+    source = {"users": {"one@example.invalid": {"state": 1}, "two@example.invalid": {"state": 2}}}
+    values = list(sanitizer.sanitize(source)["users"].values())
+    assert values == [{"state": 1}, {"state": 2}]
+
+
+def test_binary_long_opaque_and_unknown_values_do_not_echo_contents():
+    class PrivateObject:
+        def __repr__(self):
+            raise AssertionError("Object repr must never be used in support diagnostics")
+    clean = sanitizer.sanitize({"bytes": b"private binary", "long": "a" * 20000, "opaque": "Q" * 512, "unknown": PrivateObject(), "bad_float": float("nan")})
+    assert clean["bytes"]["_omitted"] == "bytes"
+    assert clean["long"]["_omitted"] == "large_string"
+    assert clean["opaque"]["_omitted"] == "opaque_string"
+    assert clean["unknown"] == {"_omitted": "unsupported_type", "type": "PrivateObject"}
+    assert clean["bad_float"] is None
+    json.dumps(clean, allow_nan=False)
+
+
+def test_recursion_is_bounded_and_sanitizing_is_idempotent():
+    cyclic = {}; cyclic["self"] = cyclic
+    json.dumps(sanitizer.sanitize(cyclic))
+    source = {"email": "demo@example.invalid", "entry": {"pin_code": "4321"}, "map_id": "demo-map", "error": "Bearer abc.def.ghi", "url": "https://example.invalid/private"}
+    clean = sanitizer.sanitize(source)
+    assert sanitizer.sanitize(clean) == clean
+
+
+def test_exclusions_apply_only_when_requested_and_do_not_touch_source():
+    source = {"raw": {"error_h5_discovery": {"snippet": "PRIVATE_RESEARCH"}, "command_discovery": {"snippet": "PRIVATE_COMMAND"}, "mapId": 12}}
+    original = deepcopy(source)
+    clean = sanitizer.sanitize(source, exclude_keys=frozenset({"error_h5_discovery", "command_discovery"}))
+    assert clean == {"raw": {"mapId": 12}}
+    assert "error_h5_discovery" in sanitizer.sanitize(source)["raw"]
+    assert source == original
+
+
+@pytest.fixture
+def diagnostics(monkeypatch):
+    """Import the real handler without booting Home Assistant or its runtime."""
+    package = "_navimower_privacy_test"
+    root = ModuleType(package); root.__path__ = [str(COMPONENT)]
+    monkeypatch.setitem(sys.modules, package, root)
+    monkeypatch.setitem(sys.modules, package + ".diagnostics_sanitize", sanitizer)
+    for name, attrs in {
+        "homeassistant": {},
+        "homeassistant.config_entries": {"ConfigEntry": object},
+        "homeassistant.core": {"HomeAssistant": object},
+        package + ".const": {"DOMAIN": "navimower", "OPT_GOOGLE_MAPS_API_KEY": "google_maps_api_key"},
+        package + ".capability_profile": {"build_capability_profile": lambda data: {}},
+        package + ".map_underlay": {"map_underlay_diagnostics": lambda coordinator: {"configured": False}},
+        package + ".private_cloud_region": {"private_cloud_region_diagnostics": lambda coordinator: {"region": "fra"}},
+        package + ".state_semantics": {"error_transition_diagnostics": lambda coordinator: {"code": 6108}},
+    }.items():
+        stub = ModuleType(name)
+        for key, value in attrs.items(): setattr(stub, key, value)
+        monkeypatch.setitem(sys.modules, name, stub)
+    return _load(package + ".diagnostics", COMPONENT / "diagnostics.py")
+
+
+def _entry():
+    return SimpleNamespace(
+        entry_id="synthetic-entry",
+        data={"access_token": "DEMO-TOKEN-ONLY", "vehicle_sn": "DEMO-MOWER-ONLY", "model": "H-test"},
+        options={"google_maps_api_key": "DEMO-GOOGLE-KEY", "chargingLimit": 100},
+    )
+
+
+def test_unloaded_download_cleans_entry_and_options(diagnostics):
+    entry = _entry()
+    entry.data["error"] = "echo DEMO-GOOGLE-KEY"
+    hass = SimpleNamespace(data={})
+    report = asyncio.run(diagnostics.async_get_config_entry_diagnostics(hass, entry))
+    assert report["cached_only"] is True
+    assert report["redaction_version"] == sanitizer.REDACTION_VERSION
+    assert report["entry"]["data"]["access_token"] == sanitizer.REDACTED
+    assert "google_maps_api_key" not in report["entry"]["options"]
+    assert "DEMO-GOOGLE-KEY" not in json.dumps(report)
+    assert entry.data["access_token"] == "DEMO-TOKEN-ONLY"
+
+
+def test_loaded_download_is_cached_only_and_omits_retired_research(diagnostics):
+    entry = _entry()
+    class NoIO:
+        def __getattr__(self, name):
+            raise AssertionError(f"Download must not call a vendor, raw export or executor: {name}")
+    data = {
+        "model": "H-test", "battery": 84, "state_code": "0104", "x": 2.0, "y": 3.0,
+        "capabilities": {"cutting_height": {"supported": True}},
+        "map": {"map_id": "test-map", "zones": [{"id": 36}], "off_limit_areas": [[[0, 0], [1, 0], [0, 1]]]},
+        "zone_states": [{"id": 36, "last_completed_at": "2026-09-01T10:00:00+00:00"}],
+        "settings": {"mowingHeightList": list(range(30, 85, 5)), "pinCode": 4321},
+        "private_cloud_error": "echo DEMO-MOWER-ONLY and DEMO-TOKEN-ONLY",
+        "raw": {
+            "index2": {"mapVersion": 11, "editMapInfo": {"editMapUid": "DEMO-EDITOR-ONLY", "editMapChannel": 2}},
+            "location": {"lastLatitude": 12.345, "lastLongitude": 67.891},
+            "device_info": {"simICCID": "DEMO-SIM-ONLY", "map_area_limit": 500},
+            "maintenance_h5_discovery": {"snippet": "PRIVATE_RESEARCH"},
+            "nested": {"command_discovery": {"snippet": "PRIVATE_COMMAND"}},
+        },
+    }
+    controller = SimpleNamespace(diagnostics=lambda: {"active_zone_id": 36, "resume_pending": True, "charging_limit_reached_at": "2026-09-01T10:00:00+00:00"})
+    bridge = SimpleNamespace(
+        diagnostic_health=lambda: {"connected": True},
+        diagnostic_inventory=lambda: {"/downlink/vehicle/DEMO-MOWER-ONLY/state": {"count": 5}},
+        diagnostic_discovery=lambda: {"samples": [{"newApiKey": "DEMO-SAMPLE-KEY"}]},
+    )
+    coordinator = SimpleNamespace(data=data, sn="DEMO-MOWER-ONLY", client=NoIO(), mqtt_bridge=bridge,
+        navimower_schedule=controller, _mqtt_location={"work_target_zone": 36},
+        _notification_raw_cache={"userName": "DEMO-USER-ONLY"})
+    hass = SimpleNamespace(data={"navimower": {entry.entry_id: coordinator}}, async_add_executor_job=NoIO())
+    original = deepcopy(data)
+    report = asyncio.run(diagnostics.async_get_config_entry_diagnostics(hass, entry))
+    encoded = json.dumps(report)
+    for private in ("DEMO-MOWER-ONLY", "DEMO-TOKEN-ONLY", "DEMO-EDITOR-ONLY", "DEMO-SIM-ONLY", "DEMO-SAMPLE-KEY", "DEMO-USER-ONLY", "PRIVATE_RESEARCH", "PRIVATE_COMMAND"):
+        assert private not in encoded
+    for retired in ("maintenance_h5_discovery", "error_h5_discovery", "command_discovery"):
+        assert retired not in encoded
+    assert report["map_edit"]["edit_session_active"] is True
+    assert report["map_edit"]["edit_map_info"]["editMapUid"] == sanitizer.REDACTED
+    assert report["map"]["map_id"] == "test-map"
+    assert report["positioning"]["x"] == 2.0
+    assert report["map"]["off_limit_areas"][0]["point_count"] == 3
+    assert report["telemetry"]["battery"] == 84
+    assert report["navimower_schedule"]["active_zone_id"] == 36
+    assert report["telemetry"]["zone_states"][0]["last_completed_at"] == "2026-09-01T10:00:00+00:00"
+    assert report["settings"]["mowingHeightList"] == list(range(30, 85, 5))
+    assert data == original
+    assert entry.options["google_maps_api_key"] == "DEMO-GOOGLE-KEY"

--- a/tests/test_v031_features.py
+++ b/tests/test_v031_features.py
@@ -1,9 +1,11 @@
-"""Static regressions for the v0.3.1+ integration features."""
+"""Regressions for the v0.3.1+ integration features."""
 from __future__ import annotations
 
 import ast
 import json
 from pathlib import Path
+
+from diagnostics_contract import load_redactor
 
 ROOT = Path(__file__).parents[1]
 COMPONENT = ROOT / "custom_components/navimower"
@@ -47,32 +49,24 @@ def test_manifest_version() -> None:
 
 
 def test_diagnostics_sanitizer_redacts_sensitive_identifiers() -> None:
-    source = (COMPONENT / "diagnostics_sanitize.py").read_text()
-    ast.parse(source)
-    assert "def sanitize" in source
-    assert "def _is_sensitive_key" in source
-    for key in (
-        '"oauth_device_id"',
-        '"vehicle_sn"',
-        '"serial_number"',
-        '"latitude"',
-        '"longitude"',
-        '"access_token"',
-        '"refresh_token"',
-        '"email"',
-        '"ssid"',
-        '"mac"',
-    ):
-        assert key in source
-    assert 'return "<redacted>"' in source
+    redactor = load_redactor()
+    keys = (
+        "oauth_device_id", "vehicle_sn", "serial_number", "latitude", "longitude",
+        "access_token", "refresh_token", "email", "ssid", "mac",
+    )
+    source = {key: "SYNTHETIC-PRIVATE-VALUE" for key in keys}
+    assert redactor.sanitize(source) == {key: "<redacted>" for key in keys}
+    assert all(value == "SYNTHETIC-PRIVATE-VALUE" for value in source.values())
 
 
 def test_diagnostics_sanitizer_bounds_large_values_and_urls() -> None:
-    source = (COMPONENT / "diagnostics_sanitize.py").read_text()
-    ast.parse(source)
-    assert '"_omitted": "large_string"' in source
-    assert '"length": len(value)' in source
-    assert '"sha256": hashlib.sha256(raw).hexdigest()' in source
-    assert "def _safe_url" in source
-    assert 'urlunsplit((parsed.scheme, location, parsed.path, "", ""))' in source
-    assert "len(value) > 16_384" in source
+    redactor = load_redactor()
+    result = redactor.sanitize({
+        "large": "x" * 16_385,
+        "url": "https://user:password@example.invalid/mower/private-id?token=secret#private",
+    })
+    assert result["large"]["_omitted"] == "large_string"
+    assert result["large"]["length"] == 16_385
+    assert len(result["large"]["sha256"]) == 64
+    # The stronger policy also removes identifying URL paths.
+    assert result["url"] == "https://example.invalid"

--- a/tests/test_v033_features.py
+++ b/tests/test_v033_features.py
@@ -5,6 +5,8 @@ import ast
 import importlib.util
 from pathlib import Path
 
+from diagnostics_contract import assert_cached_diagnostics_only
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
@@ -67,19 +69,16 @@ def test_mow_command_trace_remains_internal_without_diagnostics_lookup() -> None
     assert "self.coordinator.begin_mow_command_trace(" in mower
     assert "command_status" not in diagnostics
     assert "last_mow_command" not in diagnostics
-    if "error_h5_discovery" in diagnostics:
-        error_discovery = (COMPONENT / "error_h5_discovery.py").read_text()
-        assert "probe_error_h5" in diagnostics
-        assert 'method="GET"' in error_discovery
-        assert '"mutation_calls_executed": False' in error_discovery
-        assert '"live_command_call_executed": False' in error_discovery
-        assert "client.call(" not in error_discovery
-    elif "maintenance_h5_discovery" in diagnostics:
-        maintenance_discovery = (COMPONENT / "maintenance_h5_discovery.py").read_text()
-        assert 'method="GET"' in maintenance_discovery
-        assert '"mutation_calls_executed": False' in maintenance_discovery
-    else:
-        assert "makes no extra vendor" in diagnostics
+    assert_cached_diagnostics_only(diagnostics)
+    # Standalone research remains read-only but is not a Download dependency.
+    error_discovery = (COMPONENT / "error_h5_discovery.py").read_text()
+    assert 'method="GET"' in error_discovery
+    assert '"mutation_calls_executed": False' in error_discovery
+    assert '"live_command_call_executed": False' in error_discovery
+    assert "client.call(" not in error_discovery
+    maintenance_discovery = (COMPONENT / "maintenance_h5_discovery.py").read_text()
+    assert 'method="GET"' in maintenance_discovery
+    assert '"mutation_calls_executed": False' in maintenance_discovery
 
 
 def test_command_number_extraction_handles_known_response_shapes() -> None:

--- a/tests/test_v042_stable.py
+++ b/tests/test_v042_stable.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from diagnostics_contract import assert_cached_diagnostics_only, load_redactor
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
@@ -24,64 +26,39 @@ def test_v042_stable_release_notes_exist() -> None:
 def test_v042_support_diagnostics_remain_information_rich_and_sanitized() -> None:
     diagnostics = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
     for section in (
-        "entry",
-        "mower",
-        "connectivity",
-        "private_cloud_region",
-        "capabilities",
-        "positioning",
-        "telemetry",
-        "settings",
-        "map",
-        "history",
-        "problem_history",
-        "latest_notification",
-        "notification_center",
-        "last_resume_command",
-        "private_polling",
-        "mqtt_health",
-        "raw",
+        "entry", "mower", "connectivity", "private_cloud_region", "capabilities",
+        "positioning", "telemetry", "settings", "map", "history", "problem_history",
+        "latest_notification", "notification_center", "last_resume_command",
+        "private_polling", "mqtt_health", "raw",
     ):
         assert f'"{section}"' in diagnostics
 
-    # beta29 intentionally filters bulky maintenance research out of the raw
-    # download while keeping the remainder sanitized.
+    # Keep useful cached data; redact the whole assembled report once.
     assert 'raw_for_diagnostics = deepcopy(raw)' in diagnostics
     assert 'raw_for_diagnostics.pop("maintenance", None)' in diagnostics
-    assert 'sanitize(raw_for_diagnostics)' in diagnostics
+    assert '"raw": raw_for_diagnostics' in diagnostics
     assert "private_cloud_region_diagnostics(coordinator)" in diagnostics
     assert "build_capability_profile(data)" in diagnostics
+    assert_cached_diagnostics_only(diagnostics)
 
-    if "error_h5_discovery" in diagnostics:
-        error_discovery = (COMPONENT / "error_h5_discovery.py").read_text(encoding="utf-8")
-        assert "probe_error_h5" in diagnostics
-        assert 'method="GET"' in error_discovery
-        assert '"mutation_calls_executed": False' in error_discovery
-        assert '"live_command_call_executed": False' in error_discovery
-        assert '"notification_detail_call_executed": False' in error_discovery
-        assert "client.call(" not in error_discovery
-        assert "Authorization" not in error_discovery
-        assert "Cookie" not in error_discovery
-    elif "maintenance_h5_discovery" in diagnostics:
-        maintenance_discovery = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
-        assert 'method="GET"' in maintenance_discovery
-        assert '"mutation_calls_executed": False' in maintenance_discovery
-    else:
-        assert "makes no extra vendor" in diagnostics
+    error_discovery = (COMPONENT / "error_h5_discovery.py").read_text(encoding="utf-8")
+    assert 'method="GET"' in error_discovery
+    assert '"mutation_calls_executed": False' in error_discovery
+    assert '"live_command_call_executed": False' in error_discovery
+    assert '"notification_detail_call_executed": False' in error_discovery
+    assert "client.call(" not in error_discovery
+    assert "Authorization" not in error_discovery
+    assert "Cookie" not in error_discovery
+    maintenance_discovery = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
+    assert 'method="GET"' in maintenance_discovery
+    assert '"mutation_calls_executed": False' in maintenance_discovery
 
-    sanitizer = (COMPONENT / "diagnostics_sanitize.py").read_text(encoding="utf-8")
+    redactor = load_redactor()
     for secret in (
-        "access_token",
-        "refresh_token",
-        "password",
-        "vehicle_sn",
-        "device_id",
-        "latitude",
-        "longitude",
-        "ssid",
-        "mac",
+        "access_token", "refresh_token", "password", "vehicle_sn", "device_id",
+        "latitude", "longitude", "ssid", "mac",
     ):
-        assert f'"{secret}"' in sanitizer
+        assert redactor.sanitize({secret: "synthetic"}) == {secret: "<redacted>"}
 
 
 def test_v042_production_architecture_stays_semantic() -> None:

--- a/tests/test_v043_beta1.py
+++ b/tests/test_v043_beta1.py
@@ -2,6 +2,8 @@
 import ast
 from pathlib import Path
 
+from diagnostics_contract import assert_cached_diagnostics_only
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components/navimower"
 
@@ -11,19 +13,12 @@ def test_v043_beta1_contract() -> None:
     discovery = (COMPONENT / "maintenance_h5_discovery.py").read_text()
     ast.parse(diagnostics)
     ast.parse(discovery)
-    # Historical beta1 discovery remains in-tree and read-only, but beta29 no
-    # longer executes or embeds its bulky Maintenance/Mowing Reports payload.
-    assert "probe_maintenance_h5" in diagnostics
-    assert '"maintenance_h5_discovery": maintenance_h5_discovery' in diagnostics
+    # Historical research remains in-tree and read-only, not in the Download.
+    assert_cached_diagnostics_only(diagnostics)
     assert 'raw_for_diagnostics.pop("maintenance", None)' in diagnostics
-    assert '"removed_from_download": True' in diagnostics
     for term in (
-        "resetBlade",
-        "resetKnife",
-        "maintenanceMode",
-        "enterMaintenance",
-        "exitMaintenance",
-        "cutHeight",
+        "resetBlade", "resetKnife", "maintenanceMode", "enterMaintenance",
+        "exitMaintenance", "cutHeight",
     ):
         assert term in discovery
     assert 'method="GET"' in discovery

--- a/tests/test_v043_beta10.py
+++ b/tests/test_v043_beta10.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+from diagnostics_contract import assert_cached_diagnostics_only
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
@@ -35,35 +37,22 @@ def test_beta10_retains_raw_vendor_notification_feed() -> None:
     assert '"variable": deepcopy(data.get("notification_variable"))' in diagnostics
 
 
-def test_beta10_diagnostics_focuses_only_error_action_discovery() -> None:
+def test_beta10_error_context_survives_without_h5_discovery() -> None:
     diagnostics = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
-    # Keep beta10 discovery evidence in source history while beta29 makes normal
-    # Download diagnostics cached-only and leaves command discovery paused.
-    assert "from .error_h5_discovery import probe_error_h5" in diagnostics
-    assert "probe_error_h5," in diagnostics
-    assert '"paused": True' in diagnostics
+    assert_cached_diagnostics_only(diagnostics)
     assert '"error_investigation"' in diagnostics
-    assert '"command_discovery": deepcopy(error_command_discovery)' in diagnostics
-    assert '"removed_from_download": True' in diagnostics
-    assert "error_command_discovery = await" not in diagnostics
+    assert '"private_cloud_canonical_mqtt_transition_trigger"' in diagnostics
+    assert "error_transition_diagnostics(coordinator)" in diagnostics
 
 
 def test_beta10_error_h5_probe_remains_strictly_read_only() -> None:
     source = (COMPONENT / "error_h5_discovery.py").read_text(encoding="utf-8")
     ast.parse(source)
     for phrase in (
-        "Clear and resume",
-        "Reboot Mower",
-        "clearError",
-        "rebootMower",
-        "/vehicle/set/send",
-        "c:behavior",
-        "cmdCode",
-        "MAX_PREFIX_REQUESTS =",
-        "PREFIX_BYTES = 768 * 1024",
-        'method="GET"',
-        '"mutation_calls_executed": False',
-        '"live_command_call_executed": False',
+        "Clear and resume", "Reboot Mower", "clearError", "rebootMower",
+        "/vehicle/set/send", "c:behavior", "cmdCode", "MAX_PREFIX_REQUESTS =",
+        "PREFIX_BYTES = 768 * 1024", 'method="GET"',
+        '"mutation_calls_executed": False', '"live_command_call_executed": False',
         '"notification_detail_call_executed": False',
     ):
         assert phrase in source
@@ -75,11 +64,7 @@ def test_beta10_error_h5_probe_remains_strictly_read_only() -> None:
 def test_beta10_error_probe_keeps_bounded_evidence() -> None:
     source = (COMPONENT / "error_h5_discovery.py").read_text(encoding="utf-8")
     for phrase in (
-        '"translation_keys"',
-        '"matched_assets"',
-        '"ui_contexts"',
-        '"command_contexts"',
-        '"prefix_request_count"',
-        '"full_request_count"',
+        '"translation_keys"', '"matched_assets"', '"ui_contexts"',
+        '"command_contexts"', '"prefix_request_count"', '"full_request_count"',
     ):
         assert phrase in source

--- a/tests/test_v043_beta12.py
+++ b/tests/test_v043_beta12.py
@@ -5,6 +5,8 @@ import ast
 import json
 from pathlib import Path
 
+from diagnostics_contract import assert_cached_diagnostics_only
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
@@ -20,16 +22,10 @@ def test_beta12_error_discovery_is_wall_clock_bounded() -> None:
     source = (COMPONENT / "error_h5_discovery.py").read_text(encoding="utf-8")
     ast.parse(source)
     for phrase in (
-        "MAX_ROOT_REQUESTS = 4",
-        "MAX_PREFIX_REQUESTS = 14",
-        "MAX_FULL_MATCHES = 8",
-        "MAX_PROBE_SECONDS = 24.0",
-        "TIMEOUT = 2.5",
-        "def _deadline_fetch",
-        "wall_clock_budget_exhausted",
-        "and not budget_exhausted",
-        '"bounded_by_wall_clock": True',
-        '"budget_exhausted": budget_exhausted',
+        "MAX_ROOT_REQUESTS = 4", "MAX_PREFIX_REQUESTS = 14", "MAX_FULL_MATCHES = 8",
+        "MAX_PROBE_SECONDS = 24.0", "TIMEOUT = 2.5", "def _deadline_fetch",
+        "wall_clock_budget_exhausted", "and not budget_exhausted",
+        '"bounded_by_wall_clock": True', '"budget_exhausted": budget_exhausted',
         '"elapsed_seconds"',
     ):
         assert phrase in source
@@ -43,13 +39,11 @@ def test_beta12_prioritizes_proven_error_command_asset() -> None:
     assert "queue = sorted(candidate_map.values(), key=_candidate_queue_key)" in source
 
 
-def test_beta12_diagnostics_has_outer_timeout_fail_safe() -> None:
+def test_beta12_download_does_not_need_a_crawler_timeout_anymore() -> None:
     source = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
-    ast.parse(source)
-    assert "ERROR_DISCOVERY_TIMEOUT_SECONDS = 30.0" in source
-    assert "async with asyncio.timeout(ERROR_DISCOVERY_TIMEOUT_SECONDS):" in source
-    assert '"timed_out": True' in source
-    assert "public H5 error discovery exceeded the diagnostics timeout" in source
+    assert_cached_diagnostics_only(source)
+    assert "ERROR_DISCOVERY_TIMEOUT_SECONDS" not in source
+    assert "probe_error_h5" not in source
 
 
 def test_beta12_notification_entity_history_is_recorder_safe() -> None:

--- a/tests/test_v043_beta13.py
+++ b/tests/test_v043_beta13.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+from diagnostics_contract import assert_cached_diagnostics_only
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
@@ -48,5 +50,6 @@ def test_external_notification_caveat_removed():
 def test_diagnostics_and_time_controls_are_exposed():
     diagnostics = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
     time_source = (COMPONENT / "time.py").read_text(encoding="utf-8")
-    assert '"navimower_schedule": sanitize' in diagnostics
+    assert '"navimower_schedule": navimower_schedule_diagnostics' in diagnostics
+    assert_cached_diagnostics_only(diagnostics)
     assert 'Navimower schedule {key}' in time_source

--- a/tests/test_v043_beta14.py
+++ b/tests/test_v043_beta14.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+from diagnostics_contract import assert_cached_diagnostics_only
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
@@ -39,8 +41,8 @@ def test_transient_private_endpoint_failures_are_quiet():
     assert 'status["consecutive_failures"] = 0' in source
 
 
-def test_discovery_scope_is_unchanged():
+def test_standalone_discovery_is_bounded_but_not_a_download_dependency():
     diagnostics = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
     error_discovery = (COMPONENT / "error_h5_discovery.py").read_text(encoding="utf-8")
-    assert 'ERROR_DISCOVERY_TIMEOUT_SECONDS' in diagnostics
+    assert_cached_diagnostics_only(diagnostics)
     assert 'MAX_PROBE_SECONDS = 24.0' in error_discovery

--- a/tests/test_v043_beta2.py
+++ b/tests/test_v043_beta2.py
@@ -5,6 +5,8 @@ import ast
 from pathlib import Path
 import re
 
+from diagnostics_contract import assert_cached_diagnostics_only
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
@@ -51,11 +53,9 @@ def test_beta2_patterns_target_real_javascript_syntax() -> None:
     assert "NavimowerDiagnostics/0.4.3-beta" in source
 
 
-def test_beta2_diagnostics_keeps_read_only_maintenance_probe() -> None:
+def test_beta2_read_only_probe_is_separate_from_download() -> None:
     diagnostics = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
     discovery = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
-    assert "from .maintenance_h5_discovery import probe_maintenance_h5" in diagnostics
-    assert "await hass.async_add_executor_job" in diagnostics
-    assert '"maintenance_h5_discovery": maintenance_h5_discovery' in diagnostics
+    assert_cached_diagnostics_only(diagnostics)
     assert '"mutation_calls_executed": False' in discovery
     assert "client.call(" not in discovery

--- a/tests/test_v043_beta26.py
+++ b/tests/test_v043_beta26.py
@@ -1,6 +1,8 @@
 import ast
 from pathlib import Path
 
+from diagnostics_contract import assert_cached_diagnostics_only, load_redactor
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
@@ -41,21 +43,13 @@ def test_device_tracker_rejects_missing_or_invalid_coordinates():
 
 
 def test_download_diagnostics_still_redacts_geographic_location():
-    sanitize_source = (COMPONENT / "diagnostics_sanitize.py").read_text(encoding="utf-8")
     diagnostics_source = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
-    ast.parse(sanitize_source)
-    ast.parse(diagnostics_source)
+    assert_cached_diagnostics_only(diagnostics_source)
+    redactor = load_redactor()
     for key in (
-        '"latitude"',
-        '"longitude"',
-        '"last_latitude"',
-        '"last_longitude"',
-        '"origin_gps"',
-        '"center_gps"',
-        '"ne_gps"',
-        '"sw_gps"',
+        "latitude", "longitude", "last_latitude", "last_longitude",
+        "origin_gps", "center_gps", "ne_gps", "sw_gps",
+        "lastLatitude", "lastLongitude", "GPSLatitude", "mapOriginGps",
     ):
-        assert key in sanitize_source
-    assert 'if "latitude" in normalized or "longitude" in normalized:' in sanitize_source
-    assert 'if normalized.endswith("_gps") or normalized.startswith("gps_"):' in sanitize_source
+        assert redactor.sanitize({key: [12.34, 56.78]}) == {key: "<redacted>"}
     assert '"device_tracker_location"' not in diagnostics_source

--- a/tests/test_v043_beta3.py
+++ b/tests/test_v043_beta3.py
@@ -5,6 +5,8 @@ import ast
 from pathlib import Path
 import re
 
+from diagnostics_contract import assert_cached_diagnostics_only
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
@@ -76,4 +78,4 @@ def test_beta3_remains_public_get_only_and_non_mutating() -> None:
     assert "client.call(" not in source
     assert "Authorization" not in source
     assert "Cookie" not in source
-    assert "0.4.3-beta" in diagnostics
+    assert_cached_diagnostics_only(diagnostics)

--- a/tests/test_v043_beta4.py
+++ b/tests/test_v043_beta4.py
@@ -5,6 +5,8 @@ import ast
 from pathlib import Path
 import re
 
+from diagnostics_contract import assert_cached_diagnostics_only
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
@@ -78,10 +80,6 @@ def test_beta4_regexes_compile_and_probe_remains_non_mutating() -> None:
     assert "Cookie" not in source
 
 
-def test_beta4_diagnostics_describes_both_contract_families() -> None:
+def test_beta4_research_stays_outside_ordinary_diagnostics() -> None:
     diagnostics = (COMPONENT / "diagnostics.py").read_text(encoding="utf-8")
-    assert "probe_maintenance_h5" in diagnostics
-    assert "0.4.3-beta" in diagnostics
-    assert "maintenance" in diagnostics.lower()
-    assert "Mowing Reports" in diagnostics
-    assert '"maintenance_h5_discovery": maintenance_h5_discovery' in diagnostics
+    assert_cached_diagnostics_only(diagnostics)

--- a/tests/test_v043_beta6.py
+++ b/tests/test_v043_beta6.py
@@ -5,6 +5,8 @@ import ast
 from pathlib import Path
 import re
 
+from diagnostics_contract import assert_cached_diagnostics_only
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
@@ -84,11 +86,8 @@ def test_beta6_has_bounded_public_source_map_recovery() -> None:
     assert "SOURCE_MAP_RE" in patterns
     assert re.compile(patterns["SOURCE_MAP_RE"], re.I).search("//# sourceMappingURL=index.js.map")
     for phrase in (
-        "MAX_SOURCE_MAPS",
-        "MAX_SOURCE_MAP",
-        "def _source_map_url",
-        "def _source_map_priority",
-        "def _source_map_findings",
+        "MAX_SOURCE_MAPS", "MAX_SOURCE_MAP", "def _source_map_url",
+        "def _source_map_priority", "def _source_map_findings",
         '"source_map_fetches": source_map_fetches',
         '"source_map_findings": source_map_findings',
         '"source_map_success_count": source_map_success',
@@ -99,14 +98,9 @@ def test_beta6_has_bounded_public_source_map_recovery() -> None:
 def test_beta6_keeps_reports_transport_only_until_crypto_is_proven() -> None:
     source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
     for phrase in (
-        "REPORT_TRANSPORT_TARGETS",
-        '"handleEncipherment"',
-        '"handleDecrypt"',
-        '"keyDataOne"',
-        '"body:{data"',
-        '"live_report_request_executed": False',
-        '"status": "not_assumed"',
-        "p:101 envelope fields d,h,k,p,t",
+        "REPORT_TRANSPORT_TARGETS", '"handleEncipherment"', '"handleDecrypt"',
+        '"keyDataOne"', '"body:{data"', '"live_report_request_executed": False',
+        '"status": "not_assumed"', "p:101 envelope fields d,h,k,p,t",
     ):
         assert phrase in source
     assert "client.call(" not in source
@@ -120,5 +114,4 @@ def test_beta6_remains_public_get_only_and_non_mutating() -> None:
     assert '"public_unauthenticated_h5_only": True' in source
     assert "Authorization" not in source
     assert "Cookie" not in source
-    assert "0.4.3-beta" in diagnostics
-    assert '"maintenance_h5_discovery"' in diagnostics
+    assert_cached_diagnostics_only(diagnostics)

--- a/tests/test_v043_beta7.py
+++ b/tests/test_v043_beta7.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from pathlib import Path
 import re
 
+from diagnostics_contract import assert_cached_diagnostics_only
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
@@ -62,11 +64,8 @@ def test_beta7_source_map_phase_remains_bounded_after_beta6_404s() -> None:
 def test_beta7_adds_observed_parts_maintenance_correlation_anchors() -> None:
     source = (COMPONENT / "maintenance_h5_discovery.py").read_text(encoding="utf-8")
     for phrase in (
-        '"Time to clean your mower"',
-        '"Maintenance point reached"',
-        '"review parts usage"',
-        '"start cleaning"',
-        '"reset the timer"',
+        '"Time to clean your mower"', '"Maintenance point reached"',
+        '"review parts usage"', '"start cleaning"', '"reset the timer"',
         '"handleH5MowerSet"',
     ):
         assert phrase in source
@@ -81,5 +80,4 @@ def test_beta7_remains_public_get_only_and_non_mutating() -> None:
     assert "client.call(" not in source
     assert "Authorization" not in source
     assert "Cookie" not in source
-    assert "0.4.3-beta" in diagnostics
-    assert '"maintenance_h5_discovery"' in diagnostics
+    assert_cached_diagnostics_only(diagnostics)

--- a/tests/test_v043_beta8.py
+++ b/tests/test_v043_beta8.py
@@ -5,6 +5,8 @@ import ast
 from pathlib import Path
 import re
 
+from diagnostics_contract import assert_cached_diagnostics_only
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components" / "navimower"
 
@@ -101,5 +103,4 @@ def test_beta8_remains_public_get_only_and_non_mutating() -> None:
     assert "client.call(" not in source
     assert "Authorization" not in source
     assert "Cookie" not in source
-    assert "0.4.3-beta" in diagnostics
-    assert '"maintenance_h5_discovery"' in diagnostics
+    assert_cached_diagnostics_only(diagnostics)


### PR DESCRIPTION
## Scope

Follow the diagnostics-cleanup direction in ilguala/navimow_pro v0.5.1 and its maintainer's response to issue #13, without changing our explicit unredacted development export or hiding the protocol implementation.

**Unchanged:** `raw_export.py`, raw MQTT capture, `export_raw_data` service/permissions, `api/crypto.py`, authentication, MQTT subscriptions, mower controls, Schedule, map rendering and Map Card. No new release/tag is created by this PR.

## Changes

- Match sensitive field names across snake_case, camelCase, acronym and compact variants (including `editMapUid`, `vehicleSn`, `deviceId`, `apiKey`, `sessionKey`, PIN/SIM/GPS variants).
- Preserve support fields such as `mapping`, map/zone/task IDs, mowing-height ranges, charging limits, coverage and completion timestamps.
- Sanitize complete loaded/unloaded reports, nested JSON strings, common text credentials, URLs and known identifiers echoed elsewhere, without mutating cached data.
- Keep service origins rather than URL paths/credentials/query strings; summarize opaque/binary/unsupported values instead of exposing arbitrary reprs.
- Remove inactive H5 report placeholders and historical source-marker strings. Recursively exclude retired H5/command-discovery blocks from old caches, without deleting the standalone research modules.
- Identify the redaction policy with `redaction_version: 3` while retaining the existing report format.
- Document what remains: local X/Y geometry, user-chosen names and activity times are still useful support context, so this is not a guarantee of complete anonymity.

## Verification

Final head: `67cff71d8732979645714cf8c026cf05670b2265`.

- Validate run [34204890152](https://github.com/vahesoo/NaviMower/actions/runs/34204890152): integration, hassfest and HACS all passed.
- Full repository pytest run: **432 passed**, including **91 new synthetic privacy tests**. Compile, JSON, standalone-card separation and clean-tree checks passed.
- The actual loaded/unloaded Download handlers execute with mocked HA/cache dependencies and forbidden vendor/executor calls.
- Redactor also checked locally against three previously supplied diagnostics; selected battery/schedule fields were preserved and the original files were untouched. No private captures or values are committed.
- Updated legacy assertions that required inert H5 code strings or old per-section sanitizer syntax. Retained their unrelated runtime/parser/read-only checks; no additional suite-skipping rules were added.

The explicit `navimower.export_raw_data` action intentionally remains unredacted and manually invoked, as requested. The cleanup does not retroactively sanitize old exports or establish vendor approval.