### PR TITLE
Navimower 0.4.4-beta32: exact polygon gate areas

### DIFF
--- a/.github/release-notes/0.4.4-beta32.md
+++ b/.github/release-notes/0.4.4-beta32.md
@@ -1,0 +1,34 @@
+title: Navimower 0.4.4-beta32
+
+## Exact polygon gate areas
+
+This beta fixes the long-standing assumption that every local gate area is an axis-aligned X/Y rectangle. That works well on mower maps whose local coordinate frame happens to align with the physical passage, but it can make an oblique gate corridor much larger than intended on maps such as i108.
+
+### Polygon gate geometry
+
+- Gate areas may now include an optional mower-local `polygon` made from three or more X/Y points.
+- When a polygon is present, exact point-in-polygon membership is authoritative for the gate-area binary sensor.
+- Points on the polygon boundary count as inside so gate safety does not flicker at an edge.
+- The existing fresh-MQTT-only safety rule is unchanged; stale/private-cloud fallback positions are still not used to assert physical gate-area occupancy.
+
+### Backward compatibility
+
+- Existing `x_min`, `x_max`, `y_min`, `y_max` gate areas continue to behave exactly as before.
+- Polygon rows automatically expose their min/max bounding box as well, so older Map Card releases can still draw a compatibility rectangle even though gate automation uses the exact polygon.
+- The existing gate-area options form gains an optional JSON polygon field. Leaving it empty keeps rectangle behavior.
+- Editing an existing polygon gate area preserves and exposes the polygon instead of silently converting it back to a rectangle.
+
+### Example
+
+```text
+[[-28.75,8],[-23.5,5.25],[-19.25,10.75],[-24,14.75]]
+```
+
+This creates the rotated four-corner gate area directly in mower-local coordinates rather than using its much larger axis-aligned bounding box.
+
+### Regression coverage
+
+- Add tests for exact polygon membership, boundary handling and bounding-box compatibility.
+- Verify that legacy rectangular gate areas remain unchanged.
+- Reject malformed polygon input instead of silently falling back to an oversized rectangle.
+- Verify the polygon options-flow extension is installed through the central runtime pipeline.

--- a/custom_components/navimower/channel.py
+++ b/custom_components/navimower/channel.py
@@ -1,21 +1,95 @@
 """Local channel/corridor geometry used by gate automations and the map card."""
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 import json
+import math
 import re
 from typing import Any
 
 
+def _normalize_polygon(raw: Any) -> tuple[tuple[float, float], ...] | None:
+    """Return one validated open polygon in mower-local X/Y coordinates."""
+    if raw in (None, "", []):
+        return None
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except (TypeError, ValueError):
+            raise ValueError("invalid polygon JSON") from None
+    if not isinstance(raw, (list, tuple)):
+        raise ValueError("polygon must be a coordinate list")
+
+    points: list[tuple[float, float]] = []
+    for point in raw:
+        if not isinstance(point, (list, tuple)) or len(point) < 2:
+            raise ValueError("polygon point must contain X and Y")
+        try:
+            x, y = float(point[0]), float(point[1])
+        except (TypeError, ValueError):
+            raise ValueError("polygon coordinates must be numeric") from None
+        if not math.isfinite(x) or not math.isfinite(y):
+            raise ValueError("polygon coordinates must be finite")
+        candidate = (x, y)
+        if not points or candidate != points[-1]:
+            points.append(candidate)
+
+    if len(points) >= 2 and points[0] == points[-1]:
+        points.pop()
+    if len(points) < 3 or len(set(points)) < 3:
+        raise ValueError("polygon needs at least three distinct points")
+    return tuple(points)
+
+
+def _point_on_segment(
+    x: float,
+    y: float,
+    x1: float,
+    y1: float,
+    x2: float,
+    y2: float,
+    *,
+    tolerance: float = 1e-6,
+) -> bool:
+    """Return whether a local-map point lies on one polygon edge."""
+    cross = (x - x1) * (y2 - y1) - (y - y1) * (x2 - x1)
+    if abs(cross) > tolerance:
+        return False
+    return (
+        min(x1, x2) - tolerance <= x <= max(x1, x2) + tolerance
+        and min(y1, y2) - tolerance <= y <= max(y1, y2) + tolerance
+    )
+
+
+def _point_in_polygon(
+    x: float,
+    y: float,
+    polygon: tuple[tuple[float, float], ...],
+) -> bool:
+    """Return whether X/Y is inside or on the polygon boundary."""
+    inside = False
+    for index, (x1, y1) in enumerate(polygon):
+        x2, y2 = polygon[(index + 1) % len(polygon)]
+        if _point_on_segment(x, y, x1, y1, x2, y2):
+            return True
+        if (y1 > y) == (y2 > y):
+            continue
+        crossing_x = (x2 - x1) * (y - y1) / (y2 - y1) + x1
+        if x < crossing_x:
+            inside = not inside
+    return inside
+
+
 @dataclass(frozen=True, slots=True)
 class NavimowerChannel:
-    """A rectangular local-coordinate channel."""
+    """A local-coordinate gate area, optionally using an exact polygon."""
 
     name: str
     x_min: float
     x_max: float
     y_min: float
     y_max: float
+    polygon: tuple[tuple[float, float], ...] | None = None
 
     @property
     def slug(self) -> str:
@@ -23,23 +97,38 @@ class NavimowerChannel:
         return value or "channel"
 
     def contains(self, x: Any, y: Any) -> bool | None:
-        """Return whether a valid pose is inside this rectangle."""
+        """Return whether a valid live pose is inside this gate area."""
         try:
             px, py = float(x), float(y)
         except (TypeError, ValueError):
             return None
+        if not math.isfinite(px) or not math.isfinite(py):
+            return None
+        if self.polygon is not None:
+            return _point_in_polygon(px, py, self.polygon)
         return self.x_min <= px <= self.x_max and self.y_min <= py <= self.y_max
 
     def as_dict(self) -> dict[str, Any]:
-        return {**asdict(self), "slug": self.slug}
+        result: dict[str, Any] = {
+            "name": self.name,
+            "x_min": self.x_min,
+            "x_max": self.x_max,
+            "y_min": self.y_min,
+            "y_max": self.y_max,
+            "slug": self.slug,
+        }
+        if self.polygon is not None:
+            result["polygon"] = [[x, y] for x, y in self.polygon]
+        return result
 
 
 def parse_channels(raw: Any) -> list[NavimowerChannel]:
-    """Parse an options JSON list into validated channel rectangles.
+    """Parse saved gate areas with backward-compatible rectangle support.
 
-    Example::
-
-        [{"name":"Gate","x_min":1,"x_max":3,"y_min":-2,"y_max":2}]
+    Legacy rows use ``x_min/x_max/y_min/y_max`` only. New rows may additionally
+    provide ``polygon`` as a coordinate list (or JSON text). When present, the
+    polygon is authoritative for membership and the rectangle fields are reduced
+    to its bounding box for compatibility with older Map Card releases.
     """
     if raw in (None, "", []):
         return []
@@ -58,16 +147,29 @@ def parse_channels(raw: Any) -> list[NavimowerChannel]:
             continue
         try:
             name = str(item.get("name") or "Channel").strip()
-            x1, x2 = float(item["x_min"]), float(item["x_max"])
-            y1, y2 = float(item["y_min"]), float(item["y_max"])
+            polygon = _normalize_polygon(item.get("polygon"))
+            if polygon is not None:
+                xs = [point[0] for point in polygon]
+                ys = [point[1] for point in polygon]
+                x_min, x_max = min(xs), max(xs)
+                y_min, y_max = min(ys), max(ys)
+            else:
+                x1, x2 = float(item["x_min"]), float(item["x_max"])
+                y1, y2 = float(item["y_min"]), float(item["y_max"])
+                if not all(math.isfinite(value) for value in (x1, x2, y1, y2)):
+                    raise ValueError("rectangle coordinates must be finite")
+                x_min, x_max = min(x1, x2), max(x1, x2)
+                y_min, y_max = min(y1, y2), max(y1, y2)
         except (KeyError, TypeError, ValueError):
             continue
+
         channel = NavimowerChannel(
             name=name or "Channel",
-            x_min=min(x1, x2),
-            x_max=max(x1, x2),
-            y_min=min(y1, y2),
-            y_max=max(y1, y2),
+            x_min=x_min,
+            x_max=x_max,
+            y_min=y_min,
+            y_max=y_max,
+            polygon=polygon,
         )
         slug = channel.slug
         if slug in seen:

--- a/custom_components/navimower/gate_area_polygon_semantics.py
+++ b/custom_components/navimower/gate_area_polygon_semantics.py
@@ -1,0 +1,64 @@
+"""Options-flow support for exact polygon gate areas.
+
+Legacy gate areas remain rectangular local X/Y bounds.  This extension adds an
+optional JSON polygon field to the existing add/edit forms; when populated, the
+polygon is authoritative and the stored min/max values become its compatibility
+bounding box.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
+
+from .channel import NavimowerChannel, parse_channels
+from .config_flow_base import NavimowOptionsFlow
+
+_INSTALLED = False
+_ORIGINAL_CHANNEL_SCHEMA = NavimowOptionsFlow._channel_schema
+
+
+def _polygon_text(value: Any) -> str:
+    """Validate optional JSON polygon text without changing rectangle behavior."""
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    parsed = parse_channels([{"name": "Polygon validation", "polygon": text}])
+    if len(parsed) != 1 or parsed[0].polygon is None:
+        raise vol.Invalid(
+            "Use JSON X/Y points such as [[-28.75,8],[-23.5,5.25],[-19.25,10.75],[-24,14.75]]"
+        )
+    return text
+
+
+def _channel_schema(channel: NavimowerChannel | None = None) -> vol.Schema:
+    """Extend the legacy rectangle editor with an optional exact polygon."""
+    schema = dict(_ORIGINAL_CHANNEL_SCHEMA(channel).schema)
+    default = ""
+    if channel is not None and channel.polygon is not None:
+        default = json.dumps(
+            [[x, y] for x, y in channel.polygon],
+            separators=(",", ":"),
+        )
+    schema[
+        vol.Optional("polygon", default=default)
+    ] = vol.All(
+        TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
+        _polygon_text,
+    )
+    return vol.Schema(schema)
+
+
+def install_gate_area_polygon_semantics() -> None:
+    """Add polygon editing while preserving all existing channel flow behavior."""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    NavimowOptionsFlow._channel_schema = staticmethod(_channel_schema)
+    _INSTALLED = True

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta31"
+  "version": "0.4.4-beta32"
 }

--- a/custom_components/navimower/runtime.py
+++ b/custom_components/navimower/runtime.py
@@ -10,6 +10,7 @@ from .capability_extensions import install_capability_extensions
 from .capability_profile import install_capability_profile
 from .capability_semantics import install_capability_semantics
 from .completion_semantics import install_completion_semantics
+from .gate_area_polygon_semantics import install_gate_area_polygon_semantics
 from .georeference_cartographic_semantics import install_georeference_cartographic_semantics
 from .georeference_diagnostics_frame_semantics import (
     install_georeference_diagnostics_frame_semantics,
@@ -107,5 +108,9 @@ def install_runtime_extensions() -> None:
     # Apply editor changes only at a real round/window boundary, before slot 0 of
     # the new round is allowed to dispatch.
     install_schedule_queue_boundary_semantics()
+    # Extend the existing legacy gate-area form only after all coordinator/runtime
+    # semantics are installed. The patch is UI-only; membership remains owned by
+    # channel.py and fresh MQTT pose safety semantics remain unchanged.
+    install_gate_area_polygon_semantics()
     install_setup_flow_semantics()
     install_zone_entity_cleanup()

--- a/tests/test_v044_beta32.py
+++ b/tests/test_v044_beta32.py
@@ -1,0 +1,113 @@
+"""Regression coverage for Navimower 0.4.4-beta32 polygon gate areas."""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+CHANNEL = COMPONENT / "channel.py"
+
+
+def _load_channel_module():
+    spec = importlib.util.spec_from_file_location("navimower_channel_beta32", CHANNEL)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_polygon_gate_area_uses_exact_geometry_and_keeps_compatibility_bounds() -> None:
+    channel = _load_channel_module()
+    polygon = [
+        [-28.75, 8.00],
+        [-23.50, 5.25],
+        [-19.25, 10.75],
+        [-24.00, 14.75],
+    ]
+    parsed = channel.parse_channels(
+        [
+            {
+                "name": "ProChan",
+                "x_min": 0,
+                "x_max": 1,
+                "y_min": 0,
+                "y_max": 1,
+                "polygon": json.dumps(polygon),
+            }
+        ]
+    )
+    assert len(parsed) == 1
+    area = parsed[0]
+    assert area.polygon is not None
+    assert (area.x_min, area.x_max, area.y_min, area.y_max) == (
+        -28.75,
+        -19.25,
+        5.25,
+        14.75,
+    )
+
+    # A point near the polygon centre is inside.
+    assert area.contains(-23.875, 9.6875) is True
+    # This point is inside the old min/max bounding box but outside the rotated polygon.
+    assert area.contains(-28.5, 14.0) is False
+    # Boundary points are intentionally treated as inside for gate safety.
+    assert area.contains(-28.75, 8.0) is True
+
+    exported = area.as_dict()
+    assert exported["polygon"] == polygon
+    assert exported["x_min"] == -28.75
+    assert exported["x_max"] == -19.25
+
+
+def test_legacy_rectangular_gate_areas_remain_unchanged() -> None:
+    channel = _load_channel_module()
+    parsed = channel.parse_channels(
+        [{"name": "Legacy", "x_min": 3, "x_max": 1, "y_min": 4, "y_max": 2}]
+    )
+    assert len(parsed) == 1
+    area = parsed[0]
+    assert area.polygon is None
+    assert (area.x_min, area.x_max, area.y_min, area.y_max) == (1, 3, 2, 4)
+    assert area.contains(2, 3) is True
+    assert area.contains(4, 3) is False
+
+
+def test_invalid_polygon_is_rejected_instead_of_falling_back_to_rectangle() -> None:
+    channel = _load_channel_module()
+    parsed = channel.parse_channels(
+        [
+            {
+                "name": "Invalid polygon",
+                "x_min": 0,
+                "x_max": 100,
+                "y_min": 0,
+                "y_max": 100,
+                "polygon": "[[1,2],[3,4]]",
+            }
+        ]
+    )
+    assert parsed == []
+
+
+def test_polygon_options_semantics_are_installed_in_runtime() -> None:
+    runtime = (COMPONENT / "runtime.py").read_text(encoding="utf-8")
+    semantics = (COMPONENT / "gate_area_polygon_semantics.py").read_text(encoding="utf-8")
+    assert "from .gate_area_polygon_semantics import install_gate_area_polygon_semantics" in runtime
+    assert "install_gate_area_polygon_semantics()" in runtime
+    assert "NavimowOptionsFlow._channel_schema = staticmethod(_channel_schema)" in semantics
+    assert 'vol.Optional("polygon", default=default)' in semantics
+    assert "parse_channels" in semantics
+
+
+def test_beta32_release_metadata() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.4-beta32"
+    notes = ROOT / ".github" / "release-notes" / "0.4.4-beta32.md"
+    assert notes.is_file()
+    assert notes.read_text(encoding="utf-8").startswith(
+        "title: Navimower 0.4.4-beta32\n"
+    )


### PR DESCRIPTION
Adds exact mower-local polygon support to legacy gate areas while preserving rectangular x/y bounds for backwards compatibility.

Key points:
- optional polygon geometry is authoritative for gate-area occupancy;
- fresh MQTT pose safety semantics are unchanged;
- min/max bounds are derived from polygons for older Map Card compatibility;
- existing rectangle gate areas remain unchanged;
- options flow exposes an optional JSON polygon field;
- regression tests cover exact membership, boundary handling, malformed polygons and legacy behavior;
- bumps the integration and release notes to 0.4.4-beta32.