### PR TITLE
Navimower 0.4.4-beta33: fix gate-area Options Flow

### DIFF
--- a/.github/release-notes/0.4.4-beta33.md
+++ b/.github/release-notes/0.4.4-beta33.md
@@ -1,0 +1,12 @@
+title: Navimower 0.4.4-beta33
+
+## Gate-area Options Flow hotfix
+
+This prerelease fixes the Home Assistant Options Flow regression introduced in 0.4.4-beta32.
+
+- Opening **Add gate area** or **Edit gate area** no longer fails with a blank `Error` dialog.
+- The optional polygon field is now exposed as a directly serializable Home Assistant text selector.
+- Polygon JSON validation runs when the form is submitted instead of wrapping the selector inside `vol.All(...)`.
+- Exact polygon occupancy, MQTT freshness safety, compatibility `x_min/x_max/y_min/y_max` bounds and legacy rectangular gate areas are unchanged.
+
+Recommended Map Card companion remains **Navimower Map Card 0.3.6-beta18 or newer** for exact polygon rendering.

--- a/custom_components/navimower/gate_area_polygon_semantics.py
+++ b/custom_components/navimower/gate_area_polygon_semantics.py
@@ -1,6 +1,6 @@
 """Options-flow support for exact polygon gate areas.
 
-Legacy gate areas remain rectangular local X/Y bounds.  This extension adds an
+Legacy gate areas remain rectangular local X/Y bounds. This extension adds an
 optional JSON polygon field to the existing add/edit forms; when populated, the
 polygon is authoritative and the stored min/max values become its compatibility
 bounding box.
@@ -11,6 +11,7 @@ import json
 from typing import Any
 
 import voluptuous as vol
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.helpers.selector import (
     TextSelector,
     TextSelectorConfig,
@@ -22,6 +23,8 @@ from .config_flow_base import NavimowOptionsFlow
 
 _INSTALLED = False
 _ORIGINAL_CHANNEL_SCHEMA = NavimowOptionsFlow._channel_schema
+_ORIGINAL_CHANNEL_ADD = NavimowOptionsFlow.async_step_channel_add
+_ORIGINAL_CHANNEL_EDIT = NavimowOptionsFlow.async_step_channel_edit
 
 
 def _polygon_text(value: Any) -> str:
@@ -38,7 +41,7 @@ def _polygon_text(value: Any) -> str:
 
 
 def _channel_schema(channel: NavimowerChannel | None = None) -> vol.Schema:
-    """Extend the legacy rectangle editor with an optional exact polygon."""
+    """Extend the legacy rectangle editor with a serializable polygon selector."""
     schema = dict(_ORIGINAL_CHANNEL_SCHEMA(channel).schema)
     default = ""
     if channel is not None and channel.polygon is not None:
@@ -46,13 +49,58 @@ def _channel_schema(channel: NavimowerChannel | None = None) -> vol.Schema:
             [[x, y] for x, y in channel.polygon],
             separators=(",", ":"),
         )
-    schema[
-        vol.Optional("polygon", default=default)
-    ] = vol.All(
-        TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
-        _polygon_text,
+    # Home Assistant must serialize selectors directly for Options Flow forms.
+    # Wrapping TextSelector in vol.All(..., custom_validator) causes the form
+    # schema websocket response to fail before the dialog can be rendered.
+    schema[vol.Optional("polygon", default=default)] = TextSelector(
+        TextSelectorConfig(type=TextSelectorType.TEXT)
     )
     return vol.Schema(schema)
+
+
+def _invalid_polygon(user_input: dict[str, Any] | None) -> bool:
+    """Return whether the submitted optional polygon text is malformed."""
+    if user_input is None:
+        return False
+    try:
+        _polygon_text(user_input.get("polygon", ""))
+    except vol.Invalid:
+        return True
+    return False
+
+
+async def _async_step_channel_add(
+    self: NavimowOptionsFlow,
+    user_input: dict[str, Any] | None = None,
+) -> ConfigFlowResult:
+    """Validate polygon JSON outside the serialized selector schema."""
+    if _invalid_polygon(user_input):
+        return self.async_show_form(
+            step_id="channel_add",
+            data_schema=self._channel_schema(),
+            errors={"base": "duplicate_channel"},
+        )
+    return await _ORIGINAL_CHANNEL_ADD(self, user_input)
+
+
+async def _async_step_channel_edit(
+    self: NavimowOptionsFlow,
+    user_input: dict[str, Any] | None = None,
+) -> ConfigFlowResult:
+    """Validate edited polygon JSON outside the serialized selector schema."""
+    if _invalid_polygon(user_input):
+        channels = self._channels()
+        channel = (
+            channels[self._channel_index]
+            if self._channel_index is not None and self._channel_index < len(channels)
+            else None
+        )
+        return self.async_show_form(
+            step_id="channel_edit",
+            data_schema=self._channel_schema(channel),
+            errors={"base": "duplicate_channel"},
+        )
+    return await _ORIGINAL_CHANNEL_EDIT(self, user_input)
 
 
 def install_gate_area_polygon_semantics() -> None:
@@ -61,4 +109,6 @@ def install_gate_area_polygon_semantics() -> None:
     if _INSTALLED:
         return
     NavimowOptionsFlow._channel_schema = staticmethod(_channel_schema)
+    NavimowOptionsFlow.async_step_channel_add = _async_step_channel_add
+    NavimowOptionsFlow.async_step_channel_edit = _async_step_channel_edit
     _INSTALLED = True

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta32"
+  "version": "0.4.4-beta33"
 }

--- a/tests/test_v044_beta32.py
+++ b/tests/test_v044_beta32.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import importlib.util
 import json
 from pathlib import Path
+import re
 import sys
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -105,7 +106,8 @@ def test_polygon_options_semantics_are_installed_in_runtime() -> None:
 
 def test_beta32_release_metadata() -> None:
     manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.4.4-beta32"
+    match = re.fullmatch(r"0\.4\.4-beta(\d+)", str(manifest["version"]))
+    assert match is not None and int(match.group(1)) >= 32
     notes = ROOT / ".github" / "release-notes" / "0.4.4-beta32.md"
     assert notes.is_file()
     assert notes.read_text(encoding="utf-8").startswith(

--- a/tests/test_v044_beta33.py
+++ b/tests/test_v044_beta33.py
@@ -16,7 +16,7 @@ def test_polygon_selector_is_serializable_and_validation_is_outside_schema() -> 
     schema = source[schema_start:schema_end]
 
     assert 'schema[vol.Optional("polygon", default=default)] = TextSelector(' in schema
-    assert "vol.All(" not in schema
+    assert "] = vol.All(" not in schema
     assert "_polygon_text" not in schema
 
     assert "def _invalid_polygon" in source

--- a/tests/test_v044_beta33.py
+++ b/tests/test_v044_beta33.py
@@ -1,0 +1,35 @@
+"""Regression coverage for the beta33 gate-area Options Flow hotfix."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+SEMANTICS = COMPONENT / "gate_area_polygon_semantics.py"
+
+
+def test_polygon_selector_is_serializable_and_validation_is_outside_schema() -> None:
+    source = SEMANTICS.read_text(encoding="utf-8")
+    schema_start = source.index("def _channel_schema")
+    schema_end = source.index("\ndef _invalid_polygon", schema_start)
+    schema = source[schema_start:schema_end]
+
+    assert 'schema[vol.Optional("polygon", default=default)] = TextSelector(' in schema
+    assert "vol.All(" not in schema
+    assert "_polygon_text" not in schema
+
+    assert "def _invalid_polygon" in source
+    assert "_polygon_text(user_input.get(\"polygon\", \"\"))" in source
+    assert "NavimowOptionsFlow.async_step_channel_add = _async_step_channel_add" in source
+    assert "NavimowOptionsFlow.async_step_channel_edit = _async_step_channel_edit" in source
+
+
+def test_beta33_release_metadata() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.4-beta33"
+    notes = ROOT / ".github" / "release-notes" / "0.4.4-beta33.md"
+    assert notes.is_file()
+    assert notes.read_text(encoding="utf-8").startswith(
+        "title: Navimower 0.4.4-beta33\n"
+    )


### PR DESCRIPTION
Hotfix for the beta32 gate-area polygon editor regression reported from Home Assistant Options Flow.

The beta32 extension wrapped a Home Assistant `TextSelector` in `vol.All(..., custom_validator)`. Home Assistant needs selectors to remain directly serializable in config/options forms, so opening Add/Edit gate area could fail at the websocket form-serialization stage and show only a blank `Error` dialog.

Changes:
- expose the optional polygon as a direct `TextSelector`;
- move polygon JSON validation into the add/edit step before the existing parser;
- keep exact point-in-polygon occupancy, MQTT freshness rules and legacy rectangle fallback unchanged;
- add beta33 regression coverage and release metadata;
- keep the beta32 geometry tests forward-compatible with later 0.4.4 betas.

Companion Map Card: 0.3.6-beta18 or newer.