### PR TITLE
Navimower 0.4.4-beta34: add gate-area Map Card write API

### DIFF
--- a/.github/release-notes/0.4.4-beta34.md
+++ b/.github/release-notes/0.4.4-beta34.md
@@ -1,0 +1,15 @@
+title: Navimower 0.4.4-beta34
+
+## Gate-area Map Card write API
+
+This prerelease adds the integration-side write path required for drawing and editing gate areas directly from Navimower Map Card.
+
+- Adds `navimower.set_gate_area` for creating or replacing a polygon gate area from mower-local X/Y points.
+- Adds `navimower.delete_gate_area` for removing a gate area by its current slug.
+- Existing gate areas can be renamed while editing by passing their current slug as `gate_area_id` and the new display name separately.
+- Polygon writes support 3 to 64 unique points, including concave shapes, while rejecting self-intersecting and near-zero-area polygons.
+- Compatibility `x_min/x_max/y_min/y_max` bounds are recalculated automatically from the polygon.
+- Successful writes update the mower config-entry options and reload only that Navimower entry so binary sensors and Map API data immediately use the saved geometry.
+- Existing Options Flow editing and legacy rectangular gate areas remain supported.
+
+This release provides the backend contract for a forthcoming Map Card visual gate-area editor. Map Card 0.3.6-beta18 continues to render polygon gate areas normally.

--- a/custom_components/navimower/gate_area_editor.py
+++ b/custom_components/navimower/gate_area_editor.py
@@ -1,0 +1,151 @@
+"""Validated persistence helpers for Map Card gate-area editing."""
+from __future__ import annotations
+
+from typing import Any
+
+from .channel import NavimowerChannel, parse_channels
+
+MAX_GATE_AREA_POINTS = 64
+MIN_GATE_AREA_M2 = 0.01
+_EPSILON = 1e-9
+
+
+def _signed_area(points: tuple[tuple[float, float], ...]) -> float:
+    return 0.5 * sum(
+        x1 * y2 - x2 * y1
+        for (x1, y1), (x2, y2) in zip(points, points[1:] + points[:1])
+    )
+
+
+def _cross(
+    a: tuple[float, float],
+    b: tuple[float, float],
+    c: tuple[float, float],
+) -> float:
+    return (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])
+
+
+def _point_on_segment(
+    point: tuple[float, float],
+    start: tuple[float, float],
+    end: tuple[float, float],
+) -> bool:
+    if abs(_cross(start, end, point)) > _EPSILON:
+        return False
+    return (
+        min(start[0], end[0]) - _EPSILON <= point[0] <= max(start[0], end[0]) + _EPSILON
+        and min(start[1], end[1]) - _EPSILON <= point[1] <= max(start[1], end[1]) + _EPSILON
+    )
+
+
+def _segments_intersect(
+    a1: tuple[float, float],
+    a2: tuple[float, float],
+    b1: tuple[float, float],
+    b2: tuple[float, float],
+) -> bool:
+    c1 = _cross(a1, a2, b1)
+    c2 = _cross(a1, a2, b2)
+    c3 = _cross(b1, b2, a1)
+    c4 = _cross(b1, b2, a2)
+
+    if ((c1 > _EPSILON and c2 < -_EPSILON) or (c1 < -_EPSILON and c2 > _EPSILON)) and (
+        (c3 > _EPSILON and c4 < -_EPSILON) or (c3 < -_EPSILON and c4 > _EPSILON)
+    ):
+        return True
+
+    return (
+        (abs(c1) <= _EPSILON and _point_on_segment(b1, a1, a2))
+        or (abs(c2) <= _EPSILON and _point_on_segment(b2, a1, a2))
+        or (abs(c3) <= _EPSILON and _point_on_segment(a1, b1, b2))
+        or (abs(c4) <= _EPSILON and _point_on_segment(a2, b1, b2))
+    )
+
+
+def _validate_simple_polygon(points: tuple[tuple[float, float], ...]) -> None:
+    if len(points) > MAX_GATE_AREA_POINTS:
+        raise ValueError(f"gate area supports at most {MAX_GATE_AREA_POINTS} points")
+    if len(set(points)) != len(points):
+        raise ValueError("gate area points must be unique")
+    if abs(_signed_area(points)) < MIN_GATE_AREA_M2:
+        raise ValueError("gate area polygon is too small")
+
+    count = len(points)
+    for first in range(count):
+        first_next = (first + 1) % count
+        for second in range(first + 1, count):
+            second_next = (second + 1) % count
+            if first == second or first_next == second or second_next == first:
+                continue
+            if _segments_intersect(
+                points[first],
+                points[first_next],
+                points[second],
+                points[second_next],
+            ):
+                raise ValueError("gate area polygon must not intersect itself")
+
+
+def build_gate_area(name: Any, polygon: Any) -> NavimowerChannel:
+    """Build one strict polygon gate area for dashboard/editor writes."""
+    clean_name = str(name or "").strip()
+    if not clean_name:
+        raise ValueError("gate area name is required")
+    if len(clean_name) > 64:
+        raise ValueError("gate area name must be 64 characters or fewer")
+    if not isinstance(polygon, (list, tuple)):
+        raise ValueError("gate area polygon must be a coordinate list")
+    if len(polygon) > MAX_GATE_AREA_POINTS:
+        raise ValueError(f"gate area supports at most {MAX_GATE_AREA_POINTS} points")
+
+    parsed = parse_channels([{"name": clean_name, "polygon": polygon}])
+    if len(parsed) != 1 or parsed[0].polygon is None:
+        raise ValueError("gate area polygon needs at least three valid X/Y points")
+    area = parsed[0]
+    _validate_simple_polygon(area.polygon)
+    return area
+
+
+def upsert_gate_area(
+    raw_channels: Any,
+    *,
+    gate_area_id: Any = None,
+    name: Any,
+    polygon: Any,
+) -> list[dict[str, Any]]:
+    """Create or replace one gate area and return canonical stored options."""
+    channels = parse_channels(raw_channels)
+    replacement = build_gate_area(name, polygon)
+    existing_id = str(gate_area_id or "").strip().lower()
+
+    if existing_id:
+        index = next(
+            (idx for idx, channel in enumerate(channels) if channel.slug == existing_id),
+            None,
+        )
+        if index is None:
+            raise ValueError(f"gate area '{existing_id}' was not found")
+        if any(
+            idx != index and channel.slug == replacement.slug
+            for idx, channel in enumerate(channels)
+        ):
+            raise ValueError(f"gate area '{replacement.name}' already exists")
+        channels[index] = replacement
+    else:
+        if any(channel.slug == replacement.slug for channel in channels):
+            raise ValueError(f"gate area '{replacement.name}' already exists")
+        channels.append(replacement)
+
+    return [channel.as_dict() for channel in channels]
+
+
+def delete_gate_area(raw_channels: Any, gate_area_id: Any) -> list[dict[str, Any]]:
+    """Delete one gate area by its stable Map API slug."""
+    existing_id = str(gate_area_id or "").strip().lower()
+    if not existing_id:
+        raise ValueError("gate_area_id is required")
+    channels = parse_channels(raw_channels)
+    remaining = [channel for channel in channels if channel.slug != existing_id]
+    if len(remaining) == len(channels):
+        raise ValueError(f"gate area '{existing_id}' was not found")
+    return [channel.as_dict() for channel in remaining]

--- a/custom_components/navimower/gate_area_editor.py
+++ b/custom_components/navimower/gate_area_editor.py
@@ -67,8 +67,6 @@ def _validate_simple_polygon(points: tuple[tuple[float, float], ...]) -> None:
         raise ValueError(f"gate area supports at most {MAX_GATE_AREA_POINTS} points")
     if len(set(points)) != len(points):
         raise ValueError("gate area points must be unique")
-    if abs(_signed_area(points)) < MIN_GATE_AREA_M2:
-        raise ValueError("gate area polygon is too small")
 
     count = len(points)
     for first in range(count):
@@ -84,6 +82,9 @@ def _validate_simple_polygon(points: tuple[tuple[float, float], ...]) -> None:
                 points[second_next],
             ):
                 raise ValueError("gate area polygon must not intersect itself")
+
+    if abs(_signed_area(points)) < MIN_GATE_AREA_M2:
+        raise ValueError("gate area polygon is too small")
 
 
 def build_gate_area(name: Any, polygon: Any) -> NavimowerChannel:

--- a/custom_components/navimower/manifest.json
+++ b/custom_components/navimower/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "navimow-sdk>=0.1.2"
   ],
-  "version": "0.4.4-beta33"
+  "version": "0.4.4-beta34"
 }

--- a/custom_components/navimower/services.py
+++ b/custom_components/navimower/services.py
@@ -12,9 +12,11 @@ from .runtime import install_runtime_extensions
 from .const import (
     ACTIVITY_MOWING,
     DOMAIN,
+    OPT_CHANNELS,
     encode_partition_ids,
     mow_setup,
 )
+from .gate_area_editor import delete_gate_area, upsert_gate_area
 from .georeference_tools import async_relearn_georeference
 from .model_support import supports_ordered_zone_mowing
 from .notification_actions import (
@@ -30,6 +32,8 @@ SERVICE_SET_SCHEDULE = "set_schedule"
 SERVICE_MOW = "mow"
 SERVICE_RESUME = "resume"
 SERVICE_SET_SCHEDULE_QUEUE = "set_schedule_queue"
+SERVICE_SET_GATE_AREA = "set_gate_area"
+SERVICE_DELETE_GATE_AREA = "delete_gate_area"
 SERVICE_MARK_NOTIFICATION_READ = "mark_notification_read"
 SERVICE_MARK_ALL_NOTIFICATIONS_READ = "mark_all_notifications_read"
 SERVICE_RELEARN_GEOREFERENCE = "relearn_georeference"
@@ -74,6 +78,22 @@ SET_SCHEDULE_QUEUE_SCHEMA = vol.Schema(
     {
         vol.Optional("device_id"): cv.string,
         vol.Required("zones"): vol.All(cv.ensure_list, [vol.Coerce(int)]),
+    }
+)
+
+SET_GATE_AREA_SCHEMA = vol.Schema(
+    {
+        vol.Optional("device_id"): cv.string,
+        vol.Optional("gate_area_id"): vol.All(cv.string, vol.Length(max=128)),
+        vol.Required("name"): vol.All(cv.string, vol.Length(min=1, max=64)),
+        vol.Required("polygon"): cv.ensure_list,
+    }
+)
+
+DELETE_GATE_AREA_SCHEMA = vol.Schema(
+    {
+        vol.Optional("device_id"): cv.string,
+        vol.Required("gate_area_id"): vol.All(cv.string, vol.Length(min=1, max=128)),
     }
 )
 
@@ -226,22 +246,21 @@ def async_setup_services(hass: HomeAssistant) -> None:
         )
         try:
             result = await coordinator.async_send(
-                coordinator.client.mow_zones,
-                coordinator.sn,
+                client.mow_zones,
+                sn,
                 partition_ids,
                 partition_setup,
             )
-            coordinator.record_mow_command_result(result)
-            if call.data["reset"]:
-                coordinator.start_new_mowing_cycle(
-                    zones, source="navimower.mow_reset"
-                )
+            self.coordinator.record_mow_command_result(result)
+            self.coordinator.start_new_mowing_cycle(
+                region_ids, source="lawn_mower.start_mowing_reset"
+            )
         except Exception as err:
-            coordinator.record_mow_command_error(err)
-            coordinator.clear_pending_activity()
+            self.coordinator.record_mow_command_error(err)
+            self.coordinator.clear_pending_activity()
             if requested_ordered:
-                coordinator.clear_command_target()
-            raise HomeAssistantError(f"Navimow mow failed: {err}") from err
+                self.coordinator.clear_command_target()
+            raise
 
     async def _set_schedule_queue(call: ServiceCall) -> None:
         coordinator = _resolve_coordinator(call)
@@ -257,6 +276,48 @@ def async_setup_services(hass: HomeAssistant) -> None:
         except Exception as err:
             raise HomeAssistantError(
                 f"Navimower set_schedule_queue failed: {err}"
+            ) from err
+
+    async def _set_gate_area(call: ServiceCall) -> None:
+        coordinator = _resolve_coordinator(call)
+        try:
+            channels = upsert_gate_area(
+                coordinator.entry.options.get(OPT_CHANNELS),
+                gate_area_id=call.data.get("gate_area_id"),
+                name=call.data["name"],
+                polygon=call.data["polygon"],
+            )
+        except ValueError as err:
+            raise ServiceValidationError(str(err)) from err
+
+        options = dict(coordinator.entry.options)
+        options[OPT_CHANNELS] = channels
+        hass.config_entries.async_update_entry(coordinator.entry, options=options)
+        try:
+            await hass.config_entries.async_reload(coordinator.entry.entry_id)
+        except Exception as err:
+            raise HomeAssistantError(
+                f"Gate area was saved but Navimower reload failed: {err}"
+            ) from err
+
+    async def _delete_gate_area(call: ServiceCall) -> None:
+        coordinator = _resolve_coordinator(call)
+        try:
+            channels = delete_gate_area(
+                coordinator.entry.options.get(OPT_CHANNELS),
+                call.data["gate_area_id"],
+            )
+        except ValueError as err:
+            raise ServiceValidationError(str(err)) from err
+
+        options = dict(coordinator.entry.options)
+        options[OPT_CHANNELS] = channels
+        hass.config_entries.async_update_entry(coordinator.entry, options=options)
+        try:
+            await hass.config_entries.async_reload(coordinator.entry.entry_id)
+        except Exception as err:
+            raise HomeAssistantError(
+                f"Gate area was deleted but Navimower reload failed: {err}"
             ) from err
 
     async def _resume(call: ServiceCall) -> None:
@@ -332,6 +393,8 @@ def async_setup_services(hass: HomeAssistant) -> None:
         (SERVICE_SET_SCHEDULE, _set_schedule, SET_SCHEDULE_SCHEMA),
         (SERVICE_MOW, _mow, MOW_SCHEMA),
         (SERVICE_SET_SCHEDULE_QUEUE, _set_schedule_queue, SET_SCHEDULE_QUEUE_SCHEMA),
+        (SERVICE_SET_GATE_AREA, _set_gate_area, SET_GATE_AREA_SCHEMA),
+        (SERVICE_DELETE_GATE_AREA, _delete_gate_area, DELETE_GATE_AREA_SCHEMA),
         (SERVICE_RESUME, _resume, RESUME_SCHEMA),
         (SERVICE_MARK_NOTIFICATION_READ, _mark_notification_read, MARK_NOTIFICATION_READ_SCHEMA),
         (SERVICE_MARK_ALL_NOTIFICATIONS_READ, _mark_all_notifications_read, MARK_ALL_NOTIFICATIONS_READ_SCHEMA),

--- a/custom_components/navimower/services.py
+++ b/custom_components/navimower/services.py
@@ -246,21 +246,22 @@ def async_setup_services(hass: HomeAssistant) -> None:
         )
         try:
             result = await coordinator.async_send(
-                client.mow_zones,
-                sn,
+                coordinator.client.mow_zones,
+                coordinator.sn,
                 partition_ids,
                 partition_setup,
             )
-            self.coordinator.record_mow_command_result(result)
-            self.coordinator.start_new_mowing_cycle(
-                region_ids, source="lawn_mower.start_mowing_reset"
-            )
+            coordinator.record_mow_command_result(result)
+            if call.data["reset"]:
+                coordinator.start_new_mowing_cycle(
+                    zones, source="navimower.mow_reset"
+                )
         except Exception as err:
-            self.coordinator.record_mow_command_error(err)
-            self.coordinator.clear_pending_activity()
+            coordinator.record_mow_command_error(err)
+            coordinator.clear_pending_activity()
             if requested_ordered:
-                self.coordinator.clear_command_target()
-            raise
+                coordinator.clear_command_target()
+            raise HomeAssistantError(f"Navimow mow failed: {err}") from err
 
     async def _set_schedule_queue(call: ServiceCall) -> None:
         coordinator = _resolve_coordinator(call)

--- a/custom_components/navimower/services.yaml
+++ b/custom_components/navimower/services.yaml
@@ -94,6 +94,65 @@ resume:
         device:
           integration: navimower
 
+set_gate_area:
+  name: Create or update gate area
+  description: >-
+    Persist one integration-owned gate-area polygon in mower-local X/Y metres.
+    Omit gate_area_id to create a new area. When editing an existing area, pass
+    its current slug from the map payload as gate_area_id. The polygon must have
+    3 to 64 unique points, must not intersect itself, and its compatibility
+    x_min/x_max/y_min/y_max bounds are calculated automatically. The Navimower
+    config entry reloads after a successful save.
+  fields:
+    device_id:
+      name: Mower
+      description: Target mower (only required if more than one is configured).
+      required: false
+      selector:
+        device:
+          integration: navimower
+    gate_area_id:
+      name: Existing gate area ID
+      description: >-
+        Current gate-area slug when editing. Leave empty when creating a new area.
+      required: false
+      selector:
+        text:
+    name:
+      name: Name
+      description: Display name for the gate area.
+      required: true
+      selector:
+        text:
+    polygon:
+      name: Polygon
+      description: >-
+        Ordered mower-local X/Y points, for example
+        [[-28.48,9.08],[-23.63,6.5],[-20.87,10.5],[-25.7,13.7]].
+      required: true
+      selector:
+        object:
+
+delete_gate_area:
+  name: Delete gate area
+  description: >-
+    Delete one integration-owned gate area by its slug from the map payload. The
+    Navimower config entry reloads after a successful delete.
+  fields:
+    device_id:
+      name: Mower
+      description: Target mower (only required if more than one is configured).
+      required: false
+      selector:
+        device:
+          integration: navimower
+    gate_area_id:
+      name: Gate area ID
+      description: Current gate-area slug from the map payload.
+      required: true
+      selector:
+        text:
+
 mark_notification_read:
   name: Mark notification as read
   description: >-

--- a/tests/test_v044_beta34.py
+++ b/tests/test_v044_beta34.py
@@ -1,0 +1,131 @@
+"""Regression coverage for beta34 Map Card gate-area write support."""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "navimower"
+CHANNEL = COMPONENT / "channel.py"
+EDITOR = COMPONENT / "gate_area_editor.py"
+SERVICES = COMPONENT / "services.py"
+SERVICES_YAML = COMPONENT / "services.yaml"
+
+
+def _load_editor_module():
+    package_name = "navimower_gate_editor_beta34"
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(COMPONENT)]
+    sys.modules[package_name] = package
+
+    channel_spec = importlib.util.spec_from_file_location(
+        f"{package_name}.channel", CHANNEL
+    )
+    assert channel_spec is not None and channel_spec.loader is not None
+    channel_module = importlib.util.module_from_spec(channel_spec)
+    sys.modules[channel_spec.name] = channel_module
+    channel_spec.loader.exec_module(channel_module)
+
+    editor_spec = importlib.util.spec_from_file_location(
+        f"{package_name}.gate_area_editor", EDITOR
+    )
+    assert editor_spec is not None and editor_spec.loader is not None
+    editor_module = importlib.util.module_from_spec(editor_spec)
+    sys.modules[editor_spec.name] = editor_module
+    editor_spec.loader.exec_module(editor_module)
+    return editor_module
+
+
+def test_editor_accepts_three_or_more_points_and_calculates_bounds() -> None:
+    editor = _load_editor_module()
+    polygon = [[0, 0], [4, 0], [5, 2], [3, 4], [0, 3]]
+    stored = editor.upsert_gate_area([], name="Front gate", polygon=polygon)
+
+    assert len(stored) == 1
+    area = stored[0]
+    assert area["slug"] == "front_gate"
+    assert area["polygon"] == [[float(x), float(y)] for x, y in polygon]
+    assert (area["x_min"], area["x_max"], area["y_min"], area["y_max"]) == (
+        0.0,
+        5.0,
+        0.0,
+        4.0,
+    )
+
+
+def test_editor_updates_by_current_slug_and_deletes_without_duplicates() -> None:
+    editor = _load_editor_module()
+    first = editor.upsert_gate_area(
+        [],
+        name="Front gate",
+        polygon=[[0, 0], [4, 0], [4, 4], [0, 4]],
+    )
+    updated = editor.upsert_gate_area(
+        first,
+        gate_area_id="front_gate",
+        name="Front passage",
+        polygon=[[1, 1], [5, 1], [5, 3], [1, 3]],
+    )
+
+    assert len(updated) == 1
+    assert updated[0]["slug"] == "front_passage"
+    assert updated[0]["x_min"] == 1.0
+    assert editor.delete_gate_area(updated, "front_passage") == []
+
+
+def test_editor_rejects_self_intersection_and_duplicate_slug() -> None:
+    editor = _load_editor_module()
+    with pytest.raises(ValueError, match="intersect itself"):
+        editor.build_gate_area(
+            "Bow tie",
+            [[0, 0], [4, 4], [0, 4], [4, 0]],
+        )
+
+    stored = editor.upsert_gate_area(
+        [],
+        name="Front gate",
+        polygon=[[0, 0], [4, 0], [4, 4], [0, 4]],
+    )
+    with pytest.raises(ValueError, match="already exists"):
+        editor.upsert_gate_area(
+            stored,
+            name="Front gate",
+            polygon=[[10, 10], [12, 10], [12, 12], [10, 12]],
+        )
+
+
+def test_services_persist_options_reload_entry_and_leave_mow_semantics_intact() -> None:
+    source = SERVICES.read_text(encoding="utf-8")
+    assert 'SERVICE_SET_GATE_AREA = "set_gate_area"' in source
+    assert 'SERVICE_DELETE_GATE_AREA = "delete_gate_area"' in source
+    assert "upsert_gate_area(" in source
+    assert "delete_gate_area(" in source
+    assert "options[OPT_CHANNELS] = channels" in source
+    assert "hass.config_entries.async_update_entry(coordinator.entry, options=options)" in source
+    assert "await hass.config_entries.async_reload(coordinator.entry.entry_id)" in source
+
+    # The editor service must not accidentally alter the established mow command path.
+    assert "coordinator.client.mow_zones" in source
+    assert "coordinator.record_mow_command_result(result)" in source
+    assert "self.coordinator.record_mow_command_result" not in source
+
+    services_yaml = SERVICES_YAML.read_text(encoding="utf-8")
+    assert "\nset_gate_area:\n" in services_yaml
+    assert "\ndelete_gate_area:\n" in services_yaml
+    assert "gate_area_id:" in services_yaml
+    assert "3 to 64 unique points" in services_yaml
+
+
+def test_beta34_release_metadata() -> None:
+    manifest = json.loads((COMPONENT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.4.4-beta34"
+    notes = ROOT / ".github" / "release-notes" / "0.4.4-beta34.md"
+    assert notes.is_file()
+    assert notes.read_text(encoding="utf-8").startswith(
+        "title: Navimower 0.4.4-beta34\n"
+    )


### PR DESCRIPTION
## Summary

Adds the integration-side persistence API required for visual gate-area editing from Navimower Map Card.

- add `navimower.set_gate_area`
- add `navimower.delete_gate_area`
- identify existing areas by the current Map API slug (`gate_area_id`)
- accept 3–64 mower-local X/Y polygon points
- reject duplicate vertices, self-intersections and near-zero-area polygons
- recalculate compatibility min/max bounds automatically
- update config-entry options and reload only the selected mower entry
- preserve Options Flow editing and legacy rectangular gate areas
- add regression coverage and beta34 release metadata

The Map Card editor can now keep a local drag/click draft and write only once on Save through the integration service.